### PR TITLE
docs: add chart props reference and Recharts children anti-pattern

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -668,6 +668,56 @@ export function SpendChart() {
 }
 ```
 
+**Chart props reference (important):**
+
+Charts are **self-contained ECharts components**. Configure via props, NOT children:
+
+```tsx
+// ✅ Correct: use props for customization
+<BarChart
+  queryKey="sales_by_region"
+  parameters={{}}
+  xKey="region"                    // X-axis field
+  yKey={["revenue", "expenses"]}   // Y-axis field(s) - string or string[]
+  colors={['#40d1f5', '#4462c9']}  // Custom colors
+  stacked                          // Stack bars (BarChart, AreaChart)
+  orientation="horizontal"         // "vertical" (default) | "horizontal"
+  showLegend                       // Show legend
+  height={400}                     // Height in pixels (default: 300)
+/>
+
+<LineChart
+  queryKey="trend_data"
+  parameters={{}}
+  xKey="date"
+  yKey="value"
+  smooth                           // Smooth curves (default: true)
+  showSymbol={false}               // Hide data point markers
+/>
+```
+
+**❌ CRITICAL: Charts do NOT accept Recharts children**
+
+```tsx
+// ❌ WRONG - AppKit charts are NOT Recharts wrappers
+import { BarChart } from "@databricks/appkit-ui/react";
+import { Bar, XAxis, YAxis, CartesianGrid } from "recharts";
+
+<BarChart queryKey="data" parameters={{}}>
+  <CartesianGrid />  // ❌ This will cause TypeScript errors
+  <XAxis dataKey="x" />  // ❌ Not supported
+  <Bar dataKey="y" />  // ❌ Not supported
+</BarChart>
+
+// ✅ CORRECT - use props instead
+<BarChart
+  queryKey="data"
+  parameters={{}}
+  xKey="x"
+  yKey="y"
+/>
+```
+
 ### SQL helpers (`sql.*`)
 
 Use these to build typed parameters (they return marker objects: `{ __sql_type, value }`):
@@ -1169,6 +1219,7 @@ env:
   - `useMemo` wraps parameters objects
   - Loading/error/empty states are explicit
   - Charts use `format="auto"` unless you have a reason to force `"json"`/`"arrow"`
+  - Charts use props (`xKey`, `yKey`, `colors`) NOT children (they're ECharts-based, not Recharts)
   - If using tooltips: root is wrapped with `<TooltipProvider>`
 
 - **Never**
@@ -1176,4 +1227,5 @@ env:
   - Don't pass untyped raw params for annotated queries
   - Don't ignore `createApp()`'s promise
   - Don't invent UI components not listed in this file
+  - Don't pass Recharts children (`<Bar>`, `<XAxis>`, etc.) to AppKit chart components
 


### PR DESCRIPTION
## Summary

AppKit charts are ECharts-based and do not accept Recharts children components. This was causing TypeScript build errors when LLMs generated code mixing AppKit chart components with Recharts primitives like `<Bar>`, `<XAxis>`, `<CartesianGrid>`, etc.

### Problem

LLMs were generating code like:
```tsx
<BarChart queryKey="data" parameters={{}}>
  <CartesianGrid strokeDasharray="3 3" />
  <XAxis dataKey="region" />
  <Bar dataKey="revenue" fill="#40d1f5" />
</BarChart>
```

This causes TypeScript errors because AppKit's `BarChart` doesn't accept children - it's a self-contained ECharts component.

### Solution

Added explicit documentation to `llms.txt`:
- **Chart props reference** showing correct usage (`xKey`, `yKey`, `colors`, `stacked`, etc.)
- **Critical anti-pattern warning** about Recharts children not being supported
- **Updated LLM checklist** with chart-specific guidance

### Changes

- Add chart props reference with correct usage examples
- Add explicit anti-pattern warning about Recharts children
- Update LLM checklist with chart-specific items

🤖 Generated with [Claude Code](https://claude.ai/code)