### PR TITLE
fix: generate types command

### DIFF
--- a/packages/shared/src/cli/index.ts
+++ b/packages/shared/src/cli/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-
+import "dotenv/config";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";


### PR DESCRIPTION
CLI commands are not getting the environment injected so commands like generate-types fail