### PR TITLE
fix: avoid unused variable error in template when lakebase is disabled

### DIFF
--- a/template/server/server.ts
+++ b/template/server/server.ts
@@ -18,9 +18,11 @@ createApp({
 {{- end}}
 {{- end}}
   ],
-}).then(async (appkit) => {
+})
 {{- if .plugins.lakebase}}
-  await setupSampleLakebaseRoutes(appkit);
-  await appkit.server.start();
+  .then(async (appkit) => {
+    await setupSampleLakebaseRoutes(appkit);
+    await appkit.server.start();
+  })
 {{- end}}
-}).catch(console.error);
+  .catch(console.error);


### PR DESCRIPTION
When lakebase plugin is not enabled, the `.then(async (appkit) => {})` block was empty, causing TS6133 "declared but never read" typecheck failure. Conditionally emit the `.then()` block only when lakebase is enabled.

<img width="726" height="313" alt="image" src="https://github.com/user-attachments/assets/5ecadf85-fa33-4828-bc92-1ca84e63a76c" />
