### PR TITLE
docs: mention prerequisites versions

### DIFF
--- a/docs/docs/_prerequisites.mdx
+++ b/docs/docs/_prerequisites.mdx
@@ -1,4 +1,4 @@
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) environment
-- Databricks CLI: install and configure it according to the [official tutorial](https://docs.databricks.com/aws/en/dev-tools/cli/tutorial).
+- [Node.js](https://nodejs.org) v22+ environment with `npm`
+- Databricks CLI (v0.286.0 or higher): install and configure it according to the [official tutorial](https://docs.databricks.com/aws/en/dev-tools/cli/tutorial).

--- a/docs/docs/development/_prerequisites_app.mdx
+++ b/docs/docs/development/_prerequisites_app.mdx
@@ -1,5 +1,5 @@
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) environment
-- Databricks CLI: install and configure it according to the [official tutorial](https://docs.databricks.com/aws/en/dev-tools/cli/tutorial).
+- [Node.js](https://nodejs.org) v22+ environment with `npm`
+- Databricks CLI (v0.286.0 or higher): install and configure it according to the [official tutorial](https://docs.databricks.com/aws/en/dev-tools/cli/tutorial).
 - A new Databricks app with AppKit installed. See [Bootstrap a new Databricks app](../index.md) for more details.


### PR DESCRIPTION
Applying feedback from Joy - for now we didn't specify prerequisite version but of course we should, hence this PR.


Related internal discussion: https://databricks.slack.com/archives/C09BCFBGMC4/p1769648595471309

BTW why Node 22? Because that's the DB Apps runtime version.

## Screenshot

<img width="676" height="272" alt="image" src="https://github.com/user-attachments/assets/eabdce6c-4ab7-4280-abd7-41211542e8e0" />
