### PR TITLE
fix: convert BigInt to strings in Arrow IPC row.toJSON()

### DIFF
--- a/packages/appkit/src/connectors/sql-warehouse/client.ts
+++ b/packages/appkit/src/connectors/sql-warehouse/client.ts
@@ -3,6 +3,7 @@ import {
   type sql,
   type WorkspaceClient,
 } from "@databricks/sdk-experimental";
+import { tableFromIPC } from "apache-arrow";
 import type { TelemetryOptions } from "shared";
 import {
   AppKitError,
@@ -435,6 +436,37 @@ export class SQLWarehouseConnector {
       result: {
         ...restResult,
         data: transformedData,
+      },
+    };
+  }
+
+  /**
+   * Decode a base64 Arrow IPC attachment into row objects.
+   * Some serverless warehouses return inline results as Arrow IPC in
+   * `result.attachment` rather than `result.data_array`.
+   */
+  private _transformArrowAttachment(
+    response: sql.StatementResponse,
+    attachment: string,
+  ) {
+    const buf = Buffer.from(attachment, "base64");
+    const table = tableFromIPC(buf);
+    const data = table.toArray().map((row) => {
+      const obj = row.toJSON();
+      // Convert BigInt values to strings to avoid JSON.stringify failures
+      for (const key of Object.keys(obj)) {
+        if (typeof obj[key] === "bigint") {
+          obj[key] = obj[key].toString();
+        }
+      }
+      return obj;
+    });
+    const { attachment: _att, ...restResult } = response.result as any;
+    return {
+      ...response,
+      result: {
+        ...restResult,
+        data,
       },
     };
   }


### PR DESCRIPTION
## Summary

- `row.toJSON()` from apache-arrow preserves `BigInt` for Int64 columns. When this data is later serialized with `JSON.stringify()` for SSE streaming, it throws `TypeError: Do not know how to serialize a BigInt`.
- Convert BigInt values to strings in `_transformArrowAttachment` during row transformation, before the data reaches JSON serialization.
- This ensures Arrow IPC deserialization works correctly for serverless warehouses that return inline results as Arrow IPC in `result.attachment`.

## Test plan

- [ ] Verify that queries returning Int64 columns via Arrow IPC attachment no longer throw `TypeError: Do not know how to serialize a BigInt` during SSE streaming
- [ ] Verify that non-BigInt columns are unaffected by the change
- [ ] Verify that the string representation of BigInt values is correct and usable downstream

This pull request was AI-assisted by Isaac.