### PR TITLE
fix: npm publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
           node-version: 20
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
pnpm publish uses npm under the hood but required a recent version to OIDC to work.