### PR TITLE
fix(ci): upgrade upload-pages-artifact to v4.0.0

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Build Docs
         run: pnpm run docs:build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: ./docs/build
 


### PR DESCRIPTION
## Summary

- Upgrades `actions/upload-pages-artifact` from v3.0.1 to v4.0.0 in the docs-deploy workflow
- v3.0.1 internally references `actions/upload-artifact@v4` by tag (not SHA-pinned), which fails the org action-pinning policy
- v4.0.0 pins its internal `upload-artifact` dependency by full SHA, satisfying the policy

**Commit reference:** [`7b1f4a764d45c48632c6b24a0339c27f5614fb0b`](https://github.com/actions/upload-pages-artifact/commit/7b1f4a764d45c48632c6b24a0339c27f5614fb0b) — tagged as [`v4.0.0`](https://github.com/actions/upload-pages-artifact/releases/tag/v4.0.0)

## Why?

Our docs build fails: https://github.com/databricks/appkit/actions/runs/23747156617/job/69178755032
with an error: "Error: The action actions/upload-artifact@v4 is not allowed in databricks/appkit because all actions must be pinned to a full-length commit SHA."