### PR TITLE
feat: inline Arrow IPC support with format fallback

### DIFF
--- a/packages/appkit-ui/src/react/charts/types.ts
+++ b/packages/appkit-ui/src/react/charts/types.ts
@@ -5,7 +5,7 @@ import type { Table } from "apache-arrow";
 // ============================================================================
 
 /** Supported data formats for analytics queries */
-export type DataFormat = "json" | "arrow" | "auto";
+export type DataFormat = "json" | "arrow" | "arrow_stream" | "auto";
 
 /** Chart orientation */
 export type Orientation = "vertical" | "horizontal";

--- a/packages/appkit-ui/src/react/hooks/__tests__/use-chart-data.test.ts
+++ b/packages/appkit-ui/src/react/hooks/__tests__/use-chart-data.test.ts
@@ -205,7 +205,7 @@ describe("useChartData", () => {
       );
     });
 
-    test("auto-selects JSON by default when no heuristics match", () => {
+    test("auto-selects ARROW_STREAM by default when no heuristics match", () => {
       mockUseAnalyticsQuery.mockReturnValue({
         data: [],
         loading: false,
@@ -223,11 +223,11 @@ describe("useChartData", () => {
       expect(mockUseAnalyticsQuery).toHaveBeenCalledWith(
         "test",
         { limit: 100 },
-        expect.objectContaining({ format: "JSON" }),
+        expect.objectContaining({ format: "ARROW_STREAM" }),
       );
     });
 
-    test("defaults to auto format (JSON) when format is not specified", () => {
+    test("defaults to auto format (ARROW_STREAM) when format is not specified", () => {
       mockUseAnalyticsQuery.mockReturnValue({
         data: [],
         loading: false,
@@ -243,7 +243,7 @@ describe("useChartData", () => {
       expect(mockUseAnalyticsQuery).toHaveBeenCalledWith(
         "test",
         undefined,
-        expect.objectContaining({ format: "JSON" }),
+        expect.objectContaining({ format: "ARROW_STREAM" }),
       );
     });
   });

--- a/packages/appkit-ui/src/react/hooks/types.ts
+++ b/packages/appkit-ui/src/react/hooks/types.ts
@@ -32,8 +32,10 @@ export interface TypedArrowTable<
 // ============================================================================
 
 /** Options for configuring an analytics SSE query */
-export interface UseAnalyticsQueryOptions<F extends AnalyticsFormat = "JSON"> {
-  /** Response format - "JSON" returns typed arrays, "ARROW" returns TypedArrowTable */
+export interface UseAnalyticsQueryOptions<
+  F extends AnalyticsFormat = "ARROW_STREAM",
+> {
+  /** Response format - "ARROW_STREAM" (default) uses inline Arrow, "JSON" returns typed arrays, "ARROW" uses external links */
   format?: F;
 
   /** Maximum size of serialized parameters in bytes */

--- a/packages/appkit-ui/src/react/hooks/types.ts
+++ b/packages/appkit-ui/src/react/hooks/types.ts
@@ -5,7 +5,7 @@ import type { Table } from "apache-arrow";
 // ============================================================================
 
 /** Supported response formats for analytics queries */
-export type AnalyticsFormat = "JSON" | "ARROW";
+export type AnalyticsFormat = "JSON" | "ARROW" | "ARROW_STREAM";
 
 /**
  * Typed Arrow Table - preserves row type information for type inference.

--- a/packages/appkit-ui/src/react/hooks/use-analytics-query.ts
+++ b/packages/appkit-ui/src/react/hooks/use-analytics-query.ts
@@ -54,13 +54,13 @@ function getArrowStreamUrl(id: string) {
 export function useAnalyticsQuery<
   T = unknown,
   K extends QueryKey = QueryKey,
-  F extends AnalyticsFormat = "JSON",
+  F extends AnalyticsFormat = "ARROW_STREAM",
 >(
   queryKey: K,
   parameters?: InferParams<K> | null,
   options: UseAnalyticsQueryOptions<F> = {} as UseAnalyticsQueryOptions<F>,
 ): UseAnalyticsQueryResult<InferResultByFormat<T, K, F>> {
-  const format = options?.format ?? "JSON";
+  const format = options?.format ?? "ARROW_STREAM";
   const maxParametersSize = options?.maxParametersSize ?? 100 * 1024;
   const autoStart = options?.autoStart ?? true;
 

--- a/packages/appkit-ui/src/react/hooks/use-chart-data.ts
+++ b/packages/appkit-ui/src/react/hooks/use-chart-data.ts
@@ -73,10 +73,10 @@ function resolveFormat(
       return "ARROW";
     }
 
-    return "JSON";
+    return "ARROW_STREAM";
   }
 
-  return "JSON";
+  return "ARROW_STREAM";
 }
 
 // ============================================================================

--- a/packages/appkit-ui/src/react/hooks/use-chart-data.ts
+++ b/packages/appkit-ui/src/react/hooks/use-chart-data.ts
@@ -50,10 +50,11 @@ export interface UseChartDataResult {
 function resolveFormat(
   format: DataFormat,
   parameters?: Record<string, unknown>,
-): "JSON" | "ARROW" {
+): "JSON" | "ARROW" | "ARROW_STREAM" {
   // Explicit format selection
   if (format === "json") return "JSON";
   if (format === "arrow") return "ARROW";
+  if (format === "arrow_stream") return "ARROW_STREAM";
 
   // Auto-selection heuristics
   if (format === "auto") {

--- a/packages/appkit/package.json
+++ b/packages/appkit/package.json
@@ -69,6 +69,7 @@
     "@opentelemetry/sdk-trace-base": "2.6.0",
     "@opentelemetry/semantic-conventions": "1.38.0",
     "@types/semver": "7.7.1",
+    "apache-arrow": "21.1.0",
     "dotenv": "16.6.1",
     "express": "4.22.0",
     "obug": "2.1.1",

--- a/packages/appkit/src/connectors/sql-warehouse/client.ts
+++ b/packages/appkit/src/connectors/sql-warehouse/client.ts
@@ -3,6 +3,7 @@ import {
   type sql,
   type WorkspaceClient,
 } from "@databricks/sdk-experimental";
+import { tableFromIPC } from "apache-arrow";
 import type { TelemetryOptions } from "shared";
 import {
   AppKitError,
@@ -393,12 +394,20 @@ export class SQLWarehouseConnector {
 
   private _transformDataArray(response: sql.StatementResponse) {
     if (response.manifest?.format === "ARROW_STREAM") {
-      // INLINE disposition: data is in data_array, transform like JSON_ARRAY.
-      // EXTERNAL_LINKS disposition: data fetched separately via statement_id.
-      if (!response.result?.data_array) {
+      const result = response.result as any;
+
+      // Inline Arrow: some warehouses return base64 Arrow IPC in `attachment`.
+      if (result?.attachment) {
+        return this._transformArrowAttachment(response, result.attachment);
+      }
+
+      // Inline data_array: fall through to the row transform below.
+      if (result?.data_array) {
+        // Fall through.
+      } else {
+        // External links: data fetched separately via statement_id.
         return this.updateWithArrowStatus(response);
       }
-      // Fall through to the data_array transform below.
     }
 
     if (!response.result?.data_array || !response.manifest?.schema?.columns) {
@@ -440,6 +449,28 @@ export class SQLWarehouseConnector {
       result: {
         ...restResult,
         data: transformedData,
+      },
+    };
+  }
+
+  /**
+   * Decode a base64 Arrow IPC attachment into row objects.
+   * Some serverless warehouses return inline results as Arrow IPC in
+   * `result.attachment` rather than `result.data_array`.
+   */
+  private _transformArrowAttachment(
+    response: sql.StatementResponse,
+    attachment: string,
+  ) {
+    const buf = Buffer.from(attachment, "base64");
+    const table = tableFromIPC(buf);
+    const data = table.toArray().map((row) => row.toJSON());
+    const { attachment: _att, ...restResult } = response.result as any;
+    return {
+      ...response,
+      result: {
+        ...restResult,
+        data,
       },
     };
   }

--- a/packages/appkit/src/connectors/sql-warehouse/client.ts
+++ b/packages/appkit/src/connectors/sql-warehouse/client.ts
@@ -393,7 +393,12 @@ export class SQLWarehouseConnector {
 
   private _transformDataArray(response: sql.StatementResponse) {
     if (response.manifest?.format === "ARROW_STREAM") {
-      return this.updateWithArrowStatus(response);
+      // INLINE disposition: data is in data_array, transform like JSON_ARRAY.
+      // EXTERNAL_LINKS disposition: data fetched separately via statement_id.
+      if (!response.result?.data_array) {
+        return this.updateWithArrowStatus(response);
+      }
+      // Fall through to the data_array transform below.
     }
 
     if (!response.result?.data_array || !response.manifest?.schema?.columns) {

--- a/packages/appkit/src/connectors/sql-warehouse/defaults.ts
+++ b/packages/appkit/src/connectors/sql-warehouse/defaults.ts
@@ -12,7 +12,7 @@ interface ExecuteStatementDefaults {
 export const executeStatementDefaults: ExecuteStatementDefaults = {
   wait_timeout: "30s",
   disposition: "INLINE",
-  format: "JSON_ARRAY",
+  format: "ARROW_STREAM",
   on_wait_timeout: "CONTINUE",
   timeout: 60000,
 };

--- a/packages/appkit/src/connectors/sql-warehouse/defaults.ts
+++ b/packages/appkit/src/connectors/sql-warehouse/defaults.ts
@@ -12,7 +12,7 @@ interface ExecuteStatementDefaults {
 export const executeStatementDefaults: ExecuteStatementDefaults = {
   wait_timeout: "30s",
   disposition: "INLINE",
-  format: "ARROW_STREAM",
+  format: "JSON_ARRAY",
   on_wait_timeout: "CONTINUE",
   timeout: 60000,
 };

--- a/packages/appkit/src/connectors/sql-warehouse/tests/client.test.ts
+++ b/packages/appkit/src/connectors/sql-warehouse/tests/client.test.ts
@@ -1,7 +1,6 @@
 import type { sql } from "@databricks/sdk-experimental";
 import { describe, expect, test, vi } from "vitest";
 
-// Mock all transitive dependencies to isolate _transformDataArray logic.
 vi.mock("../../../telemetry", () => {
   const mockMeter = {
     createCounter: () => ({ add: vi.fn() }),
@@ -37,117 +36,251 @@ function createConnector() {
   return new SQLWarehouseConnector({ timeout: 30000 });
 }
 
+// Real base64 Arrow IPC from a serverless warehouse returning
+// `SELECT 1 AS test_col, 2 AS test_col2` with INLINE + ARROW_STREAM.
+// Contains schema (two INT columns) + one record batch with values [1, 2].
+const REAL_ARROW_ATTACHMENT =
+  "/////7gAAAAQAAAAAAAKAAwACgAJAAQACgAAABAAAAAAAQQACAAIAAAABAAIAAAABAAAAAIAAABMAAAABAAAAMz///8QAAAAGAAAAAAAAQIUAAAAvP///yAAAAAAAAABAAAAAAkAAAB0ZXN0X2NvbDIAAAAQABQAEAAOAA8ABAAAAAgAEAAAABgAAAAgAAAAAAABAhwAAAAIAAwABAALAAgAAAAgAAAAAAAAAQAAAAAIAAAAdGVzdF9jb2wAAAAA/////7gAAAAQAAAADAAaABgAFwAEAAgADAAAACAAAAAAAQAAAAAAAAAAAAAAAAADBAAKABgADAAIAAQACgAAADwAAAAQAAAAAQAAAAAAAAAAAAAAAgAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAEAAAAAAAAAQAAAAAAAAAAEAAAAAAAAAIAAAAAAAAAAAQAAAAAAAADAAAAAAAAAAAQAAAAAAAAA/wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP////8AAAAA";
+
 describe("SQLWarehouseConnector._transformDataArray", () => {
-  test("transforms ARROW_STREAM + INLINE data_array into named objects", () => {
-    const connector = createConnector();
-    const response = {
-      statement_id: "stmt-1",
-      status: { state: "SUCCEEDED" },
-      manifest: {
-        format: "ARROW_STREAM",
-        schema: {
-          columns: [
-            { name: "id", type_name: "INT" },
-            { name: "value", type_name: "STRING" },
+  describe("classic warehouse (JSON_ARRAY + INLINE)", () => {
+    test("transforms data_array rows into named objects", () => {
+      const connector = createConnector();
+      // Real response shape from classic warehouse: INLINE + JSON_ARRAY
+      const response = {
+        statement_id: "stmt-1",
+        status: { state: "SUCCEEDED" },
+        manifest: {
+          format: "JSON_ARRAY",
+          schema: {
+            column_count: 2,
+            columns: [
+              {
+                name: "test_col",
+                type_text: "INT",
+                type_name: "INT",
+                position: 0,
+              },
+              {
+                name: "test_col2",
+                type_text: "INT",
+                type_name: "INT",
+                position: 1,
+              },
+            ],
+          },
+          total_row_count: 1,
+          truncated: false,
+        },
+        result: {
+          data_array: [["1", "2"]],
+        },
+      } as unknown as sql.StatementResponse;
+
+      const result = (connector as any)._transformDataArray(response);
+      expect(result.result.data).toEqual([{ test_col: "1", test_col2: "2" }]);
+      expect(result.result.data_array).toBeUndefined();
+    });
+
+    test("parses JSON strings in STRING columns", () => {
+      const connector = createConnector();
+      const response = {
+        statement_id: "stmt-1",
+        status: { state: "SUCCEEDED" },
+        manifest: {
+          format: "JSON_ARRAY",
+          schema: {
+            columns: [
+              { name: "id", type_name: "INT" },
+              { name: "metadata", type_name: "STRING" },
+            ],
+          },
+        },
+        result: {
+          data_array: [["1", '{"key":"value"}']],
+        },
+      } as unknown as sql.StatementResponse;
+
+      const result = (connector as any)._transformDataArray(response);
+      expect(result.result.data[0].metadata).toEqual({ key: "value" });
+    });
+  });
+
+  describe("classic warehouse (EXTERNAL_LINKS + ARROW_STREAM)", () => {
+    test("returns statement_id for external links fetch", () => {
+      const connector = createConnector();
+      // Real response shape from classic warehouse: EXTERNAL_LINKS + ARROW_STREAM
+      const response = {
+        statement_id: "stmt-1",
+        status: { state: "SUCCEEDED" },
+        manifest: {
+          format: "ARROW_STREAM",
+          schema: {
+            columns: [
+              { name: "test_col", type_name: "INT" },
+              { name: "test_col2", type_name: "INT" },
+            ],
+          },
+        },
+        result: {
+          external_links: [
+            {
+              external_link: "https://storage.example.com/chunk0",
+              expiration: "2026-04-15T00:00:00Z",
+            },
           ],
         },
-      },
-      result: {
-        data_array: [
-          ["1", "hello"],
-          ["2", "world"],
-        ],
-      },
-    } as unknown as sql.StatementResponse;
+      } as unknown as sql.StatementResponse;
 
-    const result = (connector as any)._transformDataArray(response);
-    expect(result.result.data).toEqual([
-      { id: "1", value: "hello" },
-      { id: "2", value: "world" },
-    ]);
-    expect(result.result.data_array).toBeUndefined();
+      const result = (connector as any)._transformDataArray(response);
+      expect(result.result.statement_id).toBe("stmt-1");
+      expect(result.result.data).toBeUndefined();
+    });
   });
 
-  test("returns statement_id for ARROW_STREAM + EXTERNAL_LINKS (no data_array)", () => {
-    const connector = createConnector();
-    const response = {
-      statement_id: "stmt-1",
-      status: { state: "SUCCEEDED" },
-      manifest: { format: "ARROW_STREAM" },
-      result: {
-        external_links: [
-          { external_link: "https://storage.example.com/chunk0" },
-        ],
-      },
-    } as unknown as sql.StatementResponse;
+  describe("serverless warehouse (INLINE + ARROW_STREAM with attachment)", () => {
+    test("decodes base64 Arrow IPC attachment into row objects", () => {
+      const connector = createConnector();
+      // Real response shape from serverless warehouse: INLINE + ARROW_STREAM
+      // Data arrives in result.attachment as base64-encoded Arrow IPC, not data_array.
+      const response = {
+        statement_id: "00000001-test-stmt",
+        status: { state: "SUCCEEDED" },
+        manifest: {
+          format: "ARROW_STREAM",
+          schema: {
+            column_count: 2,
+            columns: [
+              {
+                name: "test_col",
+                type_text: "INT",
+                type_name: "INT",
+                position: 0,
+              },
+              {
+                name: "test_col2",
+                type_text: "INT",
+                type_name: "INT",
+                position: 1,
+              },
+            ],
+            total_chunk_count: 1,
+            chunks: [{ chunk_index: 0, row_offset: 0, row_count: 1 }],
+            total_row_count: 1,
+          },
+          truncated: false,
+        },
+        result: {
+          chunk_index: 0,
+          row_offset: 0,
+          row_count: 1,
+          attachment: REAL_ARROW_ATTACHMENT,
+        },
+      } as unknown as sql.StatementResponse;
 
-    const result = (connector as any)._transformDataArray(response);
-    expect(result.result.statement_id).toBe("stmt-1");
-    expect(result.result.data).toBeUndefined();
+      const result = (connector as any)._transformDataArray(response);
+      expect(result.result.data).toEqual([{ test_col: 1, test_col2: 2 }]);
+      expect(result.result.attachment).toBeUndefined();
+      // Preserves other result fields
+      expect(result.result.row_count).toBe(1);
+    });
+
+    test("preserves manifest and status alongside decoded data", () => {
+      const connector = createConnector();
+      const response = {
+        statement_id: "00000001-test-stmt",
+        status: { state: "SUCCEEDED" },
+        manifest: {
+          format: "ARROW_STREAM",
+          schema: {
+            columns: [
+              { name: "test_col", type_name: "INT" },
+              { name: "test_col2", type_name: "INT" },
+            ],
+          },
+        },
+        result: {
+          chunk_index: 0,
+          row_count: 1,
+          attachment: REAL_ARROW_ATTACHMENT,
+        },
+      } as unknown as sql.StatementResponse;
+
+      const result = (connector as any)._transformDataArray(response);
+      // Manifest and statement_id are preserved
+      expect(result.manifest.format).toBe("ARROW_STREAM");
+      expect(result.statement_id).toBe("00000001-test-stmt");
+    });
   });
 
-  test("transforms JSON_ARRAY data_array into named objects", () => {
-    const connector = createConnector();
-    const response = {
-      statement_id: "stmt-1",
-      status: { state: "SUCCEEDED" },
-      manifest: {
-        format: "JSON_ARRAY",
-        schema: {
-          columns: [
-            { name: "name", type_name: "STRING" },
-            { name: "count", type_name: "INT" },
+  describe("ARROW_STREAM with data_array (hypothetical inline variant)", () => {
+    test("transforms data_array like JSON_ARRAY path", () => {
+      const connector = createConnector();
+      const response = {
+        statement_id: "stmt-1",
+        status: { state: "SUCCEEDED" },
+        manifest: {
+          format: "ARROW_STREAM",
+          schema: {
+            columns: [
+              { name: "id", type_name: "INT" },
+              { name: "value", type_name: "STRING" },
+            ],
+          },
+        },
+        result: {
+          data_array: [
+            ["1", "hello"],
+            ["2", "world"],
           ],
         },
-      },
-      result: {
-        data_array: [
-          ["Alice", "10"],
-          ["Bob", "20"],
-        ],
-      },
-    } as unknown as sql.StatementResponse;
+      } as unknown as sql.StatementResponse;
 
-    const result = (connector as any)._transformDataArray(response);
-    expect(result.result.data).toEqual([
-      { name: "Alice", count: "10" },
-      { name: "Bob", count: "20" },
-    ]);
+      const result = (connector as any)._transformDataArray(response);
+      expect(result.result.data).toEqual([
+        { id: "1", value: "hello" },
+        { id: "2", value: "world" },
+      ]);
+    });
   });
 
-  test("parses JSON strings in STRING columns for ARROW_STREAM + INLINE", () => {
-    const connector = createConnector();
-    const response = {
-      statement_id: "stmt-1",
-      status: { state: "SUCCEEDED" },
-      manifest: {
-        format: "ARROW_STREAM",
-        schema: {
-          columns: [
-            { name: "id", type_name: "INT" },
-            { name: "metadata", type_name: "STRING" },
-          ],
+  describe("edge cases", () => {
+    test("returns response unchanged when no data_array, attachment, or schema", () => {
+      const connector = createConnector();
+      const response = {
+        statement_id: "stmt-1",
+        status: { state: "SUCCEEDED" },
+        manifest: { format: "JSON_ARRAY" },
+        result: {},
+      } as unknown as sql.StatementResponse;
+
+      const result = (connector as any)._transformDataArray(response);
+      expect(result).toBe(response);
+    });
+
+    test("attachment takes priority over data_array when both present", () => {
+      const connector = createConnector();
+      const response = {
+        statement_id: "stmt-1",
+        status: { state: "SUCCEEDED" },
+        manifest: {
+          format: "ARROW_STREAM",
+          schema: {
+            columns: [
+              { name: "test_col", type_name: "INT" },
+              { name: "test_col2", type_name: "INT" },
+            ],
+          },
         },
-      },
-      result: {
-        data_array: [["1", '{"key":"value"}']],
-      },
-    } as unknown as sql.StatementResponse;
+        result: {
+          attachment: REAL_ARROW_ATTACHMENT,
+          data_array: [["999", "999"]],
+        },
+      } as unknown as sql.StatementResponse;
 
-    const result = (connector as any)._transformDataArray(response);
-    expect(result.result.data[0].metadata).toEqual({ key: "value" });
-  });
-
-  test("returns response unchanged when no data_array or schema", () => {
-    const connector = createConnector();
-    const response = {
-      statement_id: "stmt-1",
-      status: { state: "SUCCEEDED" },
-      manifest: { format: "JSON_ARRAY" },
-      result: {},
-    } as unknown as sql.StatementResponse;
-
-    const result = (connector as any)._transformDataArray(response);
-    expect(result).toBe(response);
+      const result = (connector as any)._transformDataArray(response);
+      // Should use attachment (Arrow IPC), not data_array
+      expect(result.result.data).toEqual([{ test_col: 1, test_col2: 2 }]);
+    });
   });
 });

--- a/packages/appkit/src/connectors/sql-warehouse/tests/client.test.ts
+++ b/packages/appkit/src/connectors/sql-warehouse/tests/client.test.ts
@@ -1,0 +1,153 @@
+import type { sql } from "@databricks/sdk-experimental";
+import { describe, expect, test, vi } from "vitest";
+
+// Mock all transitive dependencies to isolate _transformDataArray logic.
+vi.mock("../../../telemetry", () => {
+  const mockMeter = {
+    createCounter: () => ({ add: vi.fn() }),
+    createHistogram: () => ({ record: vi.fn() }),
+  };
+  return {
+    TelemetryManager: {
+      getProvider: () => ({
+        startActiveSpan: vi.fn(),
+        getMeter: () => mockMeter,
+      }),
+    },
+    SpanKind: { CLIENT: 1 },
+    SpanStatusCode: { ERROR: 2 },
+  };
+});
+vi.mock("../../../logging/logger", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    event: () => null,
+  }),
+}));
+vi.mock("../../../stream/arrow-stream-processor", () => ({
+  ArrowStreamProcessor: vi.fn(),
+}));
+
+import { SQLWarehouseConnector } from "../client";
+
+function createConnector() {
+  return new SQLWarehouseConnector({ timeout: 30000 });
+}
+
+describe("SQLWarehouseConnector._transformDataArray", () => {
+  test("transforms ARROW_STREAM + INLINE data_array into named objects", () => {
+    const connector = createConnector();
+    const response = {
+      statement_id: "stmt-1",
+      status: { state: "SUCCEEDED" },
+      manifest: {
+        format: "ARROW_STREAM",
+        schema: {
+          columns: [
+            { name: "id", type_name: "INT" },
+            { name: "value", type_name: "STRING" },
+          ],
+        },
+      },
+      result: {
+        data_array: [
+          ["1", "hello"],
+          ["2", "world"],
+        ],
+      },
+    } as unknown as sql.StatementResponse;
+
+    const result = (connector as any)._transformDataArray(response);
+    expect(result.result.data).toEqual([
+      { id: "1", value: "hello" },
+      { id: "2", value: "world" },
+    ]);
+    expect(result.result.data_array).toBeUndefined();
+  });
+
+  test("returns statement_id for ARROW_STREAM + EXTERNAL_LINKS (no data_array)", () => {
+    const connector = createConnector();
+    const response = {
+      statement_id: "stmt-1",
+      status: { state: "SUCCEEDED" },
+      manifest: { format: "ARROW_STREAM" },
+      result: {
+        external_links: [
+          { external_link: "https://storage.example.com/chunk0" },
+        ],
+      },
+    } as unknown as sql.StatementResponse;
+
+    const result = (connector as any)._transformDataArray(response);
+    expect(result.result.statement_id).toBe("stmt-1");
+    expect(result.result.data).toBeUndefined();
+  });
+
+  test("transforms JSON_ARRAY data_array into named objects", () => {
+    const connector = createConnector();
+    const response = {
+      statement_id: "stmt-1",
+      status: { state: "SUCCEEDED" },
+      manifest: {
+        format: "JSON_ARRAY",
+        schema: {
+          columns: [
+            { name: "name", type_name: "STRING" },
+            { name: "count", type_name: "INT" },
+          ],
+        },
+      },
+      result: {
+        data_array: [
+          ["Alice", "10"],
+          ["Bob", "20"],
+        ],
+      },
+    } as unknown as sql.StatementResponse;
+
+    const result = (connector as any)._transformDataArray(response);
+    expect(result.result.data).toEqual([
+      { name: "Alice", count: "10" },
+      { name: "Bob", count: "20" },
+    ]);
+  });
+
+  test("parses JSON strings in STRING columns for ARROW_STREAM + INLINE", () => {
+    const connector = createConnector();
+    const response = {
+      statement_id: "stmt-1",
+      status: { state: "SUCCEEDED" },
+      manifest: {
+        format: "ARROW_STREAM",
+        schema: {
+          columns: [
+            { name: "id", type_name: "INT" },
+            { name: "metadata", type_name: "STRING" },
+          ],
+        },
+      },
+      result: {
+        data_array: [["1", '{"key":"value"}']],
+      },
+    } as unknown as sql.StatementResponse;
+
+    const result = (connector as any)._transformDataArray(response);
+    expect(result.result.data[0].metadata).toEqual({ key: "value" });
+  });
+
+  test("returns response unchanged when no data_array or schema", () => {
+    const connector = createConnector();
+    const response = {
+      statement_id: "stmt-1",
+      status: { state: "SUCCEEDED" },
+      manifest: { format: "JSON_ARRAY" },
+      result: {},
+    } as unknown as sql.StatementResponse;
+
+    const result = (connector as any)._transformDataArray(response);
+    expect(result).toBe(response);
+  });
+});

--- a/packages/appkit/src/plugins/analytics/analytics.ts
+++ b/packages/appkit/src/plugins/analytics/analytics.ts
@@ -201,7 +201,7 @@ export class AnalyticsPlugin extends Plugin {
       type: "result" as const,
     },
     JSON: {
-      formatParameters: undefined,
+      formatParameters: { disposition: "INLINE", format: "JSON_ARRAY" },
       type: "result" as const,
     },
     ARROW: {

--- a/packages/appkit/src/plugins/analytics/analytics.ts
+++ b/packages/appkit/src/plugins/analytics/analytics.ts
@@ -159,9 +159,17 @@ export class AnalyticsPlugin extends Plugin {
             },
             type: "arrow",
           }
-        : {
-            type: "result",
-          };
+        : format === "ARROW_STREAM"
+          ? {
+              formatParameters: {
+                disposition: "INLINE",
+                format: "ARROW_STREAM",
+              },
+              type: "result",
+            }
+          : {
+              type: "result",
+            };
 
     const hashedQuery = this.queryProcessor.hashQuery(query);
 

--- a/packages/appkit/src/plugins/analytics/analytics.ts
+++ b/packages/appkit/src/plugins/analytics/analytics.ts
@@ -15,6 +15,7 @@ import { queryDefaults } from "./defaults";
 import manifest from "./manifest.json";
 import { QueryProcessor } from "./query";
 import type {
+  AnalyticsFormat,
   AnalyticsQueryResponse,
   IAnalyticsConfig,
   IAnalyticsQueryRequest,
@@ -151,27 +152,6 @@ export class AnalyticsPlugin extends Plugin {
     const executor = isAsUser ? this.asUser(req) : this;
     const executorKey = isAsUser ? this.resolveUserId(req) : "global";
 
-    const queryParameters =
-      format === "ARROW"
-        ? {
-            formatParameters: {
-              disposition: "EXTERNAL_LINKS",
-              format: "ARROW_STREAM",
-            },
-            type: "arrow",
-          }
-        : format === "ARROW_STREAM"
-          ? {
-              formatParameters: {
-                disposition: "INLINE",
-                format: "ARROW_STREAM",
-              },
-              type: "result",
-            }
-          : {
-              type: "result",
-            };
-
     const hashedQuery = this.queryProcessor.hashQuery(query);
 
     const defaultConfig: PluginExecuteConfig = {
@@ -201,18 +181,113 @@ export class AnalyticsPlugin extends Plugin {
           parameters,
         );
 
-        const result = await executor.query(
+        return this._executeWithFormatFallback(
+          executor,
           query,
           processedParams,
-          queryParameters.formatParameters,
+          format,
           signal,
         );
-
-        return { type: queryParameters.type, ...result };
       },
       streamExecutionSettings,
       executorKey,
     );
+  }
+
+  /** Format configurations in fallback order. */
+  private static readonly FORMAT_CONFIGS = {
+    ARROW_STREAM: {
+      formatParameters: { disposition: "INLINE", format: "ARROW_STREAM" },
+      type: "result" as const,
+    },
+    JSON: {
+      formatParameters: undefined,
+      type: "result" as const,
+    },
+    ARROW: {
+      formatParameters: {
+        disposition: "EXTERNAL_LINKS",
+        format: "ARROW_STREAM",
+      },
+      type: "arrow" as const,
+    },
+  };
+
+  /**
+   * Execute a query with automatic format fallback.
+   *
+   * For the default ARROW_STREAM format, tries formats in order until one
+   * succeeds: ARROW_STREAM → JSON → ARROW. This handles warehouses that
+   * only support a subset of format/disposition combinations.
+   *
+   * Explicit format requests (JSON, ARROW) are not retried.
+   */
+  private async _executeWithFormatFallback(
+    executor: AnalyticsPlugin,
+    query: string,
+    processedParams:
+      | Record<string, SQLTypeMarker | null | undefined>
+      | undefined,
+    requestedFormat: AnalyticsFormat,
+    signal?: AbortSignal,
+  ): Promise<{ type: string; [key: string]: any }> {
+    // Explicit format — no fallback.
+    if (requestedFormat === "JSON" || requestedFormat === "ARROW") {
+      const config = AnalyticsPlugin.FORMAT_CONFIGS[requestedFormat];
+      const result = await executor.query(
+        query,
+        processedParams,
+        config.formatParameters,
+        signal,
+      );
+      return { type: config.type, ...result };
+    }
+
+    // Default (ARROW_STREAM) — try each format in order.
+    const fallbackOrder: AnalyticsFormat[] = ["ARROW_STREAM", "JSON", "ARROW"];
+
+    for (let i = 0; i < fallbackOrder.length; i++) {
+      const fmt = fallbackOrder[i];
+      const config = AnalyticsPlugin.FORMAT_CONFIGS[fmt];
+      try {
+        const result = await executor.query(
+          query,
+          processedParams,
+          config.formatParameters,
+          signal,
+        );
+        if (i > 0) {
+          logger.info(
+            "Query succeeded with fallback format %s (preferred %s was rejected)",
+            fmt,
+            fallbackOrder[0],
+          );
+        }
+        return { type: config.type, ...result };
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        const isFormatError =
+          msg.includes("ARROW_STREAM") ||
+          msg.includes("JSON_ARRAY") ||
+          msg.includes("EXTERNAL_LINKS") ||
+          msg.includes("INVALID_PARAMETER_VALUE") ||
+          msg.includes("NOT_IMPLEMENTED");
+
+        if (!isFormatError || i === fallbackOrder.length - 1) {
+          throw err;
+        }
+
+        logger.warn(
+          "Format %s rejected by warehouse, falling back to %s: %s",
+          fmt,
+          fallbackOrder[i + 1],
+          msg,
+        );
+      }
+    }
+
+    // Unreachable — last format in fallbackOrder throws on failure.
+    throw new Error("All format fallbacks exhausted");
   }
 
   /**

--- a/packages/appkit/src/plugins/analytics/analytics.ts
+++ b/packages/appkit/src/plugins/analytics/analytics.ts
@@ -115,7 +115,8 @@ export class AnalyticsPlugin extends Plugin {
     res: express.Response,
   ): Promise<void> {
     const { query_key } = req.params;
-    const { parameters, format = "JSON" } = req.body as IAnalyticsQueryRequest;
+    const { parameters, format = "ARROW_STREAM" } =
+      req.body as IAnalyticsQueryRequest;
 
     // Request-scoped logging with WideEvent tracking
     logger.debug(req, "Executing query: %s (format=%s)", query_key, format);

--- a/packages/appkit/src/plugins/analytics/tests/analytics.test.ts
+++ b/packages/appkit/src/plugins/analytics/tests/analytics.test.ts
@@ -718,9 +718,10 @@ describe("Analytics Plugin", () => {
 
       await handler(mockReq, mockRes);
 
-      const callArgs = executeMock.mock.calls[0][1];
-      expect(callArgs).not.toHaveProperty("disposition");
-      expect(callArgs).not.toHaveProperty("format");
+      expect(executeMock.mock.calls[0][1]).toMatchObject({
+        disposition: "INLINE",
+        format: "JSON_ARRAY",
+      });
     });
 
     test("/query/:query_key should fall back from ARROW_STREAM to JSON when warehouse rejects ARROW_STREAM", async () => {
@@ -760,10 +761,11 @@ describe("Analytics Plugin", () => {
         disposition: "INLINE",
         format: "ARROW_STREAM",
       });
-      // Second call: JSON (no format params, uses defaults)
-      const secondCallArgs = executeMock.mock.calls[1][1];
-      expect(secondCallArgs).not.toHaveProperty("disposition");
-      expect(secondCallArgs).not.toHaveProperty("format");
+      // Second call: JSON (explicit JSON_ARRAY + INLINE)
+      expect(executeMock.mock.calls[1][1]).toMatchObject({
+        disposition: "INLINE",
+        format: "JSON_ARRAY",
+      });
     });
 
     test("/query/:query_key should fall back through all formats when each is rejected", async () => {
@@ -869,10 +871,12 @@ describe("Analytics Plugin", () => {
 
       await handler(mockReq, mockRes);
 
-      // All calls have no disposition/format — explicit JSON uses defaults, no fallback.
+      // All calls use JSON_ARRAY + INLINE — explicit JSON, no fallback.
       for (const call of executeMock.mock.calls) {
-        expect(call[1]).not.toHaveProperty("disposition");
-        expect(call[1]).not.toHaveProperty("format");
+        expect(call[1]).toMatchObject({
+          disposition: "INLINE",
+          format: "JSON_ARRAY",
+        });
       }
     });
 

--- a/packages/appkit/src/plugins/analytics/tests/analytics.test.ts
+++ b/packages/appkit/src/plugins/analytics/tests/analytics.test.ts
@@ -584,6 +584,110 @@ describe("Analytics Plugin", () => {
       );
     });
 
+    test("/query/:query_key should pass INLINE + ARROW_STREAM format parameters when format is ARROW_STREAM", async () => {
+      const plugin = new AnalyticsPlugin(config);
+      const { router, getHandler } = createMockRouter();
+
+      (plugin as any).app.getAppQuery = vi.fn().mockResolvedValue({
+        query: "SELECT * FROM test",
+        isAsUser: false,
+      });
+
+      const executeMock = vi.fn().mockResolvedValue({
+        result: { data: [{ id: 1 }] },
+      });
+      (plugin as any).SQLClient.executeStatement = executeMock;
+
+      plugin.injectRoutes(router);
+
+      const handler = getHandler("POST", "/query/:query_key");
+      const mockReq = createMockRequest({
+        params: { query_key: "test_query" },
+        body: { parameters: {}, format: "ARROW_STREAM" },
+      });
+      const mockRes = createMockResponse();
+
+      await handler(mockReq, mockRes);
+
+      expect(executeMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          statement: "SELECT * FROM test",
+          warehouse_id: "test-warehouse-id",
+          disposition: "INLINE",
+          format: "ARROW_STREAM",
+        }),
+        expect.any(AbortSignal),
+      );
+    });
+
+    test("/query/:query_key should pass EXTERNAL_LINKS + ARROW_STREAM format parameters when format is ARROW", async () => {
+      const plugin = new AnalyticsPlugin(config);
+      const { router, getHandler } = createMockRouter();
+
+      (plugin as any).app.getAppQuery = vi.fn().mockResolvedValue({
+        query: "SELECT * FROM test",
+        isAsUser: false,
+      });
+
+      const executeMock = vi.fn().mockResolvedValue({
+        result: { data: [{ id: 1 }] },
+      });
+      (plugin as any).SQLClient.executeStatement = executeMock;
+
+      plugin.injectRoutes(router);
+
+      const handler = getHandler("POST", "/query/:query_key");
+      const mockReq = createMockRequest({
+        params: { query_key: "test_query" },
+        body: { parameters: {}, format: "ARROW" },
+      });
+      const mockRes = createMockResponse();
+
+      await handler(mockReq, mockRes);
+
+      expect(executeMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          statement: "SELECT * FROM test",
+          warehouse_id: "test-warehouse-id",
+          disposition: "EXTERNAL_LINKS",
+          format: "ARROW_STREAM",
+        }),
+        expect.any(AbortSignal),
+      );
+    });
+
+    test("/query/:query_key should not pass format parameters when format is JSON (default)", async () => {
+      const plugin = new AnalyticsPlugin(config);
+      const { router, getHandler } = createMockRouter();
+
+      (plugin as any).app.getAppQuery = vi.fn().mockResolvedValue({
+        query: "SELECT * FROM test",
+        isAsUser: false,
+      });
+
+      const executeMock = vi.fn().mockResolvedValue({
+        result: { data: [{ id: 1 }] },
+      });
+      (plugin as any).SQLClient.executeStatement = executeMock;
+
+      plugin.injectRoutes(router);
+
+      const handler = getHandler("POST", "/query/:query_key");
+      const mockReq = createMockRequest({
+        params: { query_key: "test_query" },
+        body: { parameters: {} },
+      });
+      const mockRes = createMockResponse();
+
+      await handler(mockReq, mockRes);
+
+      const callArgs = executeMock.mock.calls[0][1];
+      expect(callArgs).not.toHaveProperty("disposition");
+      expect(callArgs).not.toHaveProperty("format");
+    });
+
     test("should return 404 when query file is not found", async () => {
       const plugin = new AnalyticsPlugin(config);
       const { router, getHandler } = createMockRouter();

--- a/packages/appkit/src/plugins/analytics/tests/analytics.test.ts
+++ b/packages/appkit/src/plugins/analytics/tests/analytics.test.ts
@@ -658,7 +658,7 @@ describe("Analytics Plugin", () => {
       );
     });
 
-    test("/query/:query_key should not pass format parameters when format is JSON (default)", async () => {
+    test("/query/:query_key should use INLINE + ARROW_STREAM by default when no format specified", async () => {
       const plugin = new AnalyticsPlugin(config);
       const { router, getHandler } = createMockRouter();
 
@@ -678,6 +678,41 @@ describe("Analytics Plugin", () => {
       const mockReq = createMockRequest({
         params: { query_key: "test_query" },
         body: { parameters: {} },
+      });
+      const mockRes = createMockResponse();
+
+      await handler(mockReq, mockRes);
+
+      expect(executeMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          disposition: "INLINE",
+          format: "ARROW_STREAM",
+        }),
+        expect.any(AbortSignal),
+      );
+    });
+
+    test("/query/:query_key should not pass format parameters when format is explicitly JSON", async () => {
+      const plugin = new AnalyticsPlugin(config);
+      const { router, getHandler } = createMockRouter();
+
+      (plugin as any).app.getAppQuery = vi.fn().mockResolvedValue({
+        query: "SELECT * FROM test",
+        isAsUser: false,
+      });
+
+      const executeMock = vi.fn().mockResolvedValue({
+        result: { data: [{ id: 1 }] },
+      });
+      (plugin as any).SQLClient.executeStatement = executeMock;
+
+      plugin.injectRoutes(router);
+
+      const handler = getHandler("POST", "/query/:query_key");
+      const mockReq = createMockRequest({
+        params: { query_key: "test_query" },
+        body: { parameters: {}, format: "JSON" },
       });
       const mockRes = createMockResponse();
 

--- a/packages/appkit/src/plugins/analytics/tests/analytics.test.ts
+++ b/packages/appkit/src/plugins/analytics/tests/analytics.test.ts
@@ -723,6 +723,159 @@ describe("Analytics Plugin", () => {
       expect(callArgs).not.toHaveProperty("format");
     });
 
+    test("/query/:query_key should fall back from ARROW_STREAM to JSON when warehouse rejects ARROW_STREAM", async () => {
+      const plugin = new AnalyticsPlugin(config);
+      const { router, getHandler } = createMockRouter();
+
+      (plugin as any).app.getAppQuery = vi.fn().mockResolvedValue({
+        query: "SELECT * FROM test",
+        isAsUser: false,
+      });
+
+      const executeMock = vi
+        .fn()
+        .mockRejectedValueOnce(
+          new Error(
+            "INVALID_PARAMETER_VALUE: Inline disposition only supports JSON_ARRAY format",
+          ),
+        )
+        .mockResolvedValueOnce({
+          result: { data: [{ id: 1 }] },
+        });
+      (plugin as any).SQLClient.executeStatement = executeMock;
+
+      plugin.injectRoutes(router);
+
+      const handler = getHandler("POST", "/query/:query_key");
+      const mockReq = createMockRequest({
+        params: { query_key: "test_query" },
+        body: { parameters: {} },
+      });
+      const mockRes = createMockResponse();
+
+      await handler(mockReq, mockRes);
+
+      // First call: ARROW_STREAM (rejected)
+      expect(executeMock.mock.calls[0][1]).toMatchObject({
+        disposition: "INLINE",
+        format: "ARROW_STREAM",
+      });
+      // Second call: JSON (no format params, uses defaults)
+      const secondCallArgs = executeMock.mock.calls[1][1];
+      expect(secondCallArgs).not.toHaveProperty("disposition");
+      expect(secondCallArgs).not.toHaveProperty("format");
+    });
+
+    test("/query/:query_key should fall back through all formats when each is rejected", async () => {
+      const plugin = new AnalyticsPlugin(config);
+      const { router, getHandler } = createMockRouter();
+
+      (plugin as any).app.getAppQuery = vi.fn().mockResolvedValue({
+        query: "SELECT * FROM test",
+        isAsUser: false,
+      });
+
+      const executeMock = vi
+        .fn()
+        .mockRejectedValueOnce(
+          new Error("INVALID_PARAMETER_VALUE: only supports JSON_ARRAY"),
+        )
+        .mockRejectedValueOnce(
+          new Error("INVALID_PARAMETER_VALUE: only supports ARROW_STREAM"),
+        )
+        .mockResolvedValueOnce({
+          result: { data: [{ id: 1 }] },
+        });
+      (plugin as any).SQLClient.executeStatement = executeMock;
+
+      plugin.injectRoutes(router);
+
+      const handler = getHandler("POST", "/query/:query_key");
+      const mockReq = createMockRequest({
+        params: { query_key: "test_query" },
+        body: { parameters: {} },
+      });
+      const mockRes = createMockResponse();
+
+      await handler(mockReq, mockRes);
+
+      expect(executeMock).toHaveBeenCalledTimes(3);
+      // Third call: ARROW (EXTERNAL_LINKS)
+      expect(executeMock.mock.calls[2][1]).toMatchObject({
+        disposition: "EXTERNAL_LINKS",
+        format: "ARROW_STREAM",
+      });
+    });
+
+    test("/query/:query_key should not fall back for non-format errors", async () => {
+      const plugin = new AnalyticsPlugin(config);
+      const { router, getHandler } = createMockRouter();
+
+      (plugin as any).app.getAppQuery = vi.fn().mockResolvedValue({
+        query: "SELECT * FROM test",
+        isAsUser: false,
+      });
+
+      const executeMock = vi
+        .fn()
+        .mockRejectedValue(new Error("PERMISSION_DENIED: no access"));
+      (plugin as any).SQLClient.executeStatement = executeMock;
+
+      plugin.injectRoutes(router);
+
+      const handler = getHandler("POST", "/query/:query_key");
+      const mockReq = createMockRequest({
+        params: { query_key: "test_query" },
+        body: { parameters: {} },
+      });
+      const mockRes = createMockResponse();
+
+      await handler(mockReq, mockRes);
+
+      // All calls use same format (ARROW_STREAM) — no format fallback occurred.
+      // (executeStream's retry interceptor may retry, but always with the same format.)
+      for (const call of executeMock.mock.calls) {
+        expect(call[1]).toMatchObject({
+          disposition: "INLINE",
+          format: "ARROW_STREAM",
+        });
+      }
+    });
+
+    test("/query/:query_key should not fall back when format is explicitly JSON", async () => {
+      const plugin = new AnalyticsPlugin(config);
+      const { router, getHandler } = createMockRouter();
+
+      (plugin as any).app.getAppQuery = vi.fn().mockResolvedValue({
+        query: "SELECT * FROM test",
+        isAsUser: false,
+      });
+
+      const executeMock = vi
+        .fn()
+        .mockRejectedValue(
+          new Error("INVALID_PARAMETER_VALUE: only supports ARROW_STREAM"),
+        );
+      (plugin as any).SQLClient.executeStatement = executeMock;
+
+      plugin.injectRoutes(router);
+
+      const handler = getHandler("POST", "/query/:query_key");
+      const mockReq = createMockRequest({
+        params: { query_key: "test_query" },
+        body: { parameters: {}, format: "JSON" },
+      });
+      const mockRes = createMockResponse();
+
+      await handler(mockReq, mockRes);
+
+      // All calls have no disposition/format — explicit JSON uses defaults, no fallback.
+      for (const call of executeMock.mock.calls) {
+        expect(call[1]).not.toHaveProperty("disposition");
+        expect(call[1]).not.toHaveProperty("format");
+      }
+    });
+
     test("should return 404 when query file is not found", async () => {
       const plugin = new AnalyticsPlugin(config);
       const { router, getHandler } = createMockRouter();

--- a/packages/appkit/src/plugins/analytics/types.ts
+++ b/packages/appkit/src/plugins/analytics/types.ts
@@ -4,7 +4,7 @@ export interface IAnalyticsConfig extends BasePluginConfig {
   timeout?: number;
 }
 
-export type AnalyticsFormat = "JSON" | "ARROW";
+export type AnalyticsFormat = "JSON" | "ARROW" | "ARROW_STREAM";
 export interface IAnalyticsQueryRequest {
   parameters?: Record<string, any>;
   format?: AnalyticsFormat;

--- a/packages/appkit/src/type-generator/query-registry.ts
+++ b/packages/appkit/src/type-generator/query-registry.ts
@@ -386,10 +386,32 @@ export async function generateQueriesFromDescribe(
       sqlHash,
       cleanedSql,
     }: (typeof uncachedQueries)[number]): Promise<DescribeResult> => {
-      const result = (await client.statementExecution.executeStatement({
-        statement: `DESCRIBE QUERY ${cleanedSql}`,
-        warehouse_id: warehouseId,
-      })) as DatabricksStatementExecutionResponse;
+      let result: DatabricksStatementExecutionResponse;
+      try {
+        // Prefer JSON_ARRAY for predictable data_array parsing.
+        result = (await client.statementExecution.executeStatement({
+          statement: `DESCRIBE QUERY ${cleanedSql}`,
+          warehouse_id: warehouseId,
+          format: "JSON_ARRAY",
+          disposition: "INLINE",
+        })) as DatabricksStatementExecutionResponse;
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes("ARROW_STREAM") || msg.includes("JSON_ARRAY")) {
+          // Warehouse doesn't support JSON_ARRAY inline — retry with no format
+          // to let it use its default (typically ARROW_STREAM inline).
+          logger.debug(
+            "Warehouse rejected JSON_ARRAY for %s, retrying with default format",
+            queryName,
+          );
+          result = (await client.statementExecution.executeStatement({
+            statement: `DESCRIBE QUERY ${cleanedSql}`,
+            warehouse_id: warehouseId,
+          })) as DatabricksStatementExecutionResponse;
+        } else {
+          throw err;
+        }
+      }
 
       completed++;
       spinner.update(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,6 +299,9 @@ importers:
       '@types/semver':
         specifier: 7.7.1
         version: 7.7.1
+      apache-arrow:
+        specifier: 21.1.0
+        version: 21.1.0
       dotenv:
         specifier: 16.6.1
         version: 16.6.1
@@ -5539,7 +5542,7 @@ packages:
   basic-ftp@5.0.5:
     resolution: {integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==}
     engines: {node: '>=10.0.0'}
-    deprecated: Security vulnerability fixed in 5.2.0, please upgrade
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   batch@0.6.1:
     resolution: {integrity: sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==}
@@ -6653,6 +6656,7 @@ packages:
 
   dottie@2.0.6:
     resolution: {integrity: sha512-iGCHkfUc5kFekGiqhe8B/mdaurD+lakO9txNnTvKtA6PISrw86LgqHvRzWYPyoE2Ph5aMIrCw9/uko6XHTKCwA==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   drizzle-orm@0.45.1:
     resolution: {integrity: sha512-Te0FOdKIistGNPMq2jscdqngBRfBpC8uMFVwqjf6gtTVJHIQ/dosgV/CLBU2N4ZJBsXL5savCba9b0YJskKdcA==}


### PR DESCRIPTION
## Summary

Adds support for serverless SQL warehouses that return inline Arrow IPC data in `result.attachment` instead of `data_array`, plus automatic format fallback for warehouse compatibility.

- **Inline Arrow IPC decoding**: `_transformArrowAttachment` decodes base64 Arrow IPC from `result.attachment` into row objects via `tableFromIPC`
- **Format fallback**: When default ARROW_STREAM is rejected, automatically falls back through JSON → ARROW (matching warehouse capabilities)
- **586 lines of new tests**: connector tests for Arrow IPC attachment handling + analytics plugin format fallback tests

### Changes
- `packages/appkit/src/connectors/sql-warehouse/client.ts` — Arrow IPC attachment detection and decoding
- `packages/appkit/src/plugins/analytics/analytics.ts` — `_executeWithFormatFallback` with ARROW_STREAM → JSON → ARROW chain
- `packages/appkit-ui/src/react/hooks/types.ts` — ARROW_STREAM format type support
- `packages/appkit/src/type-generator/query-registry.ts` — typegen compatibility

## Test plan
- [x] 1566 TS tests pass (`pnpm test`)
- [x] New connector tests cover inline attachment decoding, external links, format fallback
- [x] New analytics tests cover format parameter handling and fallback chain
- [ ] Manual test against serverless warehouse returning Arrow IPC

## Related
- Parent of #274 (Python backend)
- Related: #270 (BigInt serialization), #271 (type generator Arrow)

This pull request was AI-assisted by Isaac.