### PR TITLE
fix(appkit): remove leftover test comments

### DIFF
--- a/packages/appkit/src/core/index.ts
+++ b/packages/appkit/src/core/index.ts
@@ -1,3 +1,1 @@
 export { createApp } from "./appkit";
-// test
-// test


### PR DESCRIPTION
## Summary
- Removes leftover `// test` comments from `packages/appkit/src/core/index.ts`

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes