### PR TITLE
fix: use default import for `Time` from `@databricks/sdk-experimental`

### DIFF
--- a/packages/appkit/src/cache/tests/cache-manager.test.ts
+++ b/packages/appkit/src/cache/tests/cache-manager.test.ts
@@ -50,6 +50,7 @@ vi.mock("../storage/persistent", () => ({
 
 // Mock WorkspaceClient
 vi.mock("@databricks/sdk-experimental", () => ({
+  default: {},
   WorkspaceClient: vi.fn().mockImplementation(() => ({})),
 }));
 

--- a/packages/appkit/src/connectors/genie/client.ts
+++ b/packages/appkit/src/connectors/genie/client.ts
@@ -1,5 +1,8 @@
 import type { WorkspaceClient } from "@databricks/sdk-experimental";
-import { Time, TimeUnits } from "@databricks/sdk-experimental";
+import sdk from "@databricks/sdk-experimental";
+
+const { Time, TimeUnits } = sdk;
+
 import type { GenieMessage } from "@databricks/sdk-experimental/dist/apis/dashboards";
 import type { Waiter } from "@databricks/sdk-experimental/dist/wait";
 import { createLogger } from "../../logging";


### PR DESCRIPTION
`Time` is a re-exported default export in the CJS-only SDK package. Node's ESM-CJS interop cannot resolve it as a named export, causing `SyntaxError: Named export 'Time' not found` for ESM consumers.