### PR TITLE
chore: tune tsdown configuration to reduce bundle size

### DIFF
--- a/packages/app-kit-ui/tsdown.config.ts
+++ b/packages/app-kit-ui/tsdown.config.ts
@@ -17,8 +17,9 @@ export default defineConfig([
     format: "esm",
     noExternal: ["shared"],
     external: (id) => {
-      // Bundle "shared" workspace package, externalize everything else from node_modules
+      // Bundle "shared" workspace package and @/ path aliases
       if (id === "shared" || id.startsWith("shared/")) return false;
+      if (id.startsWith("@/")) return false;
       return /^[^./]/.test(id) || id.includes("/node_modules/");
     },
     tsconfig: "./tsconfig.json",

--- a/packages/app-kit/tsdown.config.ts
+++ b/packages/app-kit/tsdown.config.ts
@@ -18,8 +18,9 @@ export default defineConfig([
     unbundle: true,
     noExternal: ["shared"],
     external: (id) => {
-      // Bundle "shared" workspace package, externalize everything else from node_modules
+      // Bundle "shared" workspace package and @/ path aliases
       if (id === "shared" || id.startsWith("shared/")) return false;
+      if (id.startsWith("@/")) return false;
       return /^[^./]/.test(id) || id.includes("/node_modules/");
     },
     tsconfig: "./tsconfig.json",


### PR DESCRIPTION
Reduced bundle size dramatically by not bundling node dependencies.

Before:
```
-rw-r--r--  1 fabian.jakobs  staff   966K Dec  5 11:33 databricks-app-kit-0.0.1.tgz
-rw-r--r--  1 fabian.jakobs  staff   127K Dec  5 11:33 databricks-app-kit-ui-0.0.1.tgz
```

After:
```
-rw-r--r--  1 fabian.jakobs  staff    88K Dec  5 11:32 databricks-app-kit-0.0.1.tgz
-rw-r--r--  1 fabian.jakobs  staff    68K Dec  5 11:32 databricks-app-kit-ui-0.0.1.tgz
```
