### PR TITLE
docs: fix Lakebase references to say Autoscaling instead of Provisioned

### DIFF
--- a/docs/docs/architecture.md
+++ b/docs/docs/architecture.md
@@ -83,7 +83,7 @@ The Node.js backend layer built with `@databricks/appkit`:
 
 Integration with Databricks services:
 - **SQL Warehouses**: Execute analytical queries with Arrow or JSON format
-- **Lakebase V1 (Provisioned)**: Access data from Lakebase Provisioned. Support for Lakebase Autoscaling coming soon.
+- **Lakebase Autoscaling**: OLTP database access with automatic OAuth token refresh
 
 ## See also
 

--- a/docs/docs/plugins/caching.md
+++ b/docs/docs/plugins/caching.md
@@ -19,7 +19,9 @@ await createApp({
 });
 ```
 
-Storage auto-selects **Lakebase V1 (Provisioned) persistent cache when healthy**, otherwise falls back to in-memory. Support for Lakebase Autoscaling coming soon.
+Storage auto-selects **Lakebase Autoscaling persistent cache when healthy**, otherwise falls back to in-memory.
+
+The database-backed cache requires the same Lakebase environment variables as the [Lakebase plugin](./lakebase.md#environment-variables) (`PGHOST`, `PGDATABASE`, `LAKEBASE_ENDPOINT`, `PGSSLMODE`).
 
 ## Plugin-level caching
 


### PR DESCRIPTION
## Summary

- Replaced incorrect "Lakebase V1 (Provisioned)" references with "Lakebase Autoscaling" in caching and architecture docs
- Removed stale "Support for Lakebase Autoscaling coming soon" notes
- Added link from the caching doc to the Lakebase plugin for environment variable configuration