### PR TITLE
ci: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+    # Disable version update PRs; only security updates are opened.
+    open-pull-requests-limit: 0
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Add the npm package ecosystem with security-only updates by setting
open-pull-requests-limit to 0.

Add the github-actions package ecosystem with a monthly update interval.
Monthly keeps churn low while ensuring deprecation notices and security
fixes flow in through PRs. The 7-day cooldown avoids bumping actions
that were just released, letting them bake first.

Co-authored-by: Isaac