### PR TITLE
feat: allow overriding vite client port

### DIFF
--- a/packages/appkit/src/plugins/server/vite-dev-server.ts
+++ b/packages/appkit/src/plugins/server/vite-dev-server.ts
@@ -58,11 +58,17 @@ export class ViteDevServer extends BaseServer {
     );
 
     const userConfig = loadedConfig?.config ?? {};
+    const viteClientPort = process.env.VITE_CLIENT_PORT;
+    const serverHmr = viteClientPort
+      ? { hmr: { clientPort: viteClientPort } }
+      : {};
+
     const coreConfig = {
       configFile: false,
       root: clientRoot,
       server: {
         middlewareMode: true,
+        ...serverHmr,
         watch: {
           useFsEvents: true,
           ignored: ["**/node_modules/**", "!**/node_modules/@databricks/**"],


### PR DESCRIPTION
if `process.env.VITE_CLIENT_PORT` is present in the environment then we use that port instead of the default one