### PR TITLE
chore: fix ci runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   setup:
     runs-on:
-      group: databricks-eng-protected-runner-group
+      group: databricks-protected-runner-group
       labels: linux-ubuntu-latest
 
     name: Setup
@@ -33,7 +33,7 @@ jobs:
     name: Lint & Type Check
     needs: setup
     runs-on:
-      group: databricks-eng-protected-runner-group
+      group: databricks-protected-runner-group
       labels: linux-ubuntu-latest
 
     steps:
@@ -56,7 +56,7 @@ jobs:
     name: Unit Tests
     needs: setup
     runs-on:
-      group: databricks-eng-protected-runner-group
+      group: databricks-protected-runner-group
       labels: linux-ubuntu-latest
 
     steps:


### PR DESCRIPTION
This PR fixes an issue on CI which I observed on #1:
<img width="1006" height="246" alt="image" src="https://github.com/user-attachments/assets/286c50dd-14b2-4b26-8c4c-6cf14755c05d" />

Thanks to @fjakobs for pointing to the right runner group 👍 