### PR TITLE
feat: inject config from server

### DIFF
--- a/apps/dev-playground/client/vite.config.ts
+++ b/apps/dev-playground/client/vite.config.ts
@@ -1,5 +1,4 @@
 import path from "node:path";
-import { appKitTypesPlugin } from "@databricks/app-kit";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
@@ -8,7 +7,6 @@ import { defineConfig } from "vite";
 export default defineConfig({
   plugins: [
     react(),
-    appKitTypesPlugin(),
     tanstackRouter({
       target: "react",
       autoCodeSplitting: process.env.NODE_ENV !== "development",

--- a/apps/dev-playground/server/reconnect-plugin.ts
+++ b/apps/dev-playground/server/reconnect-plugin.ts
@@ -19,6 +19,7 @@ export class ReconnectPlugin extends Plugin {
 
   injectRoutes(router: IAppRouter): void {
     this.route<ReconnectResponse>(router, {
+      name: "reconnect",
       method: "get",
       path: "/",
       handler: async (_req, res) => {
@@ -27,6 +28,7 @@ export class ReconnectPlugin extends Plugin {
     });
 
     this.route<ReconnectStreamResponse>(router, {
+      name: "stream",
       method: "get",
       path: "/stream",
       handler: async (req, res) => {

--- a/apps/dev-playground/server/telemetry-example-plugin.ts
+++ b/apps/dev-playground/server/telemetry-example-plugin.ts
@@ -41,118 +41,125 @@ class TelemetryExamples extends Plugin {
   }
 
   private registerTelemetryExampleRoutes(router: Router) {
-    router.post("/combined", async (req: Request, res: Response) => {
-      const startTime = Date.now();
+    this.route(router, {
+      name: "combined",
+      method: "post",
+      path: "/combined",
+      handler: async (req: Request, res: Response) => {
+        const startTime = Date.now();
 
-      return this.telemetry.startActiveSpan(
-        "combined-example",
-        {
-          attributes: {
-            "example.type": "combined",
-            "example.version": "v2",
+        return this.telemetry.startActiveSpan(
+          "combined-example",
+          {
+            attributes: {
+              "example.type": "combined",
+              "example.version": "v2",
+            },
           },
-        },
-        async (span: Span) => {
-          try {
-            const userId =
-              req.body?.userId || req.query.userId || "demo-user-123";
+          async (span: Span) => {
+            try {
+              const userId =
+                req.body?.userId || req.query.userId || "demo-user-123";
 
-            this.telemetry.emit({
-              severityNumber: SeverityNumber.INFO,
-              severityText: "INFO",
-              body: "Processing telemetry example request",
-              attributes: {
-                "user.id": userId,
-                "request.type": "combined-example",
-              },
-            });
+              this.telemetry.emit({
+                severityNumber: SeverityNumber.INFO,
+                severityText: "INFO",
+                body: "Processing telemetry example request",
+                attributes: {
+                  "user.id": userId,
+                  "request.type": "combined-example",
+                },
+              });
 
-            const result = await this.complexOperation(userId);
+              const result = await this.complexOperation(userId);
 
-            const duration = Date.now() - startTime;
-            this.requestCounter.add(1, { status: "success" });
-            this.durationHistogram.record(duration);
+              const duration = Date.now() - startTime;
+              this.requestCounter.add(1, { status: "success" });
+              this.durationHistogram.record(duration);
 
-            this.telemetry.emit({
-              severityNumber: SeverityNumber.INFO,
-              severityText: "INFO",
-              body: "Request completed successfully",
-              attributes: {
-                "user.id": userId,
-                "duration.ms": duration,
-                "result.fields": Object.keys(result).length,
-              },
-            });
+              this.telemetry.emit({
+                severityNumber: SeverityNumber.INFO,
+                severityText: "INFO",
+                body: "Request completed successfully",
+                attributes: {
+                  "user.id": userId,
+                  "duration.ms": duration,
+                  "result.fields": Object.keys(result).length,
+                },
+              });
 
-            span.setStatus({ code: SpanStatusCode.OK });
+              span.setStatus({ code: SpanStatusCode.OK });
 
-            res.json({
-              success: true,
-              result,
-              duration_ms: duration,
-              tracing: {
-                hint: "Open Grafana at http://localhost:3000",
-                services: [
-                  "app-template (main service)",
-                  "user-operations (complex operation)",
-                  "auth-validation (user validation)",
-                  "data-access (database operations - with cache!)",
-                  "auth-service (permissions)",
-                  "external-api (external HTTP calls)",
-                  "data-processing (transformation)",
-                ],
-                expectedSpans: [
-                  "HTTP POST (SDK auto-instrumentation)",
-                  "combined-example (custom tracer: custom-telemetry-example)",
-                  "  └─ complex-operation (custom tracer: user-operations)",
-                  "     ├─ validate-user (100ms, custom tracer: auth-validation)",
-                  "     ├─ fetch-user-data (200ms first call / cached on repeat, custom tracer: data-access) [parallel]",
-                  "     │  └─ cache.hit attribute set by SDK (false on first call, true on repeat)",
-                  "     ├─ fetch-external-resource (custom tracer: external-api) [parallel]",
-                  "     │  └─ HTTP GET https://example.com (SDK auto-instrumentation)",
-                  "     ├─ fetch-permissions (150ms, custom tracer: auth-service) [parallel]",
-                  "     └─ transform-data (80ms, custom tracer: data-processing)",
-                ],
-              },
-              metrics: {
-                recorded: ["app.requests.total", "app.request.duration"],
-              },
-              logs: {
-                emitted: [
-                  "Starting complex operation workflow",
-                  "Data fetching completed successfully",
-                  "Data transformation completed",
-                  "Permissions retrieved",
-                  "External API call completed",
-                ],
-              },
-            });
-          } catch (error) {
-            span.recordException(error as Error);
-            span.setStatus({ code: SpanStatusCode.ERROR });
-            this.requestCounter.add(1, { status: "error" });
+              res.json({
+                success: true,
+                result,
+                duration_ms: duration,
+                tracing: {
+                  hint: "Open Grafana at http://localhost:3000",
+                  services: [
+                    "app-template (main service)",
+                    "user-operations (complex operation)",
+                    "auth-validation (user validation)",
+                    "data-access (database operations - with cache!)",
+                    "auth-service (permissions)",
+                    "external-api (external HTTP calls)",
+                    "data-processing (transformation)",
+                  ],
+                  expectedSpans: [
+                    "HTTP POST (SDK auto-instrumentation)",
+                    "combined-example (custom tracer: custom-telemetry-example)",
+                    "  └─ complex-operation (custom tracer: user-operations)",
+                    "     ├─ validate-user (100ms, custom tracer: auth-validation)",
+                    "     ├─ fetch-user-data (200ms first call / cached on repeat, custom tracer: data-access) [parallel]",
+                    "     │  └─ cache.hit attribute set by SDK (false on first call, true on repeat)",
+                    "     ├─ fetch-external-resource (custom tracer: external-api) [parallel]",
+                    "     │  └─ HTTP GET https://example.com (SDK auto-instrumentation)",
+                    "     ├─ fetch-permissions (150ms, custom tracer: auth-service) [parallel]",
+                    "     └─ transform-data (80ms, custom tracer: data-processing)",
+                  ],
+                },
+                metrics: {
+                  recorded: ["app.requests.total", "app.request.duration"],
+                },
+                logs: {
+                  emitted: [
+                    "Starting complex operation workflow",
+                    "Data fetching completed successfully",
+                    "Data transformation completed",
+                    "Permissions retrieved",
+                    "External API call completed",
+                  ],
+                },
+              });
+            } catch (error) {
+              span.recordException(error as Error);
+              span.setStatus({ code: SpanStatusCode.ERROR });
+              this.requestCounter.add(1, { status: "error" });
 
-            this.telemetry.emit({
-              severityNumber: SeverityNumber.ERROR,
-              severityText: "ERROR",
-              body: error instanceof Error ? error.message : "Unknown error",
-              attributes: {
-                "error.type": error instanceof Error ? error.name : "Unknown",
-                "error.stack": error instanceof Error ? error.stack : undefined,
-                "request.path": req.path,
-              },
-            });
+              this.telemetry.emit({
+                severityNumber: SeverityNumber.ERROR,
+                severityText: "ERROR",
+                body: error instanceof Error ? error.message : "Unknown error",
+                attributes: {
+                  "error.type": error instanceof Error ? error.name : "Unknown",
+                  "error.stack":
+                    error instanceof Error ? error.stack : undefined,
+                  "request.path": req.path,
+                },
+              });
 
-            res.status(500).json({
-              error: true,
-              message: error instanceof Error ? error.message : "Unknown error",
-            });
-          } finally {
-            span.end();
-          }
-        },
-        { name: "custom-telemetry-example" },
-      );
+              res.status(500).json({
+                error: true,
+                message:
+                  error instanceof Error ? error.message : "Unknown error",
+              });
+            } finally {
+              span.end();
+            }
+          },
+          { name: "custom-telemetry-example" },
+        );
+      },
     });
   }
 

--- a/packages/app-kit/src/analytics/analytics.ts
+++ b/packages/app-kit/src/analytics/analytics.ts
@@ -42,6 +42,7 @@ export class AnalyticsPlugin extends Plugin {
 
   injectRoutes(router: IAppRouter) {
     this.route(router, {
+      name: "arrow",
       method: "get",
       path: "/arrow-result/:jobId",
       handler: async (req: Request, res: Response) => {
@@ -50,6 +51,7 @@ export class AnalyticsPlugin extends Plugin {
     });
 
     this.route(router, {
+      name: "arrowAsUser",
       method: "get",
       path: "/users/me/arrow-result/:jobId",
       handler: async (req: Request, res: Response) => {
@@ -58,6 +60,7 @@ export class AnalyticsPlugin extends Plugin {
     });
 
     this.route<AnalyticsQueryResponse>(router, {
+      name: "queryAsUser",
       method: "post",
       path: "/users/me/query/:query_key",
       handler: async (req: Request, res: Response) => {
@@ -66,6 +69,7 @@ export class AnalyticsPlugin extends Plugin {
     });
 
     this.route<AnalyticsQueryResponse>(router, {
+      name: "query",
       method: "post",
       path: "/query/:query_key",
       handler: async (req: Request, res: Response) => {

--- a/packages/app-kit/src/core/tests/databricks.test.ts
+++ b/packages/app-kit/src/core/tests/databricks.test.ts
@@ -53,6 +53,10 @@ class CoreTestPlugin implements BasePlugin {
   asUser() {
     return this;
   }
+
+  getEndpoints() {
+    return {};
+  }
 }
 
 class NormalTestPlugin implements BasePlugin {
@@ -79,6 +83,10 @@ class NormalTestPlugin implements BasePlugin {
 
   asUser() {
     return this;
+  }
+
+  getEndpoints() {
+    return {};
   }
 }
 
@@ -109,6 +117,10 @@ class DeferredTestPlugin implements BasePlugin {
   asUser(): any {
     return this;
   }
+
+  getEndpoints() {
+    return {};
+  }
 }
 
 class SlowSetupPlugin implements BasePlugin {
@@ -133,6 +145,10 @@ class SlowSetupPlugin implements BasePlugin {
   asUser(): any {
     return this;
   }
+
+  getEndpoints() {
+    return {};
+  }
 }
 
 class FailingPlugin implements BasePlugin {
@@ -151,6 +167,10 @@ class FailingPlugin implements BasePlugin {
 
   asUser(): any {
     return this;
+  }
+
+  getEndpoints() {
+    return {};
   }
 }
 

--- a/packages/app-kit/src/server/base-server.ts
+++ b/packages/app-kit/src/server/base-server.ts
@@ -1,0 +1,27 @@
+import type express from "express";
+import { type PluginEndpoints, getConfigScript } from "./utils";
+
+/**
+ * Base server for the App Kit.
+ *
+ * Abstract base class that provides common functionality for serving
+ * frontend applications. Subclasses implement specific serving strategies
+ * (Vite dev server, static file server, etc.).
+ */
+export abstract class BaseServer {
+  protected app: express.Application;
+  protected endpoints: PluginEndpoints;
+
+  constructor(app: express.Application, endpoints: PluginEndpoints = {}) {
+    this.app = app;
+    this.endpoints = endpoints;
+  }
+
+  abstract setup(): void | Promise<void>;
+
+  async close(): Promise<void> {}
+
+  protected getConfigScript(): string {
+    return getConfigScript(this.endpoints);
+  }
+}

--- a/packages/app-kit/src/server/tests/server.test.ts
+++ b/packages/app-kit/src/server/tests/server.test.ts
@@ -269,6 +269,7 @@ describe("ServerPlugin", () => {
           name: "needs-client",
           requiresDatabricksClient: true,
           injectRoutes,
+          getEndpoints: vi.fn().mockReturnValue({}),
         },
       };
 

--- a/packages/app-kit/src/server/tests/static-server.test.ts
+++ b/packages/app-kit/src/server/tests/static-server.test.ts
@@ -22,14 +22,19 @@ vi.mock("express", () => ({
   },
 }));
 
-// Mock getQueries
+// Mock getQueries and getConfigScript
 vi.mock("../utils", () => ({
   getQueries: vi.fn().mockReturnValue({ query1: "SELECT 1" }),
+  getConfigScript: vi.fn().mockReturnValue(`
+    <script>
+      window.__CONFIG__ = {"appName":"my-test-app","queries":{"query1":"query1"},"endpoints":{}};
+    </script>
+  `),
 }));
 
 import fs from "node:fs";
 import express from "express";
-import { getQueries } from "../utils";
+import { getConfigScript } from "../utils";
 import { StaticServer } from "../static-server";
 
 describe("StaticServer", () => {
@@ -174,7 +179,7 @@ describe("StaticServer", () => {
       const handler = mockApp.get.mock.calls[0][1];
       handler({ path: "/" }, mockRes, mockNext);
 
-      expect(getQueries).toHaveBeenCalled();
+      expect(getConfigScript).toHaveBeenCalled();
       const sentHtml = mockRes.send.mock.calls[0][0];
       expect(sentHtml).toContain("query1");
     });

--- a/packages/app-kit/src/server/utils.ts
+++ b/packages/app-kit/src/server/utils.ts
@@ -86,3 +86,35 @@ export function getQueries(configFolder: string) {
       .map((f) => [path.basename(f, ".sql"), path.basename(f, ".sql")]),
   );
 }
+
+import type { PluginEndpoints } from "shared";
+
+export type { PluginEndpoints };
+
+export interface RuntimeConfig {
+  appName: string;
+  queries: Record<string, string>;
+  endpoints: PluginEndpoints;
+}
+
+export function getRuntimeConfig(
+  endpoints: PluginEndpoints = {},
+): RuntimeConfig {
+  const configFolder = path.join(process.cwd(), "config");
+
+  return {
+    appName: process.env.DATABRICKS_APP_NAME || "",
+    queries: getQueries(configFolder),
+    endpoints,
+  };
+}
+
+export function getConfigScript(endpoints: PluginEndpoints = {}): string {
+  const config = getRuntimeConfig(endpoints);
+
+  return `
+    <script>
+      window.__CONFIG__ = ${JSON.stringify(config)};
+    </script>
+  `;
+}

--- a/packages/shared/src/plugin.ts
+++ b/packages/shared/src/plugin.ts
@@ -10,6 +10,8 @@ export interface BasePlugin {
   setup(): Promise<void>;
 
   injectRoutes(router: express.Router): void;
+
+  getEndpoints(): PluginEndpointMap;
 }
 
 export interface BasePluginConfig {
@@ -96,10 +98,18 @@ export type IAppRequest = express.Request;
 export type HttpMethod = "get" | "post" | "put" | "delete" | "patch" | "head";
 
 export type RouteConfig = {
+  /** Unique name for this endpoint (used for frontend access) */
+  name: string;
   method: HttpMethod;
   path: string;
   handler: (req: IAppRequest, res: IAppResponse) => Promise<void>;
 };
+
+/** Map of endpoint names to their full paths for a plugin */
+export type PluginEndpointMap = Record<string, string>;
+
+/** Map of plugin names to their endpoint maps */
+export type PluginEndpoints = Record<string, PluginEndpointMap>;
 
 export interface QuerySchemas {
   [key: string]: unknown;


### PR DESCRIPTION
This provides a centralized way of injecting configuration for the frontend, and also adding a way for accessing the endpoints provided by the backend.

An object `__CONFIG__` is injected in window with a few properties that are useful for the frontend.

<img width="968" height="394" alt="image" src="https://github.com/user-attachments/assets/183a0f62-1cee-448f-9c91-98c30816b3c7" />

Following this PR I will open another one that also provides typed access to this object