### PR TITLE
ci: fix pushing tags in release jobs

### DIFF
--- a/.github/workflows/release-lakebase.yml
+++ b/.github/workflows/release-lakebase.yml
@@ -14,6 +14,10 @@ on:
         type: boolean
         default: false
 
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'packages/lakebase/**'
   workflow_dispatch:
     inputs:
       dry-run:
@@ -11,6 +13,10 @@ on:
         required: false
         type: boolean
         default: false
+
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 jobs:
   release:

--- a/tools/publish-template-tag.ts
+++ b/tools/publish-template-tag.ts
@@ -77,7 +77,7 @@ if (installExit !== 0) {
 const commands: [string, string[]][] = [
   ["git", ["add", "template/package.json", "template/package-lock.json"]],
   ["git", ["commit", "-m", `"chore: sync template to v${version} [skip ci]"`]],
-  ["git", ["tag", `template-v${version}`]],
+  ["git", ["tag", "-a", `template-v${version}`, "-m", `Template v${version}`]],
   ["git", ["push", "origin", "main", "--follow-tags"]],
 ];
 


### PR DESCRIPTION
- Fix pushing a tag on template sync (root cause was that the push command works only with annotated tags - now we create such tag
- Fix concurrency issues for Release and Lakebase Release pipelines: https://github.com/databricks/appkit/actions/runs/22351029341/job/64677912522 release failed because a Lakebase release related commit were pushed in the meantime: 
<img width="683" height="216" alt="image" src="https://github.com/user-attachments/assets/1d4cf17b-cbff-4836-af8d-1f79b4ae84c7" />

Resolves https://databricks.atlassian.net/browse/LKB-9851
