### PR TITLE
fix: run typegen automatically via npm lifecycle hooks

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -20,6 +20,9 @@
     "test:e2e:ui": "playwright test --ui",
     "test:smoke": "playwright install chromium && playwright test tests/smoke.spec.ts",
     "clean": "rm -rf client/dist dist build node_modules .smoke-test test-results playwright-report",
+    "postinstall": "npm run typegen",
+    "prebuild": "npm run typegen",
+    "predev": "npm run typegen",
     "typegen": "appkit generate-types",
     "setup": "appkit setup --write"
   },


### PR DESCRIPTION
   - Adds `postinstall`, `prebuild`, and `predev` lifecycle hooks to the template's `package.json` that run `npm run typegen` automatically
   - Eliminates the need to manually run `npm run typegen` before types are available, preventing compilation errors when agents create apps.