### PR TITLE
chore(ci): add artifact security scanning to release pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,3 +204,39 @@ jobs:
             exit 1
           fi
 
+  artifact-scan:
+    name: Artifact Security Scan
+    needs: detect-changes
+    if: needs.detect-changes.outputs.appkit == 'true'
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build and dist
+        run: |
+          pnpm build
+          pnpm --filter=@databricks/appkit dist
+          pnpm --filter=@databricks/appkit-ui dist
+      - name: Security scan (appkit)
+        uses: databricks/gh-action-scan@1c260de6986f77d8c505975ce434830a7afdb95f
+        with:
+          artifact-path: packages/appkit/tmp
+          artifact-name: appkit-pr-test
+      - name: Security scan (appkit-ui)
+        uses: databricks/gh-action-scan@1c260de6986f77d8c505975ce434830a7afdb95f
+        with:
+          artifact-path: packages/appkit-ui/tmp
+          artifact-name: appkit-ui-pr-test
+

--- a/.github/workflows/release-lakebase.yml
+++ b/.github/workflows/release-lakebase.yml
@@ -1,11 +1,11 @@
 name: Release @databricks/lakebase
 
 on:
-  # push:
-  #   branches:
-  #     - main
-  #   paths:
-  #     - 'packages/lakebase/**'
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/lakebase/**'
   workflow_dispatch:
     inputs:
       dry-run:
@@ -61,13 +61,38 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Release
+      - name: Release (build + tag locally)
         working-directory: packages/lakebase
         run: |
           if [ "$DRY_RUN" == "true" ]; then
             pnpm release:dry
           else
-            pnpm release:ci
+            pnpm exec release-it --ci --no-git.push --no-github.release
           fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Security scan
+        if: env.DRY_RUN != 'true'
+        uses: databricks-eng/gh-action-scan@1c260de6986f77d8c505975ce434830a7afdb95f
+        with:
+          artifact-path: packages/lakebase/tmp
+          artifact-name: lakebase
+
+      - name: Push tag and create GitHub release
+        if: env.DRY_RUN != 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(node -p "require('./packages/lakebase/package.json').version")
+          git push --follow-tags
+          NOTES=$(awk '/^## \[/{if(p) exit; p=1} p' packages/lakebase/CHANGELOG.md)
+          gh release create "lakebase-v${VERSION}" \
+            --title "@databricks/lakebase v${VERSION}" \
+            --notes "$NOTES"
+
+      - name: Publish to npm
+        if: env.DRY_RUN != 'true'
+        run: npm publish packages/lakebase/tmp --access public --provenance
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,11 @@
 name: Release
 
 on:
-  # push:
-  #   branches:
-  #     - main
-  #   paths-ignore:
-  #     - 'packages/lakebase/**'
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'packages/lakebase/**'
   workflow_dispatch:
     inputs:
       dry-run:
@@ -82,13 +82,47 @@ jobs:
             echo "No releasable version detected"
           fi
 
-      - name: Release
+      - name: Release (build + tag locally, no push)
         run: |
           if [ "${{ steps.mode.outputs.dry_run }}" == "true" ]; then
             pnpm release:dry
           else
-            pnpm release:ci
+            pnpm exec release-it --ci --no-git.push --no-github.release
           fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Security scan (appkit)
+        if: steps.mode.outputs.dry_run != 'true' && steps.version.outputs.version != ''
+        uses: databricks-eng/gh-action-scan@1c260de6986f77d8c505975ce434830a7afdb95f
+        with:
+          artifact-path: packages/appkit/tmp
+          artifact-name: appkit-${{ steps.version.outputs.version }}
+
+      - name: Security scan (appkit-ui)
+        if: steps.mode.outputs.dry_run != 'true' && steps.version.outputs.version != ''
+        uses: databricks-eng/gh-action-scan@1c260de6986f77d8c505975ce434830a7afdb95f
+        with:
+          artifact-path: packages/appkit-ui/tmp
+          artifact-name: appkit-ui-${{ steps.version.outputs.version }}
+
+      - name: Push tag and create GitHub release
+        if: steps.mode.outputs.dry_run != 'true' && steps.version.outputs.version != ''
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git push --follow-tags
+          NOTES=$(awk '/^## \[/{if(p) exit; p=1} p' CHANGELOG.md)
+          gh release create "v${VERSION}" \
+            --title "AppKit v${VERSION}" \
+            --notes "$NOTES"
+
+      - name: Publish to npm
+        if: steps.mode.outputs.dry_run != 'true' && steps.version.outputs.version != ''
+        run: |
+          npm publish packages/appkit/tmp --access public --provenance
+          npm publish packages/appkit-ui/tmp --access public --provenance
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.release-it.json
+++ b/.release-it.json
@@ -25,8 +25,7 @@
   "hooks": {
     "before:init": "pnpm audit --audit-level=high --prod",
     "after:bump": "tsx tools/sync-versions.ts ${version} && pnpm build:notice && git add NOTICE.md",
-    "before:release": "pnpm build && pnpm --filter=docs build && pnpm --filter=@databricks/appkit dist && pnpm --filter=@databricks/appkit-ui dist && pnpm release:sbom",
-    "after:release": "npm publish packages/appkit/tmp --access public --provenance && npm publish packages/appkit-ui/tmp --access public --provenance"
+    "before:release": "pnpm build && pnpm --filter=docs build && pnpm --filter=@databricks/appkit dist && pnpm --filter=@databricks/appkit-ui dist && pnpm release:sbom"
   },
   "plugins": {
     "@release-it/conventional-changelog": {

--- a/packages/lakebase/.release-it.json
+++ b/packages/lakebase/.release-it.json
@@ -23,8 +23,7 @@
   "hooks": {
     "before:init": "pnpm audit --audit-level=high --prod",
     "after:bump": "npm version ${version} --no-git-tag-version --allow-same-version",
-    "before:release": "pnpm build:package && pnpm dist && pnpm release:sbom",
-    "after:release": "npm publish ./tmp --access public --provenance"
+    "before:release": "pnpm build:package && pnpm dist && pnpm release:sbom"
   },
   "plugins": {
     "@release-it/conventional-changelog": {


### PR DESCRIPTION
## Summary
- Add `gh-action-scan` to both release workflows (`release.yml`, `release-lakebase.yml`)
- Scan runs **before** git push — if scan fails, no tag is pushed and no npm publish happens
- Decouple `npm publish` from release-it's `after:release` hook into explicit workflow steps
- Uncomment push-to-main triggers for both release workflows
- Use `release-it --ci --no-git.push --no-github.release` to build + tag locally, then push + create GH release + publish only after scan passes

## How it works
1. `release-it` runs full lifecycle (audit → bump → build → dist → sbom → commit → tag) but stops before pushing
2. `gh-action-scan` scans the built `tmp/` directories
3. If scans pass: push tag, create GitHub release (with changelog notes), publish to npm
4. If scan fails: workflow fails, no tag pushed, no publish — clean state

## Test plan
- [ ] Trigger dry-run release — scan/push/publish steps should be skipped
- [ ] Trigger real release — scan steps run before push, changelog notes extracted for GH release
- [ ] Verify `security-scan-results-*` artifacts are uploaded
- [ ] Verify npm publish succeeds after scan
- [ ] Verify local `pnpm release` still works (release-it config unchanged for push/release)