### PR TITLE
chore: add files app template generation

### DIFF
--- a/docs/static/appkit-ui/styles.gen.css
+++ b/docs/static/appkit-ui/styles.gen.css
@@ -3584,6 +3584,11 @@
       --tw-exit-opacity: 0;
     }
   }
+  .data-\[state\=inactive\]\:invisible {
+    &[data-state="inactive"] {
+      visibility: hidden;
+    }
+  }
   .data-\[state\=on\]\:bg-accent {
     &[data-state="on"] {
       background-color: var(--accent);
@@ -4829,6 +4834,16 @@
     &:nth-child(2)[data-selected=true] button {
       border-top-left-radius: var(--radius-md);
       border-bottom-left-radius: var(--radius-md);
+    }
+  }
+  .\[\&\>\*\]\:col-start-1 {
+    &>* {
+      grid-column-start: 1;
+    }
+  }
+  .\[\&\>\*\]\:row-start-1 {
+    &>* {
+      grid-row-start: 1;
     }
   }
   .\[\&\>\*\]\:w-full {

--- a/tools/generate-app-templates.ts
+++ b/tools/generate-app-templates.ts
@@ -52,6 +52,7 @@ interface AppTemplate {
 
 const FEATURE_DEPENDENCIES: Record<string, string> = {
   analytics: "SQL warehouse",
+  files: "Volume",
   genie: "Genie Space",
   lakebase: "Database",
 };
@@ -59,15 +60,16 @@ const FEATURE_DEPENDENCIES: Record<string, string> = {
 const APP_TEMPLATES: AppTemplate[] = [
   {
     name: "appkit-all-in-one",
-    features: ["analytics", "genie", "lakebase"],
+    features: ["analytics", "files", "genie", "lakebase"],
     set: {
       "analytics.sql-warehouse.id": "placeholder",
+      "files.files.path": "placeholder",
       "genie.genie-space.id": "placeholder",
       "lakebase.postgres.branch": "placeholder",
       "lakebase.postgres.database": "placeholder",
     },
     description:
-      "Full-stack Node.js app with SQL analytics dashboards, Genie AI conversations, and Lakebase Autoscaling (Postgres) CRUD",
+      "Full-stack Node.js app with SQL analytics dashboards, file browser, Genie AI conversations, and Lakebase Autoscaling (Postgres) CRUD",
   },
   {
     name: "appkit-analytics",
@@ -85,6 +87,14 @@ const APP_TEMPLATES: AppTemplate[] = [
     },
     description:
       "Node.js app with AI/BI Genie for natural language data queries",
+  },
+  {
+    name: "appkit-files",
+    features: ["files"],
+    set: {
+      "files.files.path": "placeholder",
+    },
+    description: "Node.js app with file browser for Databricks Volumes",
   },
   {
     name: "appkit-lakebase",


### PR DESCRIPTION
## Summary
- Add standalone `appkit-files` template variant for scaffolding files-only apps
- Include the `files` plugin in `appkit-all-in-one` template
- Add `files` → "Volume" entry to `FEATURE_DEPENDENCIES` for README table generation

## Test plan
- [x] Run `tsx tools/generate-app-templates.ts` and verify `appkit-files` is generated
- [x] Verify `appkit-all-in-one` includes the files plugin pages and routes
- [x] Confirm generated README table includes the Volume dependency for files templates

## Result

https://github.com/databricks/app-templates/pull/144