### PR TITLE
Revert "chore: bump packages in the template"

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -28,8 +28,8 @@
   "license": "Unlicensed",
   "description": "{{.app_description}}",
   "dependencies": {
-    "@databricks/appkit": "0.4.0",
-    "@databricks/appkit-ui": "0.4.0",
+    "@databricks/appkit": "0.3.0",
+    "@databricks/appkit-ui": "0.3.0",
     "@databricks/sdk-experimental": "^0.14.2",
     "clsx": "^2.1.1",
     "embla-carousel-react": "^8.6.0",


### PR DESCRIPTION
Reverts databricks/appkit#70 until the new Databricks CLI is merged.

Related PR: https://github.com/databricks/cli/pull/4396/files#diff-ebd037dc3a04b8cf254947ba01709e6a75350551a142e9376f3b6e4f6f5eb994

## Context

The problem is that the CLI init uses a fixed command which is AppKit-version specific:
https://github.com/databricks/cli/blob/bd2d16b622bc77fb26c2cad11d187e4c86384c97/libs/apps/initializer/nodejs.go#L88
That breaks the `apps init` command for the released CLI.