### PR TITLE
chore: add CODEOWNERS for eng-apps-devex-appkit

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @databricks/eng-apps-devex-appkit


### PR DESCRIPTION
## Summary
- Adds a `.github/CODEOWNERS` file assigning `@databricks/eng-apps-devex-appkit` as the default code owner for all files in the repository.

https://github.com/orgs/databricks/teams/eng-apps-devex-appkit

<img width="1006" height="783" alt="image" src="https://github.com/user-attachments/assets/9ff4e34a-20c6-4cd0-87b3-972aa74d0c86" />
