### PR TITLE
chore(ci): replace Docker-based PR title check with JS-based action

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -18,7 +18,19 @@ jobs:
     name: Conventional Commit Title
     steps:
       - name: Validate PR title
-        uses: ytanikin/pr-conventional-commits@fda730cb152c05a849d6d84325e50c6182d9d1e9 # 1.5.1
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert","style","build"]'
-          add_label: 'false'
+          types: |
+            feat
+            fix
+            docs
+            test
+            ci
+            refactor
+            perf
+            chore
+            revert
+            style
+            build


### PR DESCRIPTION
## Summary

- Replaces `ytanikin/pr-conventional-commits` (Docker-based) with `amannn/action-semantic-pull-request` (JS/node24-based, SHA-pinned)
- The Docker action builds a container at runtime and runs `npm ci` inside it, which fails on hardened runners since `registry.npmjs.org` is blocked
- The new action ships pre-bundled (`dist/` folder) — no npm registry access needed

## Test plan
- [ ] PR title validation job passes on this PR
- [ ] Verify invalid PR titles are correctly rejected