### PR TITLE
fix: skip type generation when queries directory is missing

### DIFF
--- a/packages/shared/src/cli/commands/generate-types.ts
+++ b/packages/shared/src/cli/commands/generate-types.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import { Command } from "commander";
 
@@ -21,6 +22,12 @@ async function runGenerateTypes(
       outFile || path.join(process.cwd(), "client/src/appKitTypes.d.ts");
 
     const queryFolder = path.join(resolvedRootDir, "config/queries");
+    if (!fs.existsSync(queryFolder)) {
+      console.warn(
+        `Warning: No queries found at ${queryFolder}. Skipping type generation.`,
+      );
+      return;
+    }
 
     const resolvedWarehouseId =
       warehouseId || process.env.DATABRICKS_WAREHOUSE_ID;


### PR DESCRIPTION
## Summary
- Adds a check for whether the `config/queries` directory exists before running type generation
- Shows a warning message and exits gracefully if no queries are found
