### PR TITLE
docs: add Genie plugin documentation

### DIFF
--- a/docs/docs/plugins/genie.md
+++ b/docs/docs/plugins/genie.md
@@ -21,9 +21,7 @@ import { createApp, genie, server } from "@databricks/appkit";
 await createApp({
   plugins: [
     server(),
-    genie({
-      spaces: { default: process.env.DATABRICKS_GENIE_SPACE_ID },
-    }),
+    genie(),
   ],
 });
 ```

--- a/docs/docs/plugins/index.md
+++ b/docs/docs/plugins/index.md
@@ -19,7 +19,7 @@ const AppKit = await createApp({
   plugins: [
     server({ port: 8000 }),
     analytics(),
-    genie({ spaces: { default: process.env.DATABRICKS_GENIE_SPACE_ID } }),
+    genie(),
   ],
 });
 ```


### PR DESCRIPTION
## Summary
- Add `docs/docs/plugins/genie.md` with full Genie plugin documentation covering configuration, HTTP endpoints, SSE event types, programmatic access, and frontend components
- Update plugins index page to include `genie` in the example `createApp` snippet
