### PR TITLE
feat: add build-eval-pack workflow for eval pipeline

### DIFF
--- a/.github/workflows/build-eval-pack.yml
+++ b/.github/workflows/build-eval-pack.yml
@@ -1,0 +1,61 @@
+name: Build Eval Pack
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag, or commit to build from"
+        required: false
+        type: string
+        default: ""
+
+concurrency:
+  group: eval-pack-${{ github.event.inputs.ref || github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build:
+    name: Build SDK Tarballs
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build and pack SDK
+        run: pnpm pack:sdk
+
+      - name: Create eval pack
+        run: |
+          mkdir -p eval-pack
+          cp packages/appkit/tmp/*.tgz eval-pack/
+          cp packages/appkit-ui/tmp/*.tgz eval-pack/
+          echo "Tarballs:"
+          ls -la eval-pack/
+
+      - name: Upload eval pack
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-pack
+          path: eval-pack/*.tgz
+          retention-days: 30


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch` GitHub Actions workflow (`build-eval-pack.yml`) that:
- Builds SDK tarballs from any branch/tag/commit
- Uploads `@databricks/appkit` and `@databricks/appkit-ui` tarballs as artifacts
- Artifacts are retained for 30 days

This enables the apps-mcp-evals pipeline to download pre-built AppKit artifacts
from GitHub instead of cloning and building on the Databricks cluster (which
requires pnpm/corepack and takes ~5 minutes).

## How it works

1. Trigger manually: **Actions > Build Eval Pack > Run workflow** (optionally specify a branch)
2. The eval pipeline's `generate_single_app.py` calls the GitHub API to download the `eval-pack` artifact
3. Falls back to clone+build if no pre-built artifact exists

## Test plan

- [ ] Trigger the workflow manually on `main`
- [ ] Verify artifacts are downloadable via GitHub API
- [ ] Run an eval with `APPKIT_BRANCH=main` and confirm it downloads artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)