### PR TITLE
Add typegen warning to template App.tsx

### DIFF
--- a/template/client/src/App.tsx
+++ b/template/client/src/App.tsx
@@ -1,3 +1,15 @@
+/**
+ * ⚠️ BEFORE MODIFYING THIS FILE:
+ *
+ * 1. Create SQL files in config/queries/
+ * 2. Run `npm run typegen` to generate query types
+ * 3. Check appKitTypes.d.ts for available types
+ *
+ * Common Mistakes:
+ * - DataTable does NOT accept `data` or `columns` props
+ * - Charts use `xKey` and `yKey`, NOT `seriesKey`/`nameKey`/`valueKey`
+ * - useAnalyticsQuery has no `enabled` option - use conditional rendering
+ */
 import {
   useAnalyticsQuery,
   AreaChart,


### PR DESCRIPTION
## Summary
- Adds a warning comment at the top of `template/client/src/App.tsx` reminding agents to run `npm run typegen` before modifying the file
- Documents common mistakes with DataTable, Charts, and useAnalyticsQuery props