### PR TITLE
chore: cleanup npm install logs

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-shamefully-hoist=true
-auto-install-peers=true
-public-hoist-pattern[]=*


### PR DESCRIPTION
removes this

<img width="917" height="73" alt="image" src="https://github.com/user-attachments/assets/3c84878e-106d-4632-8e5f-0bc611539047" />
