### PR TITLE
docs: fix styles in dark mode

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -232,7 +232,7 @@ const config: Config = {
       darkTheme: prismThemes.vsDark,
     },
     mermaid: {
-      theme: { light: "base", dark: "base" },
+      theme: { light: "base", dark: "dark" },
       options: {
         themeVariables: {
           // Light mode colors (bluish) - matches Docusaurus theme

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -36,6 +36,7 @@
 [data-theme="dark"] {
   --ifm-color-primary: rgb(66, 153, 224);
   --docusaurus-highlighted-code-line-bg: rgb(55, 68, 79);
+  --ifm-code-background: hsl(230, 15%, 15%);
 }
 
 .landing-button-vertical {


### PR DESCRIPTION
Issues solved:
- For `<code>` tags, the CSS variable wasn't overriden for the dark theme
- For Mermaid diagrams, the dark theme wasn't used

## Screenshots

### Before

<img width="938" height="1023" alt="image" src="https://github.com/user-attachments/assets/cb944890-4b52-4209-9f77-e8d82dfe9dc2" />

Mermaid diagrams:

<img width="1116" height="622" alt="image" src="https://github.com/user-attachments/assets/a489781c-8adb-4ea6-83e7-93f805e743ea" />


### After

<img width="981" height="998" alt="image" src="https://github.com/user-attachments/assets/717cee0b-b851-49a7-ac9f-29e4e268c8df" />

Mermaid diagrams:

<img width="1190" height="638" alt="image" src="https://github.com/user-attachments/assets/336b1dca-c0f4-4d51-adb0-dc8548750a9b" />
