### PR TITLE
chore(appkit-ui): improve text selection visibility in genie chat bubbles

### DIFF
--- a/docs/static/appkit-ui/styles.gen.css
+++ b/docs/static/appkit-ui/styles.gen.css
@@ -4351,6 +4351,14 @@
       }
     }
   }
+  .\[\&_\*\:\:selection\]\:bg-primary-foreground\/30 {
+    & *::selection {
+      background-color: var(--primary-foreground);
+      @supports (color: color-mix(in lab, red, red)) {
+        background-color: color-mix(in oklab, var(--primary-foreground) 30%, transparent);
+      }
+    }
+  }
   .\[\&_\.recharts-cartesian-axis-tick_text\]\:fill-muted-foreground {
     & .recharts-cartesian-axis-tick text {
       fill: var(--muted-foreground);
@@ -4697,6 +4705,14 @@
   .\[\&\+\[data-slot\=item-content\]\]\:flex-none {
     &+[data-slot=item-content] {
       flex: none;
+    }
+  }
+  .\[\&\:\:selection\]\:bg-primary-foreground\/30 {
+    &::selection {
+      background-color: var(--primary-foreground);
+      @supports (color: color-mix(in lab, red, red)) {
+        background-color: color-mix(in oklab, var(--primary-foreground) 30%, transparent);
+      }
     }
   }
   .\[\&\:first-child\[data-selected\=true\]_button\]\:rounded-l-md {

--- a/packages/appkit-ui/src/react/genie/genie-chat-message.tsx
+++ b/packages/appkit-ui/src/react/genie/genie-chat-message.tsx
@@ -75,7 +75,9 @@ export function GenieChatMessage({
         <Card
           className={cn(
             "px-4 py-3 max-w-full overflow-hidden",
-            isUser ? "bg-primary text-primary-foreground" : "bg-muted",
+            isUser
+              ? "bg-primary text-primary-foreground [&_*::selection]:bg-primary-foreground/30 [&::selection]:bg-primary-foreground/30"
+              : "bg-muted",
           )}
         >
           {html && (

--- a/packages/appkit-ui/src/react/styles/globals.css
+++ b/packages/appkit-ui/src/react/styles/globals.css
@@ -373,8 +373,8 @@
   }
 
   ::selection {
-    background-color: var(--primary);
-    opacity: 0.2;
+    background-color: color-mix(in oklch, var(--primary) 30%, transparent);
+    color: var(--primary-foreground);
   }
 
   @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
Improve selection highlight contrast for both user and AI message bubbles in both light and dark themes.

### **Before**  
Note highlighted text in bubbles from messages sent by the user cannot be seen at all.
<img width="977" height="259" alt="image" src="https://github.com/user-attachments/assets/deae15d9-5ee3-43a1-9270-d41476184923" />
<img width="922" height="249" alt="image" src="https://github.com/user-attachments/assets/4b4ba49a-12d9-48bd-acde-49353e487a04" />



### **After**
<img width="943" height="322" alt="image" src="https://github.com/user-attachments/assets/15b2a78c-466f-4495-b1a6-02b91d7a4b01" />
<img width="988" height="268" alt="image" src="https://github.com/user-attachments/assets/96fbacdc-bc39-486a-a3d0-b253f4003255" />
