### PR TITLE
fix: files permissions on DABs

### DIFF
--- a/template/databricks.yml.tmpl
+++ b/template/databricks.yml.tmpl
@@ -13,14 +13,14 @@ resources:
       description: "{{.appDescription}}"
       source_code_path: ./
 
-{{- $scopes := list}}
-{{- if .plugins.genie}}{{$scopes = append $scopes "dashboards.genie"}}{{end}}
-{{- if .plugins.files}}{{$scopes = append $scopes "files.files"}}{{end}}
-{{- if $scopes}}
+{{- if or .plugins.genie .plugins.files}}
       user_api_scopes:
-      {{- range $scopes}}
-        - {{.}}
-      {{- end}}
+{{- if .plugins.genie}}
+        - dashboards.genie
+{{- end}}
+{{- if .plugins.files}}
+        - files.files
+{{- end}}
 {{- else}}
       # Uncomment to enable on behalf of user API scopes. Available scopes: sql, dashboards.genie, files.files
       # user_api_scopes:


### PR DESCRIPTION
## Summary

Make `user_api_scopes` in the DABs template dynamically composable so multiple plugins can each contribute their required scopes.

**Dynamic user_api_scopes aggregation** (`template/databricks.yml.tmpl`):
Previously, `user_api_scopes` was hardcoded to only handle the genie plugin with a simple if/else toggle. Now the template builds a `$scopes` list by conditionally appending each plugin's required scope (genie → `dashboards.genie`, files → `files.files`), then renders the full list if non-empty or falls back to the commented-out placeholder. This makes adding future plugin scopes a one-liner.

### Other changes

- Added `files.files` scope support for the new files plugin.