### PR TITLE
feat: add execution context attributes to telemetry spans

### DIFF
--- a/docs/docs/plugins/custom-plugins.md
+++ b/docs/docs/plugins/custom-plugins.md
@@ -130,7 +130,7 @@ This pattern allows:
 - **Shared services**:
   - **Cache management**: Access the cache service via `this.cache`. See [`CacheConfig`](../api/appkit/Interface.CacheConfig.md) for configuration.
   - **Telemetry**: Instrument your plugin with traces and metrics via `this.telemetry`. See [`ITelemetry`](../api/appkit/Interface.ITelemetry.md).
-- **Execution interceptors**: Use `execute()` and `executeStream()` with [`StreamExecutionSettings`](../api/appkit/Interface.StreamExecutionSettings.md)
+- **Execution interceptors**: Use `execute()` and `executeStream()` with [`StreamExecutionSettings`](../api/appkit/Interface.StreamExecutionSettings.md) for automatic caching, retry, timeout, and [telemetry span attributes](./execution-context.md#telemetry-span-attributes) (`execution.context`, `caller.id`)
 
 **Consuming your plugin programmatically**
 

--- a/docs/docs/plugins/execution-context.md
+++ b/docs/docs/plugins/execution-context.md
@@ -52,6 +52,8 @@ The `plugin.execute` span created by the execution interceptor chain includes th
 | `caller.id` | `string` | The user ID (OBO) or service principal ID |
 | `execution.obo_dev_fallback` | `boolean` | Set to `true` when an OBO call falls back to service principal in development mode |
 
+These attributes are automatically added when your plugin uses `execute()` or `executeStream()`. All built-in plugins use these methods for their OBO operations. Custom plugins should do the same to get automatic telemetry instrumentation.
+
 ## Development mode behavior
 
 In local development (`NODE_ENV=development`), if `asUser(req)` is called without a user token, it logs a warning and skips user impersonation — the operation runs with the default credentials configured for the app instead. The telemetry span will show `execution.context: "service"` with `execution.obo_dev_fallback: true` to distinguish these from regular service principal calls.

--- a/docs/docs/plugins/execution-context.md
+++ b/docs/docs/plugins/execution-context.md
@@ -42,6 +42,16 @@ Exported from `@databricks/appkit`:
 - `getWarehouseId()`: `Promise<string>` (from `DATABRICKS_WAREHOUSE_ID` or auto-selected in dev)
 - `getWorkspaceId()`: `Promise<string>` (from `DATABRICKS_WORKSPACE_ID` or fetched)
 
+## Telemetry span attributes
+
+The `plugin.execute` span created by the execution interceptor chain includes these attributes:
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `execution.context` | `"user"` \| `"service"` | Whether the operation runs as a user (OBO) or service principal |
+| `caller.id` | `string` | The user ID (OBO) or service principal ID |
+| `execution.obo_dev_fallback` | `boolean` | Set to `true` when an OBO call falls back to service principal in development mode |
+
 ## Development mode behavior
 
-In local development (`NODE_ENV=development`), if `asUser(req)` is called without a user token, it logs a warning and skips user impersonation — the operation runs with the default credentials configured for the app instead.
+In local development (`NODE_ENV=development`), if `asUser(req)` is called without a user token, it logs a warning and skips user impersonation — the operation runs with the default credentials configured for the app instead. The telemetry span will show `execution.context: "service"` with `execution.obo_dev_fallback: true` to distinguish these from regular service principal calls.

--- a/packages/appkit/package.json
+++ b/packages/appkit/package.json
@@ -81,6 +81,7 @@
     "zod": "4.3.6"
   },
   "devDependencies": {
+    "@opentelemetry/context-async-hooks": "2.6.1",
     "@types/express": "4.17.25",
     "@types/json-schema": "7.0.15",
     "@types/pg": "8.16.0",

--- a/packages/appkit/src/context/execution-context.ts
+++ b/packages/appkit/src/context/execution-context.ts
@@ -81,3 +81,11 @@ export function getWarehouseId(): Promise<string> {
 export function getWorkspaceId(): Promise<string> {
   return getExecutionContext().workspaceId;
 }
+
+/**
+ * Check if currently running in a user context.
+ */
+export function isInUserContext(): boolean {
+  const ctx = executionContextStorage.getStore();
+  return ctx !== undefined;
+}

--- a/packages/appkit/src/plugin/interceptors/telemetry.ts
+++ b/packages/appkit/src/plugin/interceptors/telemetry.ts
@@ -1,4 +1,5 @@
 import type { TelemetryConfig } from "shared";
+import { isInUserContext } from "../../context/execution-context";
 import type { ITelemetry, Span } from "../../telemetry";
 import { SpanStatusCode } from "../../telemetry";
 import type { ExecutionInterceptor, InterceptorContext } from "./types";
@@ -24,6 +25,12 @@ export class TelemetryInterceptor implements ExecutionInterceptor {
       spanName,
       { attributes: this.config?.attributes },
       async (span: Span) => {
+        span.setAttribute(
+          "execution.context",
+          isInUserContext() ? "user" : "service",
+        );
+        span.setAttribute("caller.id", context.userKey);
+
         let abortHandler: (() => void) | undefined;
         let isAborted = false;
 

--- a/packages/appkit/src/plugin/interceptors/telemetry.ts
+++ b/packages/appkit/src/plugin/interceptors/telemetry.ts
@@ -1,5 +1,8 @@
 import type { TelemetryConfig } from "shared";
-import { isInUserContext } from "../../context/execution-context";
+import {
+  getCurrentUserId,
+  isInUserContext,
+} from "../../context/execution-context";
 import type { ITelemetry, Span } from "../../telemetry";
 import { SpanStatusCode } from "../../telemetry";
 import { isDevOboFallback } from "../plugin";
@@ -30,7 +33,7 @@ export class TelemetryInterceptor implements ExecutionInterceptor {
           "execution.context",
           isInUserContext() ? "user" : "service",
         );
-        span.setAttribute("caller.id", context.userKey);
+        span.setAttribute("caller.id", getCurrentUserId());
         if (isDevOboFallback()) {
           span.setAttribute("execution.obo_dev_fallback", true);
         }

--- a/packages/appkit/src/plugin/interceptors/telemetry.ts
+++ b/packages/appkit/src/plugin/interceptors/telemetry.ts
@@ -2,6 +2,7 @@ import type { TelemetryConfig } from "shared";
 import { isInUserContext } from "../../context/execution-context";
 import type { ITelemetry, Span } from "../../telemetry";
 import { SpanStatusCode } from "../../telemetry";
+import { isDevOboFallback } from "../plugin";
 import type { ExecutionInterceptor, InterceptorContext } from "./types";
 
 export class TelemetryInterceptor implements ExecutionInterceptor {
@@ -30,6 +31,9 @@ export class TelemetryInterceptor implements ExecutionInterceptor {
           isInUserContext() ? "user" : "service",
         );
         span.setAttribute("caller.id", context.userKey);
+        if (isDevOboFallback()) {
+          span.setAttribute("execution.obo_dev_fallback", true);
+        }
 
         let abortHandler: (() => void) | undefined;
         let isAborted = false;

--- a/packages/appkit/src/plugin/interceptors/telemetry.ts
+++ b/packages/appkit/src/plugin/interceptors/telemetry.ts
@@ -29,15 +29,6 @@ export class TelemetryInterceptor implements ExecutionInterceptor {
       spanName,
       { attributes: this.config?.attributes },
       async (span: Span) => {
-        span.setAttribute(
-          "execution.context",
-          isInUserContext() ? "user" : "service",
-        );
-        span.setAttribute("caller.id", getCurrentUserId());
-        if (isDevOboFallback()) {
-          span.setAttribute("execution.obo_dev_fallback", true);
-        }
-
         let abortHandler: (() => void) | undefined;
         let isAborted = false;
 
@@ -59,6 +50,15 @@ export class TelemetryInterceptor implements ExecutionInterceptor {
         }
 
         try {
+          span.setAttribute(
+            "execution.context",
+            isInUserContext() ? "user" : "service",
+          );
+          span.setAttribute("caller.id", getCurrentUserId());
+          if (isDevOboFallback()) {
+            span.setAttribute("execution.obo_dev_fallback", true);
+          }
+
           const result = await fn();
           if (!isAborted) {
             span.setStatus({ code: SpanStatusCode.OK });

--- a/packages/appkit/src/plugin/plugin.ts
+++ b/packages/appkit/src/plugin/plugin.ts
@@ -1,4 +1,4 @@
-import { context as otelContext } from "@opentelemetry/api";
+import { createContextKey, context as otelContext } from "@opentelemetry/api";
 import type express from "express";
 import type {
   BasePlugin,
@@ -41,6 +41,20 @@ import type {
 } from "./interceptors/types";
 
 const logger = createLogger("plugin");
+
+/**
+ * OTel context key for marking OBO dev mode fallback.
+ * Set when asUser() is called in development mode without a user token.
+ */
+const DEV_OBO_FALLBACK_KEY = createContextKey("appkit.devOboFallback");
+
+/**
+ * Returns true if the current execution is an OBO dev mode fallback
+ * (asUser() was called but fell back to service principal due to missing token).
+ */
+export function isDevOboFallback(): boolean {
+  return otelContext.active().getValue(DEV_OBO_FALLBACK_KEY) === true;
+}
 
 /**
  * Narrow an unknown thrown value to an Error that carries a numeric
@@ -339,7 +353,23 @@ export abstract class Plugin<
         "asUser() called without user token in development mode. Skipping user impersonation.",
       );
 
-      return this;
+      // Return a proxy that marks execution as OBO dev fallback via OTel context,
+      // so telemetry spans can distinguish intended OBO calls from regular SP calls
+      return new Proxy(this, {
+        get: (target, prop, receiver) => {
+          const value = Reflect.get(target, prop, receiver);
+          if (typeof value !== "function") return value;
+          if (typeof prop === "string" && EXCLUDED_FROM_PROXY.has(prop))
+            return value;
+
+          return (...args: unknown[]) => {
+            const ctx = otelContext
+              .active()
+              .setValue(DEV_OBO_FALLBACK_KEY, true);
+            return otelContext.with(ctx, () => value.apply(target, args));
+          };
+        },
+      }) as this;
     }
 
     if (!token) {

--- a/packages/appkit/src/plugin/plugin.ts
+++ b/packages/appkit/src/plugin/plugin.ts
@@ -1,3 +1,4 @@
+import { context as otelContext } from "@opentelemetry/api";
 import type express from "express";
 import type {
   BasePlugin,
@@ -409,6 +410,9 @@ export abstract class Plugin<
     const effectiveUserKey = userKey ?? getCurrentUserId();
 
     const self = this;
+    // capture the active OTel context (HTTP span) before entering the async generator,
+    // where it would otherwise be lost across the async boundary
+    const parentOtelContext = otelContext.active();
 
     // wrapper function to ensure it returns a generator
     const asyncWrapperFn = async function* (streamSignal?: AbortSignal) {
@@ -428,11 +432,14 @@ export abstract class Plugin<
         return result;
       };
 
-      // execute the function with interceptors
-      const result = await self._executeWithInterceptors(
-        wrappedFn as (signal?: AbortSignal) => Promise<T>,
-        interceptors,
-        context,
+      // execute the function with interceptors, restoring the parent OTel context
+      // so telemetry spans are linked as children of the HTTP request span
+      const result = await otelContext.with(parentOtelContext, () =>
+        self._executeWithInterceptors(
+          wrappedFn as (signal?: AbortSignal) => Promise<T>,
+          interceptors,
+          context,
+        ),
       );
 
       // check if result is a generator

--- a/packages/appkit/src/plugin/tests/plugin.test.ts
+++ b/packages/appkit/src/plugin/tests/plugin.test.ts
@@ -1,3 +1,9 @@
+import {
+  type ContextManager,
+  createContextKey,
+  context as otelContext,
+} from "@opentelemetry/api";
+import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
 import { createMockTelemetry, mockServiceContext } from "@tools/test-helpers";
 import type express from "express";
 import type {
@@ -5,7 +11,16 @@ import type {
   IAppResponse,
   PluginExecuteConfig,
 } from "shared";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
 import { AppManager } from "../../app";
 import { CacheManager } from "../../cache";
 import { ServiceContext } from "../../context/service-context";
@@ -20,7 +35,7 @@ import { StreamManager } from "../../stream";
 import type { ITelemetry, TelemetryProvider } from "../../telemetry";
 import { TelemetryManager } from "../../telemetry";
 import type { InterceptorContext } from "../interceptors/types";
-import { Plugin } from "../plugin";
+import { isDevOboFallback, Plugin } from "../plugin";
 
 const { MockApiError } = vi.hoisted(() => {
   class MockApiError extends Error {
@@ -145,6 +160,20 @@ class PluginWithRoutes extends TestPlugin {
   injectRoutes(_router: express.Router) {
     this.routesInjected = true;
     // Mock route injection
+  }
+}
+
+class OboTestPlugin extends Plugin<BasePluginConfig> {
+  lastOboFallbackValue: boolean | undefined;
+
+  async captureOboFallback(): Promise<string> {
+    this.lastOboFallbackValue = isDevOboFallback();
+    return "captured";
+  }
+
+  syncCapture(): string {
+    this.lastOboFallbackValue = isDevOboFallback();
+    return "sync-captured";
   }
 }
 
@@ -914,6 +943,166 @@ describe("Plugin", () => {
       });
 
       expect(result).toEqual({ ok: true, data: "integration-result" });
+    });
+  });
+
+  describe("asUser() dev fallback", () => {
+    let originalNodeEnv: string | undefined;
+    let contextManager: ContextManager;
+
+    beforeAll(() => {
+      otelContext.disable();
+      contextManager = new AsyncLocalStorageContextManager().enable();
+      otelContext.setGlobalContextManager(contextManager);
+    });
+
+    afterAll(() => {
+      otelContext.disable();
+    });
+
+    beforeEach(() => {
+      originalNodeEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = "development";
+      vi.useRealTimers();
+    });
+
+    afterEach(() => {
+      process.env.NODE_ENV = originalNodeEnv;
+    });
+
+    function createMockReqWithoutToken(): express.Request {
+      return {
+        header: vi.fn().mockReturnValue(undefined),
+      } as unknown as express.Request;
+    }
+
+    test("should return a Proxy (different reference) in dev mode without token", () => {
+      const plugin = new TestPlugin(config);
+      const proxied = plugin.asUser(createMockReqWithoutToken());
+
+      expect(proxied).not.toBe(plugin);
+      expect(proxied).toBeInstanceOf(TestPlugin);
+    });
+
+    test("should pass through non-function properties unchanged", () => {
+      const plugin = new TestPlugin(config);
+      const proxied = plugin.asUser(createMockReqWithoutToken());
+
+      expect(proxied.name).toBe(plugin.name);
+    });
+
+    test("should preserve return values from proxied async methods", async () => {
+      const plugin = new TestPlugin(config);
+      const proxied = plugin.asUser(createMockReqWithoutToken());
+
+      const result = await proxied.customMethod("value");
+      expect(result).toBe("processed-value");
+    });
+
+    test("should preserve return values from proxied sync methods", () => {
+      const plugin = new TestPlugin(config);
+      const proxied = plugin.asUser(createMockReqWithoutToken());
+
+      const result = proxied.syncMethod("value");
+      expect(result).toBe("sync-value");
+    });
+
+    test("should set isDevOboFallback() to true inside proxied method", async () => {
+      const plugin = new OboTestPlugin(config);
+      const proxied = plugin.asUser(createMockReqWithoutToken());
+
+      await proxied.captureOboFallback();
+
+      expect(plugin.lastOboFallbackValue).toBe(true);
+    });
+
+    test("should set isDevOboFallback() to true inside proxied sync method", () => {
+      const plugin = new OboTestPlugin(config);
+      const proxied = plugin.asUser(createMockReqWithoutToken());
+
+      proxied.syncCapture();
+
+      expect(plugin.lastOboFallbackValue).toBe(true);
+    });
+
+    test("should not set OBO fallback for excluded methods (setup)", async () => {
+      const plugin = new OboTestPlugin(config);
+      // Override setup to capture OBO fallback
+      plugin.setup = async () => {
+        plugin.lastOboFallbackValue = isDevOboFallback();
+      };
+
+      const proxied = plugin.asUser(createMockReqWithoutToken());
+      await proxied.setup();
+
+      expect(plugin.lastOboFallbackValue).toBe(false);
+    });
+
+    test("isDevOboFallback() should return false outside proxy context", () => {
+      expect(isDevOboFallback()).toBe(false);
+    });
+  });
+
+  describe("executeStream OTel context preservation", () => {
+    let contextManager: ContextManager;
+
+    beforeAll(() => {
+      otelContext.disable();
+      contextManager = new AsyncLocalStorageContextManager().enable();
+      otelContext.setGlobalContextManager(contextManager);
+    });
+
+    afterAll(() => {
+      otelContext.disable();
+    });
+
+    beforeEach(() => {
+      vi.useRealTimers();
+    });
+
+    test("should preserve parent OTel context inside async generator", async () => {
+      const plugin = new TestPlugin(config);
+      const mockResponse = {} as IAppResponse;
+
+      const TEST_KEY = createContextKey("test.parent.context");
+      const parentCtx = otelContext.active().setValue(TEST_KEY, "parent-value");
+
+      let capturedContextValue: unknown;
+
+      const mockFn = vi.fn().mockImplementation(async () => {
+        capturedContextValue = otelContext.active().getValue(TEST_KEY);
+        return "stream-result";
+      });
+
+      // Capture the generator function passed to streamManager.stream
+      let capturedGeneratorFn: any;
+      vi.mocked(mockStreamManager.stream).mockImplementation(
+        async (_res, genFn) => {
+          capturedGeneratorFn = genFn;
+        },
+      );
+
+      // Execute within the parent context
+      await otelContext.with(parentCtx, () =>
+        (plugin as any).executeStream(mockResponse, mockFn, {
+          default: {},
+          stream: {},
+        }),
+      );
+
+      // Invoke the captured generator OUTSIDE the parent context scope
+      // The generator should restore parentOtelContext internally
+      const gen = capturedGeneratorFn();
+      await gen.next();
+
+      expect(capturedContextValue).toBe("parent-value");
+    });
+
+    test("should not have parent context without the fix (baseline)", async () => {
+      const TEST_KEY = createContextKey("test.baseline.context");
+
+      // Outside any context, the value should not exist
+      expect(otelContext.active().getValue(TEST_KEY)).toBeUndefined();
     });
   });
 });

--- a/packages/appkit/src/plugins/analytics/analytics.ts
+++ b/packages/appkit/src/plugins/analytics/analytics.ts
@@ -45,7 +45,10 @@ export class AnalyticsPlugin extends Plugin {
   }
 
   injectRoutes(router: IAppRouter) {
-    // Service principal endpoints
+    // Arrow data downloads always run as service principal and bypass the
+    // interceptor chain (execute/executeStream). The original query execution
+    // handles OBO via executeStream(); this endpoint fetches pre-computed
+    // results by job ID.
     this.route(router, {
       name: "arrow",
       method: "get",

--- a/packages/appkit/src/telemetry/tests/telemetry-interceptor.test.ts
+++ b/packages/appkit/src/telemetry/tests/telemetry-interceptor.test.ts
@@ -38,6 +38,8 @@ describe("TelemetryInterceptor", () => {
       metadata: new Map(),
       userKey: "test",
     };
+
+    vi.spyOn(executionContext, "getCurrentUserId").mockReturnValue("test-user");
   });
 
   test("should execute function and set span status to OK on success", async () => {
@@ -136,6 +138,7 @@ describe("TelemetryInterceptor", () => {
 
   test("should set execution context as 'service' when not in user context", async () => {
     vi.spyOn(executionContext, "isInUserContext").mockReturnValue(false);
+    vi.spyOn(executionContext, "getCurrentUserId").mockReturnValue("sp-123");
     const interceptor = new TelemetryInterceptor(mockTelemetry);
     const fn = vi.fn().mockResolvedValue("result");
 
@@ -145,19 +148,16 @@ describe("TelemetryInterceptor", () => {
       "execution.context",
       "service",
     );
-    expect(mockSpan.setAttribute).toHaveBeenCalledWith("caller.id", "test");
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("caller.id", "sp-123");
   });
 
   test("should set execution context as 'user' when in user context", async () => {
     vi.spyOn(executionContext, "isInUserContext").mockReturnValue(true);
+    vi.spyOn(executionContext, "getCurrentUserId").mockReturnValue("user-123");
     const interceptor = new TelemetryInterceptor(mockTelemetry);
     const fn = vi.fn().mockResolvedValue("result");
-    const userContext: InterceptorContext = {
-      metadata: new Map(),
-      userKey: "user-123",
-    };
 
-    await interceptor.intercept(fn, userContext);
+    await interceptor.intercept(fn, context);
 
     expect(mockSpan.setAttribute).toHaveBeenCalledWith(
       "execution.context",

--- a/packages/appkit/src/telemetry/tests/telemetry-interceptor.test.ts
+++ b/packages/appkit/src/telemetry/tests/telemetry-interceptor.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import * as executionContext from "../../context/execution-context";
 import { TelemetryInterceptor } from "../../plugin/interceptors/telemetry";
 import type { InterceptorContext } from "../../plugin/interceptors/types";
+import * as pluginModule from "../../plugin/plugin";
 import type { ITelemetry } from "../types";
 
 describe("TelemetryInterceptor", () => {
@@ -163,5 +164,37 @@ describe("TelemetryInterceptor", () => {
       "user",
     );
     expect(mockSpan.setAttribute).toHaveBeenCalledWith("caller.id", "user-123");
+  });
+
+  test("should set execution.obo_dev_fallback when in dev OBO fallback", async () => {
+    vi.spyOn(executionContext, "isInUserContext").mockReturnValue(false);
+    vi.spyOn(pluginModule, "isDevOboFallback").mockReturnValue(true);
+    const interceptor = new TelemetryInterceptor(mockTelemetry);
+    const fn = vi.fn().mockResolvedValue("result");
+
+    await interceptor.intercept(fn, context);
+
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      "execution.context",
+      "service",
+    );
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      "execution.obo_dev_fallback",
+      true,
+    );
+  });
+
+  test("should not set execution.obo_dev_fallback when not in dev fallback", async () => {
+    vi.spyOn(executionContext, "isInUserContext").mockReturnValue(false);
+    vi.spyOn(pluginModule, "isDevOboFallback").mockReturnValue(false);
+    const interceptor = new TelemetryInterceptor(mockTelemetry);
+    const fn = vi.fn().mockResolvedValue("result");
+
+    await interceptor.intercept(fn, context);
+
+    expect(mockSpan.setAttribute).not.toHaveBeenCalledWith(
+      "execution.obo_dev_fallback",
+      expect.anything(),
+    );
   });
 });

--- a/packages/appkit/src/telemetry/tests/telemetry-interceptor.test.ts
+++ b/packages/appkit/src/telemetry/tests/telemetry-interceptor.test.ts
@@ -1,6 +1,7 @@
 import { type Span, SpanStatusCode } from "@opentelemetry/api";
 import type { TelemetryConfig } from "shared";
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import * as executionContext from "../../context/execution-context";
 import { TelemetryInterceptor } from "../../plugin/interceptors/telemetry";
 import type { InterceptorContext } from "../../plugin/interceptors/types";
 import type { ITelemetry } from "../types";
@@ -130,5 +131,37 @@ describe("TelemetryInterceptor", () => {
 
     // Verify end was called despite the error
     expect(mockSpan.end).toHaveBeenCalledTimes(1);
+  });
+
+  test("should set execution context as 'service' when not in user context", async () => {
+    vi.spyOn(executionContext, "isInUserContext").mockReturnValue(false);
+    const interceptor = new TelemetryInterceptor(mockTelemetry);
+    const fn = vi.fn().mockResolvedValue("result");
+
+    await interceptor.intercept(fn, context);
+
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      "execution.context",
+      "service",
+    );
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("caller.id", "test");
+  });
+
+  test("should set execution context as 'user' when in user context", async () => {
+    vi.spyOn(executionContext, "isInUserContext").mockReturnValue(true);
+    const interceptor = new TelemetryInterceptor(mockTelemetry);
+    const fn = vi.fn().mockResolvedValue("result");
+    const userContext: InterceptorContext = {
+      metadata: new Map(),
+      userKey: "user-123",
+    };
+
+    await interceptor.intercept(fn, userContext);
+
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      "execution.context",
+      "user",
+    );
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("caller.id", "user-123");
   });
 });

--- a/packages/lakebase/src/pool.ts
+++ b/packages/lakebase/src/pool.ts
@@ -92,6 +92,7 @@ export function createLakebasePool(
         kind: SpanKind.CLIENT,
         attributes: {
           "db.system": "lakebase",
+          "db.user": poolConfig.user ?? "unknown",
           "db.statement": sql ? sql.substring(0, 500) : "unknown",
         },
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -330,6 +330,9 @@ importers:
         specifier: 4.3.6
         version: 4.3.6
     devDependencies:
+      '@opentelemetry/context-async-hooks':
+        specifier: 2.6.1
+        version: 2.6.1(@opentelemetry/api@1.9.0)
       '@types/express':
         specifier: 4.17.25
         version: 4.17.25
@@ -2786,6 +2789,12 @@ packages:
 
   '@opentelemetry/context-async-hooks@2.2.0':
     resolution: {integrity: sha512-qRkLWiUEZNAmYapZ7KGS5C4OmBLcP/H2foXeOEaowYCR0wi89fHejrfYfbuLVCMLp/dWZXKvQusdbUEZjERfwQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/context-async-hooks@2.6.1':
+    resolution: {integrity: sha512-XHzhwRNkBpeP8Fs/qjGrAf9r9PRv67wkJQ/7ZPaBQQ68DYlTBBx5MF9LvPx7mhuXcDessKK2b+DcxqwpgkcivQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
@@ -15115,6 +15124,10 @@ snapshots:
       - supports-color
 
   '@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
 


### PR DESCRIPTION
## Summary

- Adds `execution.context`, `caller.id`, and `execution.obo_dev_fallback` span attributes to the telemetry interceptor for OBO observability
- Fixes orphaned `plugin.execute` spans by preserving OTel context across the async generator boundary in `executeStream()`
- Adds `db.user` attribute to lakebase query spans
- Documents telemetry span attributes in execution-context.md and custom-plugins.md

## Changes

### Telemetry span attributes (`plugin.execute` span)

| Attribute | Type | Description |
|---|---|---|
| `execution.context` | `"user"` \| `"service"` | Whether the operation runs as OBO or service principal |
| `caller.id` | `string` | The user ID (OBO) or service principal ID |
| `execution.obo_dev_fallback` | `boolean` | `true` when an OBO call falls back to SP in dev mode (no `x-forwarded-access-token`) |

### OTel context propagation fix

`executeStream()` runs the interceptor chain inside an async generator — OTel lost the parent HTTP span context at this boundary. Spans were created but orphaned in separate traces. Fix: capture `otelContext.active()` before the generator, restore with `otelContext.with()` inside.

### OBO dev mode fallback

In dev mode without `x-forwarded-access-token`, `asUser()` returns a thin proxy that sets an OTel context key (`DEV_OBO_FALLBACK_KEY`). The telemetry interceptor reads this to set `execution.obo_dev_fallback: true`. No mutable state — scoped automatically per execution via OTel context.

### `caller.id` fix

Previously used `context.userKey` (a cache key — analytics passes `"global"` for SP queries). Now uses `getCurrentUserId()` which always returns the real identity.

### Lakebase `db.user`

Adds `db.user` attribute to `lakebase.query` spans showing the PostgreSQL role used for the connection.

### Arrow-result clarification

Added comment clarifying the arrow-result route intentionally bypasses the interceptor chain (data download, not query execution).

## Test plan

- [x] Unit tests for all new attributes (user/service/dev fallback paths)
- [x] All 1578 tests pass
- [x] Full build pipeline passes
- [x] Manual: Grafana traces verified via Chrome DevTools MCP + Tempo API

## Screenshots

### Service Principal

<img width="639" height="285" alt="image" src="https://github.com/user-attachments/assets/e6379247-59b9-4682-b354-87f3d93a8493" />

### User (for deployed app - when we have the forwarded token)

<img width="812" height="423" alt="image" src="https://github.com/user-attachments/assets/f8de83fd-c910-4259-b0cf-c933f9b37ea6" />

### Local for OBO

<img width="1280" height="1222" alt="obo-trace-screenshot" src="https://github.com/user-attachments/assets/24694a33-26d8-4991-938a-27de1ab6baeb" />

### Lakebase - DB user

<img width="1028" height="686" alt="image" src="https://github.com/user-attachments/assets/b8dd14ec-c00b-47fc-8016-40c514d6a593" />

## Plugin OBO coverage verification

All built-in plugins that use `asUser()` go through `execute()` / `executeStream()`:

| Plugin | Method | File |
|---|---|---|
| analytics | `executeStream()` | [analytics.ts:187](https://github.com/databricks/appkit/blob/main/packages/appkit/src/plugins/analytics/analytics.ts#L187) |
| genie | `executeStream()` | [genie.ts:124](https://github.com/databricks/appkit/blob/main/packages/appkit/src/plugins/genie/genie.ts#L124), [:176](https://github.com/databricks/appkit/blob/main/packages/appkit/src/plugins/genie/genie.ts#L176), [:228](https://github.com/databricks/appkit/blob/main/packages/appkit/src/plugins/genie/genie.ts#L228) |
| files | `execute()` | [plugin.ts:445](https://github.com/databricks/appkit/blob/main/packages/appkit/src/plugins/files/plugin.ts#L445), [:481](https://github.com/databricks/appkit/blob/main/packages/appkit/src/plugins/files/plugin.ts#L481), [:551](https://github.com/databricks/appkit/blob/main/packages/appkit/src/plugins/files/plugin.ts#L551), [:622](https://github.com/databricks/appkit/blob/main/packages/appkit/src/plugins/files/plugin.ts#L622), [:658](https://github.com/databricks/appkit/blob/main/packages/appkit/src/plugins/files/plugin.ts#L658), [:694](https://github.com/databricks/appkit/blob/main/packages/appkit/src/plugins/files/plugin.ts#L694), [:782](https://github.com/databricks/appkit/blob/main/packages/appkit/src/plugins/files/plugin.ts#L782), [:842](https://github.com/databricks/appkit/blob/main/packages/appkit/src/plugins/files/plugin.ts#L842), [:887](https://github.com/databricks/appkit/blob/main/packages/appkit/src/plugins/files/plugin.ts#L887) |
| serving | `execute()` | [serving.ts:297](https://github.com/databricks/appkit/blob/main/packages/appkit/src/plugins/serving/serving.ts#L297) |
| vector-search | `execute()` | [vector-search.ts:98](https://github.com/databricks/appkit/blob/main/packages/appkit/src/plugins/vector-search/vector-search.ts#L98), [:173](https://github.com/databricks/appkit/blob/main/packages/appkit/src/plugins/vector-search/vector-search.ts#L173), [:240](https://github.com/databricks/appkit/blob/main/packages/appkit/src/plugins/vector-search/vector-search.ts#L240) |
| lakebase | N/A (OBO not supported yet) | `db.user` attribute added to `lakebase.query` spans showing the PostgreSQL role. `execution.context`/`caller.id` will be added when OBO (per-user pools) is implemented. |

**Not covered (by design):**
- **analytics arrow-result** (`GET /arrow-result/:jobId`) — data download endpoint, always runs as SP. Clarified with comment.