### PR TITLE
fix: don't write to node_modules. NPM doesn't like it

### DIFF
--- a/packages/appkit/src/type-generator/cache.ts
+++ b/packages/appkit/src/type-generator/cache.ts
@@ -24,12 +24,7 @@ interface Cache {
 
 export const CACHE_VERSION = "1";
 const CACHE_FILE = ".appkit-types-cache.json";
-const CACHE_DIR = path.join(
-  process.cwd(),
-  "node_modules",
-  ".databricks",
-  "appkit",
-);
+const CACHE_DIR = path.join(process.cwd(), ".databricks", "appkit");
 
 /**
  * Hash the SQL query


### PR DESCRIPTION
I'm getting errors like this:

```
$ databricks experimental aitools tools validate ./ --profile dais
Error: install failed (duration: 0.9s)
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🔍 Databricks AI Tools MCP server: Validating your app
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

Validation Progress:
🔄 Starting Node.js validation: build + typecheck + tests
⏳ Step 1/6: Running Install...
❌ Install failed (0.9s)

❌ Failed to install dependencies

Exit code: 190

Stdout:


Stderr:
npm error code ENOTEMPTY
npm error syscall rename
npm error path /Users/fabian.jakobs/Workspaces/skill-builder/nyc-taxi-viz/node_modules/@databricks/appkit
npm error dest /Users/fabian.jakobs/Workspaces/skill-builder/nyc-taxi-viz/node_modules/@databricks/.appkit-guYJj7r0
npm error errno -66
npm error ENOTEMPTY: directory not empty, rename '/Users/fabian.jakobs/Workspaces/skill-builder/nyc-taxi-viz/node_modules/@databricks/appkit' -> '/Users/fabian.jakobs/Workspaces/skill-builder/nyc-taxi-viz/node_modules/@databricks/.appkit-guYJj7r0'
npm error A complete log of this run can be found in: /Users/fabian.jakobs/.npm/_logs/2026-01-12T10_22_57_769Z-debug-0.log

Error: validation failed
```