### PR TITLE
chore: bump packages in the template

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -28,8 +28,8 @@
   "license": "Unlicensed",
   "description": "{{.app_description}}",
   "dependencies": {
-    "@databricks/appkit": "0.3.0",
-    "@databricks/appkit-ui": "0.3.0",
+    "@databricks/appkit": "0.4.0",
+    "@databricks/appkit-ui": "0.4.0",
     "@databricks/sdk-experimental": "^0.14.2",
     "clsx": "^2.1.1",
     "embla-carousel-react": "^8.6.0",


### PR DESCRIPTION
Reason: Use the latest packages as template already references the new AppKit CLI commands.