### PR TITLE
feat(appkit): plugin infrastructure — attachContext + PluginContext mediator

### DIFF
--- a/docs/docs/api/appkit/Class.Plugin.md
+++ b/docs/docs/api/appkit/Class.Plugin.md
@@ -136,6 +136,14 @@ protected config: TConfig;
 
 ***
 
+### context?
+
+```ts
+protected optional context: PluginContext;
+```
+
+***
+
 ### devFileReader
 
 ```ts
@@ -241,6 +249,42 @@ A proxied plugin instance that executes as the user
 
 AuthenticationError if user token is not available in request headers (production only).
   In development mode (`NODE_ENV=development`), skips user impersonation instead of throwing.
+
+***
+
+### attachContext()
+
+```ts
+attachContext(deps: {
+  context?: unknown;
+  telemetryConfig?: TelemetryOptions;
+}): void;
+```
+
+Binds runtime dependencies (telemetry provider, cache, plugin context) to
+this plugin. Called by `AppKit._createApp` after construction and before
+`setup()`. Idempotent: safe to call if the constructor already bound them
+eagerly. Kept separate so factories can eagerly construct plugin instances
+without running this before `TelemetryManager.initialize()` /
+`CacheManager.getInstance()` have run.
+
+#### Parameters
+
+| Parameter | Type |
+| ------ | ------ |
+| `deps` | \{ `context?`: `unknown`; `telemetryConfig?`: `TelemetryOptions`; \} |
+| `deps.context?` | `unknown` |
+| `deps.telemetryConfig?` | `TelemetryOptions` |
+
+#### Returns
+
+`void`
+
+#### Implementation of
+
+```ts
+BasePlugin.attachContext
+```
 
 ***
 

--- a/knip.json
+++ b/knip.json
@@ -17,6 +17,7 @@
     "**/*.css",
     "packages/appkit/src/plugins/vector-search/**",
     "packages/appkit/src/plugin/index.ts",
+    "packages/appkit/src/plugin/to-plugin.ts",
     "packages/appkit/src/plugins/agents/index.ts",
     "packages/appkit/src/plugins/agents/tools/index.ts",
     "packages/appkit/src/plugins/agents/from-plugin.ts",

--- a/packages/appkit/src/beta.ts
+++ b/packages/appkit/src/beta.ts
@@ -1,8 +1,38 @@
-// Beta plugins -- APIs may change between minor releases.
-// These plugins are on a path to GA and will graduate.
-// Import from '@databricks/appkit' once a plugin graduates to GA.
+// Beta plugins and APIs -- may change between minor releases.
+// These are on a path to GA and will graduate to '@databricks/appkit'.
 //
-// The exports below are auto-generated from each plugin's manifest.json
+// Plugin factory exports are auto-generated from each plugin's manifest.json
 // "stability" field. See tools/generate-plugin-entries.ts.
 export { DatabricksAdapter, parseTextToolCalls } from "./agents/databricks";
+
+// Agent types from shared
+export type {
+  AgentAdapter,
+  AgentEvent,
+  AgentInput,
+  AgentRunContext,
+  AgentToolDefinition,
+  Message,
+  Thread,
+  ThreadStore,
+  ToolProvider,
+} from "shared";
+
+// Tool authoring primitives
+export {
+  type FunctionTool,
+  type HostedTool,
+  isFunctionTool,
+  isHostedTool,
+  mcpServer,
+  type ToolConfig,
+  tool,
+} from "./core/agent/tools";
+export {
+  type AgentTool,
+  isToolkitEntry,
+  type ToolkitEntry,
+  type ToolkitOptions,
+} from "./core/agent/types";
+
 export * from "./plugins/beta-exports.generated";

--- a/packages/appkit/src/beta.ts
+++ b/packages/appkit/src/beta.ts
@@ -1,9 +1,9 @@
-// Beta plugins and APIs -- may change between minor releases.
-// These are on a path to GA and will graduate to '@databricks/appkit'.
+// Beta plugins -- APIs may change between minor releases.
+// These plugins are on a path to GA and will graduate.
+// Import from '@databricks/appkit' once a plugin graduates to GA.
 //
-// Plugin factory exports are auto-generated from each plugin's manifest.json
+// The exports below are auto-generated from each plugin's manifest.json
 // "stability" field. See tools/generate-plugin-entries.ts.
-export { DatabricksAdapter, parseTextToolCalls } from "./agents/databricks";
 
 // Agent types from shared
 export type {
@@ -17,6 +17,7 @@ export type {
   ThreadStore,
   ToolProvider,
 } from "shared";
+export { DatabricksAdapter, parseTextToolCalls } from "./agents/databricks";
 
 // Tool authoring primitives
 export {

--- a/packages/appkit/src/beta.ts
+++ b/packages/appkit/src/beta.ts
@@ -21,13 +21,21 @@ export { DatabricksAdapter, parseTextToolCalls } from "./agents/databricks";
 
 // Tool authoring primitives
 export {
+  AppKitMcpClient,
+  defineTool,
+  executeFromRegistry,
   type FunctionTool,
+  functionToolToDefinition,
   type HostedTool,
   isFunctionTool,
   isHostedTool,
   mcpServer,
+  resolveHostedTools,
   type ToolConfig,
+  type ToolEntry,
+  type ToolRegistry,
   tool,
+  toolsFromRegistry,
 } from "./core/agent/tools";
 export {
   type AgentTool,

--- a/packages/appkit/src/core/agent/build-toolkit.ts
+++ b/packages/appkit/src/core/agent/build-toolkit.ts
@@ -1,0 +1,63 @@
+import type { AgentToolDefinition } from "shared";
+import type { ToolRegistry } from "./tools/define-tool";
+import { toToolJSONSchema } from "./tools/json-schema";
+import type { ToolkitEntry, ToolkitOptions } from "./types";
+
+/**
+ * Converts a plugin's internal `ToolRegistry` into a keyed record of
+ * `ToolkitEntry` markers suitable for spreading into an `AgentDefinition.tools`
+ * record.
+ *
+ * The `opts` record controls shape and filtering:
+ * - `prefix` — overrides the default `${pluginName}.` prefix; `""` drops it.
+ * - `only` — allowlist of local tool names to include (post-prefix).
+ * - `except` — denylist of local names.
+ * - `rename` — per-tool key remapping (applied after prefix/filter).
+ *
+ * Each entry carries `pluginName` + `localName` so the agents plugin can
+ * dispatch back through `PluginContext.executeTool` for OBO + telemetry.
+ */
+export function buildToolkitEntries(
+  pluginName: string,
+  registry: ToolRegistry,
+  opts: ToolkitOptions = {},
+): Record<string, ToolkitEntry> {
+  const prefix = opts.prefix ?? `${pluginName}.`;
+  const only = opts.only ? new Set(opts.only) : null;
+  const except = opts.except ? new Set(opts.except) : null;
+  const rename = opts.rename ?? {};
+
+  const out: Record<string, ToolkitEntry> = {};
+
+  for (const [localName, entry] of Object.entries(registry)) {
+    if (only && !only.has(localName)) continue;
+    if (except?.has(localName)) continue;
+
+    const keyAfterPrefix = `${prefix}${localName}`;
+    const key = rename[localName] ?? keyAfterPrefix;
+
+    const parameters = toToolJSONSchema(
+      entry.schema,
+    ) as unknown as AgentToolDefinition["parameters"];
+
+    const def: AgentToolDefinition = {
+      name: key,
+      description: entry.description,
+      parameters,
+    };
+    if (entry.annotations) {
+      def.annotations = entry.annotations;
+    }
+
+    out[key] = {
+      __toolkitRef: true,
+      pluginName,
+      localName,
+      def,
+      annotations: entry.annotations,
+      autoInheritable: entry.autoInheritable,
+    };
+  }
+
+  return out;
+}

--- a/packages/appkit/src/core/agent/tests/build-toolkit.test.ts
+++ b/packages/appkit/src/core/agent/tests/build-toolkit.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "vitest";
+import { z } from "zod";
+import { buildToolkitEntries } from "../build-toolkit";
+import { defineTool, type ToolRegistry } from "../tools/define-tool";
+import { isToolkitEntry } from "../types";
+
+const registry: ToolRegistry = {
+  query: defineTool({
+    description: "Run a query",
+    schema: z.object({ sql: z.string() }),
+    handler: () => "ok",
+  }),
+  history: defineTool({
+    description: "Get query history",
+    schema: z.object({}),
+    handler: () => [],
+  }),
+};
+
+describe("buildToolkitEntries", () => {
+  test("produces ToolkitEntry per registry item with default dotted prefix", () => {
+    const entries = buildToolkitEntries("analytics", registry);
+    expect(Object.keys(entries).sort()).toEqual([
+      "analytics.history",
+      "analytics.query",
+    ]);
+    for (const entry of Object.values(entries)) {
+      expect(isToolkitEntry(entry)).toBe(true);
+      expect(entry.pluginName).toBe("analytics");
+    }
+  });
+
+  test("respects prefix option (empty drops the namespace)", () => {
+    const entries = buildToolkitEntries("analytics", registry, { prefix: "" });
+    expect(Object.keys(entries).sort()).toEqual(["history", "query"]);
+  });
+
+  test("respects custom prefix", () => {
+    const entries = buildToolkitEntries("analytics", registry, {
+      prefix: "db.",
+    });
+    expect(Object.keys(entries).sort()).toEqual(["db.history", "db.query"]);
+  });
+
+  test("only filter keeps the listed local names", () => {
+    const entries = buildToolkitEntries("analytics", registry, {
+      only: ["query"],
+    });
+    expect(Object.keys(entries)).toEqual(["analytics.query"]);
+  });
+
+  test("except filter drops the listed local names", () => {
+    const entries = buildToolkitEntries("analytics", registry, {
+      except: ["history"],
+    });
+    expect(Object.keys(entries)).toEqual(["analytics.query"]);
+  });
+
+  test("rename remaps specific local names (overrides the prefix key)", () => {
+    const entries = buildToolkitEntries("analytics", registry, {
+      rename: { query: "sql" },
+    });
+    expect(Object.keys(entries).sort()).toEqual(["analytics.history", "sql"]);
+  });
+
+  test("exposes the original plugin+local name so dispatch can route", () => {
+    const entries = buildToolkitEntries("analytics", registry, {
+      prefix: "db.",
+    });
+    const qEntry = entries["db.query"];
+    expect(qEntry.pluginName).toBe("analytics");
+    expect(qEntry.localName).toBe("query");
+    expect(qEntry.def.name).toBe("db.query");
+  });
+
+  test("propagates autoInheritable from the source registry", () => {
+    const mixed: ToolRegistry = {
+      readIt: defineTool({
+        description: "safe read",
+        schema: z.object({}),
+        autoInheritable: true,
+        handler: () => "ok",
+      }),
+      writeIt: defineTool({
+        description: "unsafe write",
+        schema: z.object({}),
+        autoInheritable: false,
+        handler: () => "ok",
+      }),
+      unmarked: defineTool({
+        description: "default: not auto-inheritable",
+        schema: z.object({}),
+        handler: () => "ok",
+      }),
+    };
+    const entries = buildToolkitEntries("p", mixed);
+    expect(entries["p.readIt"].autoInheritable).toBe(true);
+    expect(entries["p.writeIt"].autoInheritable).toBe(false);
+    expect(entries["p.unmarked"].autoInheritable).toBeUndefined();
+  });
+});

--- a/packages/appkit/src/core/agent/tests/define-tool.test.ts
+++ b/packages/appkit/src/core/agent/tests/define-tool.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test, vi } from "vitest";
+import { z } from "zod";
+import {
+  defineTool,
+  executeFromRegistry,
+  type ToolRegistry,
+  toolsFromRegistry,
+} from "../tools/define-tool";
+
+describe("defineTool()", () => {
+  test("returns an entry matching the input config", () => {
+    const entry = defineTool({
+      description: "echo",
+      schema: z.object({ msg: z.string() }),
+      annotations: { readOnly: true },
+      handler: ({ msg }) => msg,
+    });
+
+    expect(entry.description).toBe("echo");
+    expect(entry.annotations).toEqual({ readOnly: true });
+    expect(typeof entry.handler).toBe("function");
+  });
+});
+
+describe("executeFromRegistry", () => {
+  const registry: ToolRegistry = {
+    echo: defineTool({
+      description: "echo",
+      schema: z.object({ msg: z.string() }),
+      handler: ({ msg }) => `got ${msg}`,
+    }),
+  };
+
+  test("validates args and calls handler on success", async () => {
+    const result = await executeFromRegistry(registry, "echo", { msg: "hi" });
+    expect(result).toBe("got hi");
+  });
+
+  test("returns formatted error string on validation failure", async () => {
+    const result = await executeFromRegistry(registry, "echo", {});
+    expect(typeof result).toBe("string");
+    expect(result).toContain("Invalid arguments for echo");
+    expect(result).toContain("msg");
+  });
+
+  test("throws for unknown tool names", async () => {
+    await expect(executeFromRegistry(registry, "missing", {})).rejects.toThrow(
+      /Unknown tool: missing/,
+    );
+  });
+
+  test("forwards AbortSignal to the handler", async () => {
+    const handler = vi.fn(async (_args: { x: string }, signal?: AbortSignal) =>
+      signal?.aborted ? "aborted" : "ok",
+    );
+    const reg: ToolRegistry = {
+      t: defineTool({
+        description: "t",
+        schema: z.object({ x: z.string() }),
+        handler,
+      }),
+    };
+
+    const controller = new AbortController();
+    controller.abort();
+    await executeFromRegistry(reg, "t", { x: "hi" }, controller.signal);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0][1]).toBe(controller.signal);
+  });
+});
+
+describe("toolsFromRegistry", () => {
+  test("produces AgentToolDefinition[] with JSON Schema parameters", () => {
+    const registry: ToolRegistry = {
+      query: defineTool({
+        description: "Execute a SQL query",
+        schema: z.object({
+          query: z.string().describe("SQL query"),
+        }),
+        annotations: { readOnly: true, requiresUserContext: true },
+        handler: () => "ok",
+      }),
+    };
+
+    const defs = toolsFromRegistry(registry);
+    expect(defs).toHaveLength(1);
+    expect(defs[0].name).toBe("query");
+    expect(defs[0].description).toBe("Execute a SQL query");
+    expect(defs[0].parameters).toMatchObject({
+      type: "object",
+      properties: {
+        query: { type: "string", description: "SQL query" },
+      },
+      required: ["query"],
+    });
+    expect(defs[0].annotations).toEqual({
+      readOnly: true,
+      requiresUserContext: true,
+    });
+  });
+
+  test("preserves dotted names like uploads.list from the registry keys", () => {
+    const registry: ToolRegistry = {
+      "uploads.list": defineTool({
+        description: "list uploads",
+        schema: z.object({}),
+        handler: () => [],
+      }),
+      "documents.list": defineTool({
+        description: "list documents",
+        schema: z.object({}),
+        handler: () => [],
+      }),
+    };
+
+    const names = toolsFromRegistry(registry).map((d) => d.name);
+    expect(names).toContain("uploads.list");
+    expect(names).toContain("documents.list");
+  });
+
+  test("omits annotations when none are provided", () => {
+    const registry: ToolRegistry = {
+      plain: defineTool({
+        description: "plain",
+        schema: z.object({}),
+        handler: () => "ok",
+      }),
+    };
+    const [def] = toolsFromRegistry(registry);
+    expect(def.annotations).toBeUndefined();
+  });
+});

--- a/packages/appkit/src/core/agent/tests/function-tool.test.ts
+++ b/packages/appkit/src/core/agent/tests/function-tool.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "vitest";
+import {
+  functionToolToDefinition,
+  isFunctionTool,
+} from "../tools/function-tool";
+
+describe("isFunctionTool", () => {
+  test("returns true for valid FunctionTool", () => {
+    expect(
+      isFunctionTool({
+        type: "function",
+        name: "greet",
+        execute: async () => "hello",
+      }),
+    ).toBe(true);
+  });
+
+  test("returns true for minimal FunctionTool", () => {
+    expect(
+      isFunctionTool({
+        type: "function",
+        name: "x",
+        execute: () => "y",
+      }),
+    ).toBe(true);
+  });
+
+  test("returns false for null", () => {
+    expect(isFunctionTool(null)).toBe(false);
+  });
+
+  test("returns false for non-object", () => {
+    expect(isFunctionTool("function")).toBe(false);
+  });
+
+  test("returns false for wrong type", () => {
+    expect(
+      isFunctionTool({
+        type: "genie-space",
+        name: "x",
+        execute: () => "y",
+      }),
+    ).toBe(false);
+  });
+
+  test("returns false when execute is missing", () => {
+    expect(isFunctionTool({ type: "function", name: "x" })).toBe(false);
+  });
+
+  test("returns false when name is missing", () => {
+    expect(isFunctionTool({ type: "function", execute: () => "y" })).toBe(
+      false,
+    );
+  });
+});
+
+describe("functionToolToDefinition", () => {
+  test("converts a FunctionTool with all fields", () => {
+    const def = functionToolToDefinition({
+      type: "function",
+      name: "getWeather",
+      description: "Get current weather",
+      parameters: {
+        type: "object",
+        properties: { city: { type: "string" } },
+        required: ["city"],
+      },
+      execute: async () => "sunny",
+    });
+
+    expect(def.name).toBe("getWeather");
+    expect(def.description).toBe("Get current weather");
+    expect(def.parameters).toEqual({
+      type: "object",
+      properties: { city: { type: "string" } },
+      required: ["city"],
+    });
+  });
+
+  test("uses name as fallback description", () => {
+    const def = functionToolToDefinition({
+      type: "function",
+      name: "myTool",
+      execute: async () => "result",
+    });
+
+    expect(def.description).toBe("myTool");
+  });
+
+  test("uses empty object schema when parameters are null", () => {
+    const def = functionToolToDefinition({
+      type: "function",
+      name: "noParams",
+      parameters: null,
+      execute: async () => "ok",
+    });
+
+    expect(def.parameters).toEqual({ type: "object", properties: {} });
+  });
+
+  test("uses empty object schema when parameters are omitted", () => {
+    const def = functionToolToDefinition({
+      type: "function",
+      name: "noParams",
+      execute: async () => "ok",
+    });
+
+    expect(def.parameters).toEqual({ type: "object", properties: {} });
+  });
+});

--- a/packages/appkit/src/core/agent/tests/hosted-tools.test.ts
+++ b/packages/appkit/src/core/agent/tests/hosted-tools.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "vitest";
+import { isHostedTool, resolveHostedTools } from "../tools/hosted-tools";
+
+describe("isHostedTool", () => {
+  test("returns true for genie-space", () => {
+    expect(
+      isHostedTool({ type: "genie-space", genie_space: { id: "abc" } }),
+    ).toBe(true);
+  });
+
+  test("returns true for vector_search_index", () => {
+    expect(
+      isHostedTool({
+        type: "vector_search_index",
+        vector_search_index: { name: "cat.schema.idx" },
+      }),
+    ).toBe(true);
+  });
+
+  test("returns true for custom_mcp_server", () => {
+    expect(
+      isHostedTool({
+        type: "custom_mcp_server",
+        custom_mcp_server: { app_name: "my-app", app_url: "my-app-url" },
+      }),
+    ).toBe(true);
+  });
+
+  test("returns true for external_mcp_server", () => {
+    expect(
+      isHostedTool({
+        type: "external_mcp_server",
+        external_mcp_server: { connection_name: "conn1" },
+      }),
+    ).toBe(true);
+  });
+
+  test("returns false for FunctionTool", () => {
+    expect(
+      isHostedTool({ type: "function", name: "x", execute: () => "y" }),
+    ).toBe(false);
+  });
+
+  test("returns false for null", () => {
+    expect(isHostedTool(null)).toBe(false);
+  });
+
+  test("returns false for unknown type", () => {
+    expect(isHostedTool({ type: "unknown" })).toBe(false);
+  });
+
+  test("returns false for non-object", () => {
+    expect(isHostedTool(42)).toBe(false);
+  });
+});
+
+describe("resolveHostedTools", () => {
+  test("resolves genie-space to correct MCP endpoint", () => {
+    const configs = resolveHostedTools([
+      { type: "genie-space", genie_space: { id: "space123" } },
+    ]);
+
+    expect(configs).toHaveLength(1);
+    expect(configs[0].name).toBe("genie-space123");
+    expect(configs[0].url).toBe("/api/2.0/mcp/genie/space123");
+  });
+
+  test("resolves vector_search_index with 3-part name", () => {
+    const configs = resolveHostedTools([
+      {
+        type: "vector_search_index",
+        vector_search_index: { name: "catalog.schema.my_index" },
+      },
+    ]);
+
+    expect(configs).toHaveLength(1);
+    expect(configs[0].name).toBe("vs-catalog-schema-my_index");
+    expect(configs[0].url).toBe(
+      "/api/2.0/mcp/vector-search/catalog/schema/my_index",
+    );
+  });
+
+  test("throws for invalid vector_search_index name", () => {
+    expect(() =>
+      resolveHostedTools([
+        {
+          type: "vector_search_index",
+          vector_search_index: { name: "bad.name" },
+        },
+      ]),
+    ).toThrow("3-part dotted");
+  });
+
+  test("resolves custom_mcp_server", () => {
+    const configs = resolveHostedTools([
+      {
+        type: "custom_mcp_server",
+        custom_mcp_server: { app_name: "my-app", app_url: "my-app-endpoint" },
+      },
+    ]);
+
+    expect(configs[0].name).toBe("my-app");
+    expect(configs[0].url).toBe("my-app-endpoint");
+  });
+
+  test("resolves external_mcp_server", () => {
+    const configs = resolveHostedTools([
+      {
+        type: "external_mcp_server",
+        external_mcp_server: { connection_name: "conn1" },
+      },
+    ]);
+
+    expect(configs[0].name).toBe("conn1");
+    expect(configs[0].url).toBe("/api/2.0/mcp/external/conn1");
+  });
+
+  test("resolves multiple tools preserving order", () => {
+    const configs = resolveHostedTools([
+      { type: "genie-space", genie_space: { id: "g1" } },
+      {
+        type: "external_mcp_server",
+        external_mcp_server: { connection_name: "e1" },
+      },
+    ]);
+
+    expect(configs).toHaveLength(2);
+    expect(configs[0].name).toBe("genie-g1");
+    expect(configs[1].name).toBe("e1");
+  });
+});

--- a/packages/appkit/src/core/agent/tests/sql-policy.test.ts
+++ b/packages/appkit/src/core/agent/tests/sql-policy.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, test } from "vitest";
+import {
+  assertReadOnlySql,
+  classifyReadOnly,
+  ReadOnlySqlViolation,
+} from "../tools/sql-policy";
+
+function ok(sql: string) {
+  const result = classifyReadOnly(sql);
+  if (!result.readOnly) {
+    throw new Error(
+      `Expected readOnly=true for ${JSON.stringify(sql)}, got reason: ${result.reason}`,
+    );
+  }
+  return result;
+}
+
+function rejected(sql: string) {
+  const result = classifyReadOnly(sql);
+  if (result.readOnly) {
+    throw new Error(
+      `Expected readOnly=false for ${JSON.stringify(sql)}, got readOnly=true`,
+    );
+  }
+  return result;
+}
+
+describe("classifyReadOnly: plain reads are admitted", () => {
+  test.each([
+    "SELECT 1",
+    "select 1",
+    "SELECT * FROM users",
+    "SELECT * FROM main.sales.orders WHERE created_at > now() - interval '7 days'",
+    "SELECT COUNT(*) FROM main.sales.orders",
+    "WITH a AS (SELECT 1) SELECT * FROM a",
+    "WITH RECURSIVE t AS (SELECT 1) SELECT * FROM t",
+    "SHOW TABLES",
+    "SHOW TABLES IN main.sales",
+    "DESCRIBE EXTENDED main.sales.orders",
+    "DESC main.sales.orders",
+    "EXPLAIN SELECT 1",
+    "EXPLAIN ANALYZE SELECT 1",
+  ])("admits %s", (sql) => {
+    expect(ok(sql).statements).toBe(1);
+  });
+});
+
+describe("classifyReadOnly: writes are rejected", () => {
+  test.each([
+    ["DROP TABLE users", "DROP"],
+    ["UPDATE users SET email = 'x@y.com'", "UPDATE"],
+    ["DELETE FROM orders WHERE id = 1", "DELETE"],
+    ["INSERT INTO x VALUES (1)", "INSERT"],
+    ["CREATE TABLE x (id INT)", "CREATE"],
+    ["ALTER TABLE x ADD COLUMN y INT", "ALTER"],
+    ["TRUNCATE TABLE orders", "TRUNCATE"],
+    ["GRANT SELECT ON t TO u", "GRANT"],
+    ["REVOKE ALL ON t FROM u", "REVOKE"],
+    ["CALL sp_do_thing()", "CALL"],
+    ["COPY t FROM '/tmp/x'", "COPY"],
+    ["MERGE INTO t USING s", "MERGE"],
+    ["REFRESH TABLE t", "REFRESH"],
+    ["VACUUM t", "VACUUM"],
+  ])("rejects %s", (sql, keyword) => {
+    const result = rejected(sql);
+    expect(result.reason).toContain(keyword);
+  });
+});
+
+describe("classifyReadOnly: stacked statements", () => {
+  test("rejects SELECT followed by DROP", () => {
+    const result = rejected("SELECT 1; DROP TABLE x");
+    expect(result.reason).toMatch(/DROP/);
+  });
+
+  test("rejects DROP followed by SELECT (write comes first)", () => {
+    const result = rejected("DROP TABLE x; SELECT 1");
+    expect(result.reason).toMatch(/DROP/);
+  });
+
+  test("admits multiple SELECTs", () => {
+    expect(ok("SELECT 1; SELECT 2").statements).toBe(2);
+  });
+
+  test("admits trailing semicolon on single statement", () => {
+    expect(ok("SELECT 1;").statements).toBe(1);
+  });
+
+  test("admits SELECT, SHOW, DESCRIBE batch", () => {
+    const result = ok("SELECT 1; SHOW TABLES; DESCRIBE x;");
+    expect(result.statements).toBe(3);
+  });
+});
+
+describe("classifyReadOnly: comment handling", () => {
+  test("admits SELECT with line comment hiding a write keyword", () => {
+    ok("SELECT 1 -- DROP TABLE x\n");
+  });
+
+  test("admits SELECT preceded by line comment with write keyword", () => {
+    ok("-- DROP TABLE x\nSELECT 1");
+  });
+
+  test("admits SELECT with block comment containing stacked write", () => {
+    ok("SELECT 1 /* ; DROP TABLE x */");
+  });
+
+  test("handles nested block comments (PostgreSQL style)", () => {
+    ok("SELECT 1 /* outer /* inner */ still inside */");
+  });
+
+  test("rejects when write is outside the comment", () => {
+    const result = rejected("/* SELECT 1 */ DROP TABLE x");
+    expect(result.reason).toMatch(/DROP/);
+  });
+
+  test("empty after stripping comments is rejected", () => {
+    rejected("-- only a comment");
+    rejected("/* nothing */");
+  });
+});
+
+describe("classifyReadOnly: string literal handling", () => {
+  test("admits SELECT with write keyword inside single-quoted string", () => {
+    ok("SELECT 'DROP TABLE x' AS msg");
+  });
+
+  test("admits SELECT with semicolon inside single-quoted string", () => {
+    ok("SELECT 'value; DROP TABLE x' AS msg");
+  });
+
+  test("admits SELECT with doubled-quote escape", () => {
+    ok("SELECT 'it''s ok; DROP' AS msg");
+  });
+
+  test("admits SELECT with backslash escape inside string", () => {
+    ok("SELECT E'line\\'s end; DROP' AS msg");
+  });
+
+  test("admits SELECT with dollar-quoted string hiding a write", () => {
+    ok("SELECT $body$ arbitrary ; DROP TABLE x $body$ AS msg");
+  });
+
+  test("admits SELECT with untagged dollar quote", () => {
+    ok("SELECT $$hello; DROP$$ AS msg");
+  });
+
+  test("admits SELECT with ANSI double-quoted identifier named drop", () => {
+    ok('SELECT * FROM "drop"');
+  });
+
+  test("admits SELECT with doubled-quote inside ANSI identifier", () => {
+    ok('SELECT * FROM "weird""name"');
+  });
+
+  test("admits SELECT with backtick identifier (Databricks)", () => {
+    ok("SELECT * FROM `my table`");
+  });
+});
+
+describe("classifyReadOnly: degenerate input", () => {
+  test("rejects empty string", () => {
+    rejected("");
+  });
+
+  test("rejects whitespace-only", () => {
+    rejected("   \n\t  ");
+  });
+
+  test("rejects semicolons only", () => {
+    rejected(";;;");
+  });
+
+  test("rejects non-SQL garbage", () => {
+    rejected("-- this is just a comment\n-- nothing else");
+    rejected("random garbage text");
+  });
+
+  test("rejects a single empty statement between two selects", () => {
+    // "SELECT 1;; SELECT 2" — the middle empty statement is dropped by
+    // splitter; the surviving two statements are both SELECT, admitted.
+    ok("SELECT 1;; SELECT 2");
+  });
+});
+
+describe("classifyReadOnly: evasion-resistance", () => {
+  test("cannot hide DROP after a comment-ended newline", () => {
+    const result = rejected("-- intent\nDROP TABLE x");
+    expect(result.reason).toMatch(/DROP/);
+  });
+
+  test("cannot hide DROP via concatenated strings (strings end cleanly)", () => {
+    rejected("'SELECT 1'; DROP TABLE x");
+  });
+
+  test("bare DROP after unclosed string is still considered part of the string (defensive)", () => {
+    // An unclosed single quote eats the rest of the input — classifier
+    // sees the whole thing as one stripped, empty-ish statement and rejects.
+    rejected("SELECT 'unterminated ; DROP TABLE x");
+  });
+
+  test("dollar-quoted literal with malicious tag is handled", () => {
+    ok("SELECT $tag$ DROP $tag$ AS harmless");
+  });
+
+  test("mismatched dollar-quote tag is treated as unterminated", () => {
+    rejected("SELECT $a$ DROP TABLE x $b$");
+  });
+});
+
+describe("assertReadOnlySql", () => {
+  test("returns void on read-only SQL", () => {
+    expect(() => assertReadOnlySql("SELECT 1")).not.toThrow();
+  });
+
+  test("throws ReadOnlySqlViolation with descriptive message on writes", () => {
+    expect(() => assertReadOnlySql("DROP TABLE x")).toThrow(
+      ReadOnlySqlViolation,
+    );
+    try {
+      assertReadOnlySql("DROP TABLE x");
+    } catch (e) {
+      expect((e as Error).message).toMatch(/SQL read-only policy violation/);
+      expect((e as Error).message).toMatch(/DROP/);
+    }
+  });
+});

--- a/packages/appkit/src/core/agent/tests/tool.test.ts
+++ b/packages/appkit/src/core/agent/tests/tool.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "vitest";
+import { z } from "zod";
+import { formatZodError, tool } from "../tools/tool";
+
+describe("tool()", () => {
+  test("produces a FunctionTool with JSON Schema parameters from the Zod schema", () => {
+    const weather = tool({
+      name: "get_weather",
+      description: "Get the current weather for a city",
+      schema: z.object({
+        city: z.string().describe("City name"),
+      }),
+      execute: async ({ city }) => `Sunny in ${city}`,
+    });
+
+    expect(weather.type).toBe("function");
+    expect(weather.name).toBe("get_weather");
+    expect(weather.description).toBe("Get the current weather for a city");
+    expect(weather.parameters).toMatchObject({
+      type: "object",
+      properties: {
+        city: { type: "string", description: "City name" },
+      },
+      required: ["city"],
+    });
+  });
+
+  test("execute receives typed args on valid input", async () => {
+    const echo = tool({
+      name: "echo",
+      schema: z.object({ message: z.string() }),
+      execute: async ({ message }) => {
+        const _typed: string = message;
+        return `got ${_typed}`;
+      },
+    });
+
+    const result = await echo.execute({ message: "hi" });
+    expect(result).toBe("got hi");
+  });
+
+  test("returns formatted error string (does not throw) when args are invalid", async () => {
+    const weather = tool({
+      name: "get_weather",
+      schema: z.object({ city: z.string() }),
+      execute: async ({ city }) => `Sunny in ${city}`,
+    });
+
+    const result = await weather.execute({});
+    expect(typeof result).toBe("string");
+    expect(result).toContain("Invalid arguments for get_weather");
+    expect(result).toContain("city");
+  });
+
+  test("joins multiple validation errors with '; '", async () => {
+    const t = tool({
+      name: "multi",
+      schema: z.object({ a: z.string(), b: z.number() }),
+      execute: async () => "ok",
+    });
+
+    const result = await t.execute({});
+    expect(result).toContain("a:");
+    expect(result).toContain("b:");
+    expect(result).toContain(";");
+  });
+
+  test("optional fields validate when absent", async () => {
+    const t = tool({
+      name: "opt",
+      schema: z.object({ note: z.string().optional() }),
+      execute: async ({ note }) => note ?? "(no note)",
+    });
+
+    expect(await t.execute({})).toBe("(no note)");
+    expect(await t.execute({ note: "hello" })).toBe("hello");
+  });
+
+  test("description falls back to the tool name when omitted", () => {
+    const t = tool({
+      name: "my_tool",
+      schema: z.object({}),
+      execute: async () => "ok",
+    });
+
+    expect(t.description).toBe("my_tool");
+    expect(t.parameters).toBeDefined();
+  });
+});
+
+describe("formatZodError", () => {
+  test("formats a single issue with the tool name", () => {
+    const schema = z.object({ city: z.string() });
+    const result = schema.safeParse({});
+    if (result.success) throw new Error("expected failure");
+
+    const msg = formatZodError(result.error, "get_weather");
+    expect(msg).toMatch(/^Invalid arguments for get_weather: /);
+    expect(msg).toContain("city:");
+  });
+
+  test("joins multiple issues with '; '", () => {
+    const schema = z.object({ a: z.string(), b: z.number() });
+    const result = schema.safeParse({});
+    if (result.success) throw new Error("expected failure");
+
+    const msg = formatZodError(result.error, "t");
+    expect(msg.split(";").length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/appkit/src/core/agent/tools/define-tool.ts
+++ b/packages/appkit/src/core/agent/tools/define-tool.ts
@@ -1,0 +1,94 @@
+import type { AgentToolDefinition, ToolAnnotations } from "shared";
+import type { z } from "zod";
+import { toToolJSONSchema } from "./json-schema";
+import { formatZodError } from "./tool";
+
+/**
+ * Single-tool entry for a plugin's internal tool registry.
+ *
+ * Plugins collect these into a `Record<string, ToolEntry>` keyed by the tool's
+ * public name and dispatch via `executeFromRegistry`.
+ */
+export interface ToolEntry<S extends z.ZodType = z.ZodType> {
+  description: string;
+  schema: S;
+  annotations?: ToolAnnotations;
+  /**
+   * Whether this tool is eligible for auto-inheritance into markdown or
+   * code-defined agents that enable `autoInheritTools`. Defaults to `false`
+   * (safe-by-default) — plugin authors must explicitly opt a tool in if they
+   * consider it safe enough to appear in every agent's tool record without an
+   * explicit `tools:` declaration. Destructive or privilege-sensitive tools
+   * should leave this unset so that they only reach agents that wire them
+   * explicitly (via `tools:`, `toolkits:`, or `fromPlugin({ only: [...] })`).
+   */
+  autoInheritable?: boolean;
+  handler: (
+    args: z.infer<S>,
+    signal?: AbortSignal,
+  ) => unknown | Promise<unknown>;
+}
+
+export type ToolRegistry = Record<string, ToolEntry>;
+
+/**
+ * Defines a single tool entry for a plugin's internal registry.
+ *
+ * The generic `S` flows from `schema` through to the `handler` callback so
+ * `args` is fully typed from the Zod schema. Names are assigned by the
+ * registry key, so they are not repeated inside the entry.
+ */
+export function defineTool<S extends z.ZodType>(
+  config: ToolEntry<S>,
+): ToolEntry<S> {
+  return config;
+}
+
+/**
+ * Validates tool-call arguments against the entry's schema and invokes its
+ * handler. On validation failure, returns an LLM-friendly error string
+ * (matching the behavior of `tool()`) rather than throwing, so the model
+ * can self-correct on its next turn.
+ */
+export async function executeFromRegistry(
+  registry: ToolRegistry,
+  name: string,
+  args: unknown,
+  signal?: AbortSignal,
+): Promise<unknown> {
+  const entry = registry[name];
+  if (!entry) {
+    throw new Error(`Unknown tool: ${name}`);
+  }
+  const parsed = entry.schema.safeParse(args);
+  if (!parsed.success) {
+    return formatZodError(parsed.error, name);
+  }
+  return entry.handler(parsed.data, signal);
+}
+
+/**
+ * Produces the `AgentToolDefinition[]` a ToolProvider exposes to the LLM,
+ * deriving `parameters` JSON Schema from each entry's Zod schema.
+ *
+ * Tool names come from registry keys (supports dotted names like
+ * `uploads.list` for dynamic plugins).
+ */
+export function toolsFromRegistry(
+  registry: ToolRegistry,
+): AgentToolDefinition[] {
+  return Object.entries(registry).map(([name, entry]) => {
+    const parameters = toToolJSONSchema(
+      entry.schema,
+    ) as unknown as AgentToolDefinition["parameters"];
+    const def: AgentToolDefinition = {
+      name,
+      description: entry.description,
+      parameters,
+    };
+    if (entry.annotations) {
+      def.annotations = entry.annotations;
+    }
+    return def;
+  });
+}

--- a/packages/appkit/src/core/agent/tools/function-tool.ts
+++ b/packages/appkit/src/core/agent/tools/function-tool.ts
@@ -1,0 +1,33 @@
+import type { AgentToolDefinition } from "shared";
+
+export interface FunctionTool {
+  type: "function";
+  name: string;
+  description?: string | null;
+  parameters?: Record<string, unknown> | null;
+  strict?: boolean | null;
+  execute: (args: Record<string, unknown>) => Promise<string> | string;
+}
+
+export function isFunctionTool(value: unknown): value is FunctionTool {
+  if (typeof value !== "object" || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    obj.type === "function" &&
+    typeof obj.name === "string" &&
+    typeof obj.execute === "function"
+  );
+}
+
+export function functionToolToDefinition(
+  tool: FunctionTool,
+): AgentToolDefinition {
+  return {
+    name: tool.name,
+    description: tool.description ?? tool.name,
+    parameters: (tool.parameters as AgentToolDefinition["parameters"]) ?? {
+      type: "object",
+      properties: {},
+    },
+  };
+}

--- a/packages/appkit/src/core/agent/tools/hosted-tools.ts
+++ b/packages/appkit/src/core/agent/tools/hosted-tools.ts
@@ -1,0 +1,102 @@
+export interface GenieTool {
+  type: "genie-space";
+  genie_space: { id: string };
+}
+
+export interface VectorSearchIndexTool {
+  type: "vector_search_index";
+  vector_search_index: { name: string };
+}
+
+export interface CustomMcpServerTool {
+  type: "custom_mcp_server";
+  custom_mcp_server: { app_name: string; app_url: string };
+}
+
+export interface ExternalMcpServerTool {
+  type: "external_mcp_server";
+  external_mcp_server: { connection_name: string };
+}
+
+export type HostedTool =
+  | GenieTool
+  | VectorSearchIndexTool
+  | CustomMcpServerTool
+  | ExternalMcpServerTool;
+
+const HOSTED_TOOL_TYPES = new Set([
+  "genie-space",
+  "vector_search_index",
+  "custom_mcp_server",
+  "external_mcp_server",
+]);
+
+export function isHostedTool(value: unknown): value is HostedTool {
+  if (typeof value !== "object" || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return typeof obj.type === "string" && HOSTED_TOOL_TYPES.has(obj.type);
+}
+
+export interface McpEndpointConfig {
+  name: string;
+  /** Absolute URL or path relative to workspace host */
+  url: string;
+}
+
+/**
+ * Resolves HostedTool configs into MCP endpoint configurations
+ * that the MCP client can connect to.
+ */
+function resolveHostedTool(tool: HostedTool): McpEndpointConfig {
+  switch (tool.type) {
+    case "genie-space":
+      return {
+        name: `genie-${tool.genie_space.id}`,
+        url: `/api/2.0/mcp/genie/${tool.genie_space.id}`,
+      };
+    case "vector_search_index": {
+      const parts = tool.vector_search_index.name.split(".");
+      if (parts.length !== 3) {
+        throw new Error(
+          `vector_search_index name must be 3-part dotted (catalog.schema.index), got: ${tool.vector_search_index.name}`,
+        );
+      }
+      return {
+        name: `vs-${parts.join("-")}`,
+        url: `/api/2.0/mcp/vector-search/${parts[0]}/${parts[1]}/${parts[2]}`,
+      };
+    }
+    case "custom_mcp_server":
+      return {
+        name: tool.custom_mcp_server.app_name,
+        url: tool.custom_mcp_server.app_url,
+      };
+    case "external_mcp_server":
+      return {
+        name: tool.external_mcp_server.connection_name,
+        url: `/api/2.0/mcp/external/${tool.external_mcp_server.connection_name}`,
+      };
+  }
+}
+
+export function resolveHostedTools(tools: HostedTool[]): McpEndpointConfig[] {
+  return tools.map(resolveHostedTool);
+}
+
+/**
+ * Factory for declaring a custom MCP server tool.
+ *
+ * Replaces the verbose `{ type: "custom_mcp_server", custom_mcp_server: { app_name, app_url } }`
+ * wrapper with a concise positional call.
+ *
+ * Example:
+ * ```ts
+ * mcpServer("my-app", "https://my-app.databricksapps.com/mcp")
+ * ```
+ */
+export function mcpServer(name: string, url: string): CustomMcpServerTool {
+  return {
+    type: "custom_mcp_server",
+    custom_mcp_server: { app_name: name, app_url: url },
+  };
+}

--- a/packages/appkit/src/core/agent/tools/index.ts
+++ b/packages/appkit/src/core/agent/tools/index.ts
@@ -1,3 +1,4 @@
+export { AppKitMcpClient } from "../../../plugins/agents/tools/mcp-client";
 export {
   defineTool,
   executeFromRegistry,
@@ -16,5 +17,4 @@ export {
   mcpServer,
   resolveHostedTools,
 } from "./hosted-tools";
-export { AppKitMcpClient } from "../../../plugins/agents/tools/mcp-client";
 export { type ToolConfig, tool } from "./tool";

--- a/packages/appkit/src/core/agent/tools/index.ts
+++ b/packages/appkit/src/core/agent/tools/index.ts
@@ -1,0 +1,20 @@
+export {
+  defineTool,
+  executeFromRegistry,
+  type ToolEntry,
+  type ToolRegistry,
+  toolsFromRegistry,
+} from "./define-tool";
+export {
+  type FunctionTool,
+  functionToolToDefinition,
+  isFunctionTool,
+} from "./function-tool";
+export {
+  type HostedTool,
+  isHostedTool,
+  mcpServer,
+  resolveHostedTools,
+} from "./hosted-tools";
+export { AppKitMcpClient } from "../../../plugins/agents/tools/mcp-client";
+export { type ToolConfig, tool } from "./tool";

--- a/packages/appkit/src/core/agent/tools/json-schema.ts
+++ b/packages/appkit/src/core/agent/tools/json-schema.ts
@@ -1,0 +1,20 @@
+import { toJSONSchema, type z } from "zod";
+
+/**
+ * Converts a Zod schema to JSON Schema suitable for an LLM tool-call
+ * `parameters` field.
+ *
+ * Wraps `zod`'s `toJSONSchema()` and strips the top-level `$schema` annotation
+ * that Zod v4 emits by default (e.g. `"https://json-schema.org/draft/..."`).
+ * The Databricks Mosaic serving endpoint forwards tool schemas to Google's
+ * Gemini `function_declarations` format, which rejects any top-level key it
+ * doesn't explicitly recognize — including `$schema` — with a 400
+ * `Invalid JSON payload received. Unknown name "$schema"` error. Other LLM
+ * providers either ignore the field or also trip on it, so stripping here is
+ * safe across backends.
+ */
+export function toToolJSONSchema(schema: z.ZodType): Record<string, unknown> {
+  const raw = toJSONSchema(schema) as Record<string, unknown>;
+  const { $schema: _ignored, ...rest } = raw;
+  return rest;
+}

--- a/packages/appkit/src/core/agent/tools/sql-policy.ts
+++ b/packages/appkit/src/core/agent/tools/sql-policy.ts
@@ -1,0 +1,317 @@
+/**
+ * Conservative SQL classifier used by agent-facing query tools to enforce
+ * `readOnly: true` annotations at execution time.
+ *
+ * Why a hand-rolled tokenizer rather than `node-sql-parser` or `pgsql-parser`:
+ *
+ * - `node-sql-parser`'s Hive/Spark dialect coverage rejects common Databricks
+ *   SQL patterns (three-part `catalog.schema.table` names, `SHOW TABLES IN`,
+ *   `DESCRIBE EXTENDED`, `EXPLAIN`) that must be allowed by a read-only
+ *   classifier. Its PostgreSQL grammar rejects `SHOW`/`DESCRIBE` too.
+ * - `pgsql-parser` (libpg_query) is a native binding and fails to install
+ *   cleanly on every Databricks App runtime we care about.
+ *
+ * We don't need to fully parse SQL — we only need to decide whether every
+ * statement in the batch starts with a read-only keyword. A small tokenizer
+ * that correctly strips strings, identifiers, and comments is enough and
+ * costs no extra dependencies.
+ *
+ * What this classifier guarantees (when it returns `readOnly: true`):
+ *
+ * - Every semicolon-separated statement outside a string, identifier, or
+ *   comment begins with `SELECT`, `WITH`, `SHOW`, `EXPLAIN`, `DESCRIBE`, or
+ *   `DESC`.
+ * - `SELECT 1; DROP TABLE x` is rejected (stacked write detected).
+ * - `SELECT 'value; DROP TABLE x'` passes (literal inside a string).
+ * - `-- DROP TABLE x\nSELECT 1` passes (comment stripped).
+ * - `SELECT 1 <block-comment ; DROP block-comment>` passes (comment stripped).
+ *
+ * What this classifier does NOT guarantee:
+ *
+ * - A `SELECT` statement may still have side effects via function calls
+ *   (`SELECT pg_advisory_lock(...)`, `SELECT lo_import('/etc/passwd')`, CTEs
+ *   with DML in Postgres 9.1+). Callers that need stronger guarantees should
+ *   combine this check with a runtime mechanism: for PostgreSQL, execute the
+ *   statement inside a dedicated client's `BEGIN READ ONLY … ROLLBACK`
+ *   transaction (see `LakebasePlugin.runReadOnlyStatement`). A batched
+ *   `pool.query("BEGIN READ ONLY; <stmt>; ROLLBACK")` cannot be used because
+ *   the Postgres Extended Query protocol rejects multi-statement prepared
+ *   queries, which silently breaks parameterized SQL.
+ */
+
+const READ_ONLY_KEYWORDS = new Set([
+  "SELECT",
+  "WITH",
+  "SHOW",
+  "EXPLAIN",
+  "DESCRIBE",
+  "DESC",
+]);
+
+type SqlReadOnlyResult =
+  | { readOnly: true; statements: number }
+  | { readOnly: false; reason: string };
+
+/**
+ * Classify a SQL string as read-only or not. See module docstring for the
+ * precise guarantee this offers.
+ */
+export function classifyReadOnly(sql: string): SqlReadOnlyResult {
+  const strip = stripCommentsAndQuoted(sql);
+  if (strip.unterminated) {
+    return {
+      readOnly: false,
+      reason: `SQL has an unterminated ${strip.unterminated} literal`,
+    };
+  }
+  const statements = splitStatements(strip.cleaned);
+
+  if (statements.length === 0) {
+    return {
+      readOnly: false,
+      reason: "SQL is empty or contains only comments",
+    };
+  }
+
+  for (let i = 0; i < statements.length; i++) {
+    const stmt = statements[i];
+    const firstWord = firstKeyword(stmt);
+    if (!firstWord) {
+      return {
+        readOnly: false,
+        reason: `statement ${i + 1} of ${statements.length} is empty`,
+      };
+    }
+    if (!READ_ONLY_KEYWORDS.has(firstWord.toUpperCase())) {
+      return {
+        readOnly: false,
+        reason: `statement starts with '${firstWord}'; only SELECT, WITH, SHOW, EXPLAIN, DESCRIBE, DESC are allowed in read-only mode`,
+      };
+    }
+  }
+
+  return { readOnly: true, statements: statements.length };
+}
+
+/**
+ * Assert `sql` is read-only or throw {@link ReadOnlySqlViolation}. Suitable
+ * for calling from agent-tool handlers where the thrown string surfaces back
+ * to the LLM as the tool's error output.
+ */
+export function assertReadOnlySql(sql: string): void {
+  const result = classifyReadOnly(sql);
+  if (!result.readOnly) {
+    throw new ReadOnlySqlViolation(result.reason);
+  }
+}
+
+export class ReadOnlySqlViolation extends Error {
+  constructor(reason: string) {
+    super(`SQL read-only policy violation: ${reason}`);
+    this.name = "ReadOnlySqlViolation";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tokenizer helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk `sql` character-by-character and replace every string literal,
+ * identifier quote, and comment body with a single space of equivalent
+ * length. Leaves structural tokens (semicolons, whitespace, identifiers,
+ * operators) in place.
+ *
+ * Handles:
+ * - `-- line comments` through end-of-line
+ * - SQL block comments (slash-star ... star-slash) with correct nesting (PostgreSQL)
+ * - `'single-quoted strings'` with `''` escape
+ * - `"double-quoted identifiers"` with `""` escape (ANSI)
+ * - `` `backtick identifiers` `` (Databricks)
+ * - `$tag$dollar quoted$tag$` strings (PostgreSQL)
+ * - `E'escape-style'` strings (PostgreSQL)
+ */
+type StripResult = {
+  cleaned: string;
+  /** Non-null if tokenization ended inside an unterminated literal or comment. */
+  unterminated:
+    | null
+    | "string"
+    | "identifier"
+    | "block comment"
+    | "dollar-quoted string";
+};
+
+function stripCommentsAndQuoted(sql: string): StripResult {
+  const out: string[] = [];
+  let i = 0;
+  const n = sql.length;
+  let unterminated: StripResult["unterminated"] = null;
+
+  while (i < n) {
+    const ch = sql[i];
+    const next = i + 1 < n ? sql[i + 1] : "";
+
+    if (ch === "-" && next === "-") {
+      out.push("  ");
+      i += 2;
+      while (i < n && sql[i] !== "\n") {
+        out.push(" ");
+        i++;
+      }
+      continue;
+    }
+
+    if (ch === "/" && next === "*") {
+      out.push("  ");
+      i += 2;
+      let depth = 1;
+      while (i < n && depth > 0) {
+        if (sql[i] === "/" && sql[i + 1] === "*") {
+          out.push("  ");
+          i += 2;
+          depth++;
+          continue;
+        }
+        if (sql[i] === "*" && sql[i + 1] === "/") {
+          out.push("  ");
+          i += 2;
+          depth--;
+          continue;
+        }
+        out.push(sql[i] === "\n" ? "\n" : " ");
+        i++;
+      }
+      if (depth > 0) {
+        unterminated = "block comment";
+      }
+      continue;
+    }
+
+    if (
+      ch === "'" ||
+      (ch === "E" && next === "'") ||
+      (ch === "e" && next === "'")
+    ) {
+      if (ch === "E" || ch === "e") {
+        out.push(" ");
+        i++;
+      }
+      out.push(" ");
+      i++;
+      let closed = false;
+      while (i < n) {
+        if (sql[i] === "'" && sql[i + 1] === "'") {
+          out.push("  ");
+          i += 2;
+          continue;
+        }
+        if (sql[i] === "\\" && sql[i + 1]) {
+          out.push("  ");
+          i += 2;
+          continue;
+        }
+        if (sql[i] === "'") {
+          out.push(" ");
+          i++;
+          closed = true;
+          break;
+        }
+        out.push(sql[i] === "\n" ? "\n" : " ");
+        i++;
+      }
+      if (!closed) unterminated = "string";
+      continue;
+    }
+
+    if (ch === '"') {
+      out.push(" ");
+      i++;
+      let closed = false;
+      while (i < n) {
+        if (sql[i] === '"' && sql[i + 1] === '"') {
+          out.push("  ");
+          i += 2;
+          continue;
+        }
+        if (sql[i] === '"') {
+          out.push(" ");
+          i++;
+          closed = true;
+          break;
+        }
+        out.push(sql[i] === "\n" ? "\n" : " ");
+        i++;
+      }
+      if (!closed) unterminated = "identifier";
+      continue;
+    }
+
+    if (ch === "`") {
+      out.push(" ");
+      i++;
+      let closed = false;
+      while (i < n) {
+        if (sql[i] === "`" && sql[i + 1] === "`") {
+          out.push("  ");
+          i += 2;
+          continue;
+        }
+        if (sql[i] === "`") {
+          out.push(" ");
+          i++;
+          closed = true;
+          break;
+        }
+        out.push(sql[i] === "\n" ? "\n" : " ");
+        i++;
+      }
+      if (!closed) unterminated = "identifier";
+      continue;
+    }
+
+    if (ch === "$") {
+      const tagMatch = sql.slice(i).match(/^\$([A-Za-z_][A-Za-z0-9_]*)?\$/);
+      if (tagMatch) {
+        const tag = tagMatch[0];
+        out.push(" ".repeat(tag.length));
+        i += tag.length;
+        const closeIdx = sql.indexOf(tag, i);
+        if (closeIdx === -1) {
+          while (i < n) {
+            out.push(sql[i] === "\n" ? "\n" : " ");
+            i++;
+          }
+          unterminated = "dollar-quoted string";
+        } else {
+          while (i < closeIdx) {
+            out.push(sql[i] === "\n" ? "\n" : " ");
+            i++;
+          }
+          out.push(" ".repeat(tag.length));
+          i += tag.length;
+        }
+        continue;
+      }
+    }
+
+    out.push(ch);
+    i++;
+  }
+
+  return { cleaned: out.join(""), unterminated };
+}
+
+/** Split on unquoted `;`, trim, drop empty segments. */
+function splitStatements(cleanedSql: string): string[] {
+  return cleanedSql
+    .split(";")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/** Return the first bareword keyword of a statement, or null if empty. */
+function firstKeyword(stmt: string): string | null {
+  const match = stmt.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)/);
+  return match ? match[1] : null;
+}

--- a/packages/appkit/src/core/agent/tools/tool.ts
+++ b/packages/appkit/src/core/agent/tools/tool.ts
@@ -1,0 +1,53 @@
+import type { z } from "zod";
+import type { FunctionTool } from "./function-tool";
+import { toToolJSONSchema } from "./json-schema";
+
+export interface ToolConfig<S extends z.ZodType> {
+  name: string;
+  description?: string;
+  schema: S;
+  execute: (args: z.infer<S>) => Promise<string> | string;
+}
+
+/**
+ * Factory for defining function tools with Zod schemas.
+ *
+ * - Generates JSON Schema (for the LLM) from the Zod schema via `z.toJSONSchema()`.
+ * - Infers the `execute` argument type from the schema.
+ * - Validates tool call arguments at runtime. On validation failure, returns
+ *   a formatted error string to the LLM instead of throwing, so the model
+ *   can self-correct on its next turn.
+ */
+export function tool<S extends z.ZodType>(config: ToolConfig<S>): FunctionTool {
+  const parameters = toToolJSONSchema(config.schema) as unknown as Record<
+    string,
+    unknown
+  >;
+
+  return {
+    type: "function",
+    name: config.name,
+    description: config.description ?? config.name,
+    parameters,
+    execute: async (args: Record<string, unknown>) => {
+      const parsed = config.schema.safeParse(args);
+      if (!parsed.success) {
+        return formatZodError(parsed.error, config.name);
+      }
+      return config.execute(parsed.data as z.infer<S>);
+    },
+  };
+}
+
+/**
+ * Formats a Zod validation error into an LLM-friendly string.
+ *
+ * Example: `Invalid arguments for get_weather: city: Invalid input: expected string, received undefined`
+ */
+export function formatZodError(error: z.ZodError, toolName: string): string {
+  const parts = error.issues.map((issue) => {
+    const field = issue.path.length > 0 ? issue.path.join(".") : "(root)";
+    return `${field}: ${issue.message}`;
+  });
+  return `Invalid arguments for ${toolName}: ${parts.join("; ")}`;
+}

--- a/packages/appkit/src/core/agent/types.ts
+++ b/packages/appkit/src/core/agent/types.ts
@@ -1,0 +1,54 @@
+import type { AgentToolDefinition, ToolAnnotations } from "shared";
+import type { FunctionTool } from "./tools/function-tool";
+import type { HostedTool } from "./tools/hosted-tools";
+
+/**
+ * A tool reference produced by a plugin's `.toolkit()` call. The agents plugin
+ * recognizes the `__toolkitRef` brand and dispatches tool invocations through
+ * `PluginContext.executeTool(req, pluginName, localName, ...)`, preserving
+ * OBO (asUser) and telemetry spans.
+ */
+export interface ToolkitEntry {
+  readonly __toolkitRef: true;
+  pluginName: string;
+  localName: string;
+  def: AgentToolDefinition;
+  annotations?: ToolAnnotations;
+  /**
+   * Whether this tool is eligible for `autoInheritTools` spreading. Mirrors
+   * {@link ToolEntry.autoInheritable} from the source registry so the agents
+   * plugin can filter auto-inherited tools without re-walking the provider's
+   * internal registry.
+   */
+  autoInheritable?: boolean;
+}
+
+/**
+ * Any tool an agent can invoke: inline function tools (`tool()`), hosted MCP
+ * tools (`mcpServer()` / raw hosted), or toolkit references from plugins
+ * (`analytics().toolkit()`).
+ */
+export type AgentTool = FunctionTool | HostedTool | ToolkitEntry;
+
+export interface ToolkitOptions {
+  /** Key prefix to prepend to each tool's local name. Defaults to `${pluginName}.`. */
+  prefix?: string;
+  /** Only include tools whose local name matches one of these. */
+  only?: string[];
+  /** Exclude tools whose local name matches one of these. */
+  except?: string[];
+  /** Remap specific local names to different keys (applied after prefix). */
+  rename?: Record<string, string>;
+}
+
+/**
+ * Type guard for `ToolkitEntry` — used to differentiate toolkit references
+ * from inline tools in a mixed `tools` record.
+ */
+export function isToolkitEntry(value: unknown): value is ToolkitEntry {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { __toolkitRef?: unknown }).__toolkitRef === true
+  );
+}

--- a/packages/appkit/src/core/appkit.ts
+++ b/packages/appkit/src/core/appkit.ts
@@ -14,15 +14,19 @@ import { createLogger } from "../logging/logger";
 import { ResourceRegistry, ResourceType } from "../registry";
 import type { TelemetryConfig } from "../telemetry";
 import { TelemetryManager } from "../telemetry";
+import { isToolProvider, PluginContext } from "./plugin-context";
 
 const logger = createLogger("appkit");
 
 export class AppKit<TPlugins extends InputPluginMap> {
   #pluginInstances: Record<string, BasePlugin> = {};
   #setupPromises: Promise<void>[] = [];
+  #context: PluginContext;
 
   private constructor(config: { plugins: TPlugins }) {
     const { plugins, ...globalConfig } = config;
+
+    this.#context = new PluginContext();
 
     const pluginEntries = Object.entries(plugins);
 
@@ -38,20 +42,24 @@ export class AppKit<TPlugins extends InputPluginMap> {
 
     for (const [name, pluginData] of corePlugins) {
       if (pluginData) {
-        this.createAndRegisterPlugin(globalConfig, name, pluginData);
+        this.createAndRegisterPlugin(globalConfig, name, pluginData, {
+          context: this.#context,
+        });
       }
     }
 
     for (const [name, pluginData] of normalPlugins) {
       if (pluginData) {
-        this.createAndRegisterPlugin(globalConfig, name, pluginData);
+        this.createAndRegisterPlugin(globalConfig, name, pluginData, {
+          context: this.#context,
+        });
       }
     }
 
     for (const [name, pluginData] of deferredPlugins) {
       if (pluginData) {
         this.createAndRegisterPlugin(globalConfig, name, pluginData, {
-          plugins: this.#pluginInstances,
+          context: this.#context,
         });
       }
     }
@@ -73,7 +81,19 @@ export class AppKit<TPlugins extends InputPluginMap> {
     };
     const pluginInstance = new Plugin(baseConfig);
 
+    if (typeof pluginInstance.attachContext === "function") {
+      pluginInstance.attachContext({
+        context: this.#context,
+        telemetryConfig: baseConfig.telemetry,
+      });
+    }
+
     this.#pluginInstances[name] = pluginInstance;
+
+    this.#context.registerPlugin(name, pluginInstance);
+    if (isToolProvider(pluginInstance)) {
+      this.#context.registerToolProvider(name, pluginInstance);
+    }
 
     this.#setupPromises.push(pluginInstance.setup());
 
@@ -203,6 +223,7 @@ export class AppKit<TPlugins extends InputPluginMap> {
     const instance = new AppKit(mergedConfig);
 
     await Promise.all(instance.#setupPromises);
+    await instance.#context.emitLifecycle("setup:complete");
 
     const handle = instance as unknown as PluginMap<T>;
 

--- a/packages/appkit/src/core/plugin-context.ts
+++ b/packages/appkit/src/core/plugin-context.ts
@@ -1,0 +1,287 @@
+import type express from "express";
+import type { BasePlugin, ToolProvider } from "shared";
+import { createLogger } from "../logging/logger";
+import { TelemetryManager } from "../telemetry";
+
+const logger = createLogger("plugin-context");
+
+interface BufferedRoute {
+  method: string;
+  path: string;
+  handlers: express.RequestHandler[];
+}
+
+interface RouteTarget {
+  addExtension(fn: (app: express.Application) => void): void;
+}
+
+interface ToolProviderEntry {
+  plugin: BasePlugin & ToolProvider;
+  name: string;
+}
+
+type LifecycleEvent = "setup:complete" | "server:ready" | "shutdown";
+
+/**
+ * Mediator for inter-plugin communication.
+ *
+ * Created by AppKit core and passed to every plugin. Plugins request
+ * capabilities from the context instead of holding direct references
+ * to sibling plugin instances.
+ *
+ * Capabilities:
+ * - Route mounting with buffering (order-independent)
+ * - Typed ToolProvider registry (live, not snapshot-based)
+ * - User-scoped tool execution with automatic telemetry
+ * - Lifecycle hooks for plugin coordination
+ */
+export class PluginContext {
+  private routeBuffer: BufferedRoute[] = [];
+  private routeTarget: RouteTarget | null = null;
+  private toolProviders = new Map<string, ToolProviderEntry>();
+  private plugins = new Map<string, BasePlugin>();
+  private lifecycleHooks = new Map<
+    LifecycleEvent,
+    Set<() => void | Promise<void>>
+  >();
+  private telemetry = TelemetryManager.getProvider("plugin-context");
+
+  /**
+   * Register a route on the root Express application.
+   *
+   * If a route target (server plugin) has registered, the route is applied
+   * immediately. Otherwise it is buffered and flushed when a route target
+   * becomes available.
+   */
+  addRoute(
+    method: string,
+    path: string,
+    ...handlers: express.RequestHandler[]
+  ): void {
+    if (this.routeTarget) {
+      this.applyRoute({ method, path, handlers });
+    } else {
+      this.routeBuffer.push({ method, path, handlers });
+    }
+  }
+
+  /**
+   * Register middleware on the root Express application.
+   *
+   * Same buffering semantics as `addRoute`.
+   */
+  addMiddleware(path: string, ...handlers: express.RequestHandler[]): void {
+    if (this.routeTarget) {
+      this.applyMiddleware(path, handlers);
+    } else {
+      this.routeBuffer.push({ method: "use", path, handlers });
+    }
+  }
+
+  /**
+   * Called by the server plugin to opt in as the route target.
+   * Flushes all buffered routes via the server's `addExtension`.
+   */
+  registerAsRouteTarget(target: RouteTarget): void {
+    this.routeTarget = target;
+
+    for (const route of this.routeBuffer) {
+      if (route.method === "use") {
+        this.applyMiddleware(route.path, route.handlers);
+      } else {
+        this.applyRoute(route);
+      }
+    }
+    this.routeBuffer = [];
+  }
+
+  /**
+   * Register a plugin that implements the ToolProvider interface.
+   * Called by AppKit core after constructing each plugin.
+   */
+  registerToolProvider(name: string, plugin: BasePlugin & ToolProvider): void {
+    this.toolProviders.set(name, { plugin, name });
+  }
+
+  /**
+   * Register a plugin instance.
+   * Called by AppKit core after constructing each plugin.
+   */
+  registerPlugin(name: string, instance: BasePlugin): void {
+    this.plugins.set(name, instance);
+  }
+
+  /**
+   * Returns all registered plugin instances keyed by name.
+   * Used by the server plugin for route injection, client config,
+   * and shutdown coordination.
+   */
+  getPlugins(): Map<string, BasePlugin> {
+    return this.plugins;
+  }
+
+  /**
+   * Returns all registered ToolProvider plugins.
+   * Always returns the current set — not a frozen snapshot.
+   */
+  getToolProviders(): Array<{ name: string; provider: ToolProvider }> {
+    return Array.from(this.toolProviders.values()).map((entry) => ({
+      name: entry.name,
+      provider: entry.plugin,
+    }));
+  }
+
+  /**
+   * Execute a tool on a ToolProvider plugin with automatic user scoping
+   * and telemetry.
+   *
+   * The context:
+   * 1. Resolves the plugin by name
+   * 2. Calls `asUser(req)` for user-scoped execution
+   * 3. Wraps the call in a telemetry span with a 30s timeout
+   */
+  async executeTool(
+    req: express.Request,
+    pluginName: string,
+    toolName: string,
+    args: unknown,
+    signal?: AbortSignal,
+  ): Promise<unknown> {
+    const entry = this.toolProviders.get(pluginName);
+    if (!entry) {
+      throw new Error(
+        `PluginContext: unknown plugin "${pluginName}". Available: ${Array.from(this.toolProviders.keys()).join(", ")}`,
+      );
+    }
+
+    const tracer = this.telemetry.getTracer();
+    const operationName = `executeTool:${pluginName}.${toolName}`;
+
+    return tracer.startActiveSpan(operationName, async (span) => {
+      const timeout = 30_000;
+      const timeoutSignal = AbortSignal.timeout(timeout);
+      const combinedSignal = signal
+        ? AbortSignal.any([signal, timeoutSignal])
+        : timeoutSignal;
+
+      try {
+        const userPlugin = (entry.plugin as any).asUser(req);
+        const result = await (userPlugin as ToolProvider).executeAgentTool(
+          toolName,
+          args,
+          combinedSignal,
+        );
+        span.setStatus({ code: 0 });
+        return result;
+      } catch (error) {
+        span.setStatus({
+          code: 2,
+          message:
+            error instanceof Error ? error.message : "Tool execution failed",
+        });
+        span.recordException(
+          error instanceof Error ? error : new Error(String(error)),
+        );
+        throw error;
+      } finally {
+        span.end();
+      }
+    });
+  }
+
+  /**
+   * Register a lifecycle hook callback.
+   */
+  onLifecycle(event: LifecycleEvent, fn: () => void | Promise<void>): void {
+    let hooks = this.lifecycleHooks.get(event);
+    if (!hooks) {
+      hooks = new Set();
+      this.lifecycleHooks.set(event, hooks);
+    }
+    hooks.add(fn);
+  }
+
+  /**
+   * Emit a lifecycle event, calling all registered callbacks.
+   * Errors in individual callbacks are logged but do not prevent
+   * other callbacks from running.
+   *
+   * @internal Called by AppKit core only.
+   */
+  async emitLifecycle(event: LifecycleEvent): Promise<void> {
+    const hooks = this.lifecycleHooks.get(event);
+    if (!hooks) return;
+
+    if (
+      event === "setup:complete" &&
+      this.routeBuffer.length > 0 &&
+      !this.routeTarget
+    ) {
+      logger.warn(
+        "%d buffered routes were never applied — no server plugin registered as route target",
+        this.routeBuffer.length,
+      );
+    }
+
+    for (const fn of hooks) {
+      try {
+        await fn();
+      } catch (error) {
+        logger.error("Lifecycle hook '%s' failed: %O", event, error);
+      }
+    }
+  }
+
+  /**
+   * Returns all registered plugin names.
+   */
+  getPluginNames(): string[] {
+    return Array.from(this.plugins.keys());
+  }
+
+  /**
+   * Check if a plugin with the given name is registered.
+   */
+  hasPlugin(name: string): boolean {
+    return this.plugins.has(name);
+  }
+
+  private applyRoute(route: BufferedRoute): void {
+    if (!this.routeTarget) return;
+    this.routeTarget.addExtension((app) => {
+      const method = route.method.toLowerCase() as keyof express.Application;
+      if (typeof app[method] === "function") {
+        (app[method] as (...a: unknown[]) => void)(
+          route.path,
+          ...route.handlers,
+        );
+      }
+    });
+  }
+
+  private applyMiddleware(
+    path: string,
+    handlers: express.RequestHandler[],
+  ): void {
+    if (!this.routeTarget) return;
+    this.routeTarget.addExtension((app) => {
+      app.use(path, ...handlers);
+    });
+  }
+}
+
+/**
+ * Type guard: checks whether a plugin implements the ToolProvider interface.
+ */
+export function isToolProvider(
+  plugin: unknown,
+): plugin is BasePlugin & ToolProvider {
+  return (
+    typeof plugin === "object" &&
+    plugin !== null &&
+    "getAgentTools" in plugin &&
+    typeof (plugin as ToolProvider).getAgentTools === "function" &&
+    "executeAgentTool" in plugin &&
+    typeof (plugin as ToolProvider).executeAgentTool === "function"
+  );
+}

--- a/packages/appkit/src/core/plugin-context.ts
+++ b/packages/appkit/src/core/plugin-context.ts
@@ -1,7 +1,7 @@
 import type express from "express";
-import type { BasePlugin, ToolProvider } from "shared";
+import type { BasePlugin, IAppRequest, ToolProvider } from "shared";
 import { createLogger } from "../logging/logger";
-import { TelemetryManager } from "../telemetry";
+import { SpanStatusCode, TelemetryManager } from "../telemetry";
 
 const logger = createLogger("plugin-context");
 
@@ -15,10 +15,14 @@ interface RouteTarget {
   addExtension(fn: (app: express.Application) => void): void;
 }
 
-interface ToolProviderEntry {
-  plugin: BasePlugin & ToolProvider;
-  name: string;
-}
+/**
+ * A tool-provider plugin that also exposes user-scoped execution. Plugins
+ * derived from {@link Plugin} satisfy this implicitly because `asUser` lives
+ * on the base class. {@link isToolProvider} narrows to this shape so
+ * `executeTool` can call `asUser` without an unsafe cast.
+ */
+type ToolProviderPlugin = BasePlugin &
+  ToolProvider & { asUser: (req: IAppRequest) => ToolProvider };
 
 type LifecycleEvent = "setup:complete" | "server:ready" | "shutdown";
 
@@ -38,7 +42,7 @@ type LifecycleEvent = "setup:complete" | "server:ready" | "shutdown";
 export class PluginContext {
   private routeBuffer: BufferedRoute[] = [];
   private routeTarget: RouteTarget | null = null;
-  private toolProviders = new Map<string, ToolProviderEntry>();
+  private toolProviders = new Map<string, ToolProviderPlugin>();
   private plugins = new Map<string, BasePlugin>();
   private lifecycleHooks = new Map<
     LifecycleEvent,
@@ -81,8 +85,19 @@ export class PluginContext {
   /**
    * Called by the server plugin to opt in as the route target.
    * Flushes all buffered routes via the server's `addExtension`.
+   *
+   * Only the first caller wins — subsequent calls are ignored with a warning.
+   * In practice only the server plugin registers, but a misconfigured app
+   * (two server plugins, or duplicate AppKit setup in tests) would otherwise
+   * silently drop the first target's later extensions.
    */
   registerAsRouteTarget(target: RouteTarget): void {
+    if (this.routeTarget) {
+      logger.warn(
+        "registerAsRouteTarget called more than once; ignoring duplicate registration",
+      );
+      return;
+    }
     this.routeTarget = target;
 
     for (const route of this.routeBuffer) {
@@ -98,9 +113,19 @@ export class PluginContext {
   /**
    * Register a plugin that implements the ToolProvider interface.
    * Called by AppKit core after constructing each plugin.
+   *
+   * Plugin names should be unique (they are derived from `manifest.name`).
+   * A duplicate registration overwrites the previous entry and emits a
+   * warning so the misconfiguration is visible in startup logs.
    */
-  registerToolProvider(name: string, plugin: BasePlugin & ToolProvider): void {
-    this.toolProviders.set(name, { plugin, name });
+  registerToolProvider(name: string, plugin: ToolProviderPlugin): void {
+    if (this.toolProviders.has(name)) {
+      logger.warn(
+        'Tool provider "%s" registered more than once; the previous registration is being overwritten',
+        name,
+      );
+    }
+    this.toolProviders.set(name, plugin);
   }
 
   /**
@@ -114,9 +139,10 @@ export class PluginContext {
   /**
    * Returns all registered plugin instances keyed by name.
    * Used by the server plugin for route injection, client config,
-   * and shutdown coordination.
+   * and shutdown coordination. The returned map is read-only at the
+   * type level — callers must not mutate the live registry.
    */
-  getPlugins(): Map<string, BasePlugin> {
+  getPlugins(): ReadonlyMap<string, BasePlugin> {
     return this.plugins;
   }
 
@@ -125,9 +151,9 @@ export class PluginContext {
    * Always returns the current set — not a frozen snapshot.
    */
   getToolProviders(): Array<{ name: string; provider: ToolProvider }> {
-    return Array.from(this.toolProviders.values()).map((entry) => ({
-      name: entry.name,
-      provider: entry.plugin,
+    return Array.from(this.toolProviders.entries()).map(([name, provider]) => ({
+      name,
+      provider,
     }));
   }
 
@@ -147,8 +173,8 @@ export class PluginContext {
     args: unknown,
     signal?: AbortSignal,
   ): Promise<unknown> {
-    const entry = this.toolProviders.get(pluginName);
-    if (!entry) {
+    const provider = this.toolProviders.get(pluginName);
+    if (!provider) {
       throw new Error(
         `PluginContext: unknown plugin "${pluginName}". Available: ${Array.from(this.toolProviders.keys()).join(", ")}`,
       );
@@ -165,17 +191,17 @@ export class PluginContext {
         : timeoutSignal;
 
       try {
-        const userPlugin = (entry.plugin as any).asUser(req);
-        const result = await (userPlugin as ToolProvider).executeAgentTool(
+        const userScoped = provider.asUser(req);
+        const result = await userScoped.executeAgentTool(
           toolName,
           args,
           combinedSignal,
         );
-        span.setStatus({ code: 0 });
+        span.setStatus({ code: SpanStatusCode.OK });
         return result;
       } catch (error) {
         span.setStatus({
-          code: 2,
+          code: SpanStatusCode.ERROR,
           message:
             error instanceof Error ? error.message : "Tool execution failed",
         });
@@ -223,7 +249,10 @@ export class PluginContext {
       );
     }
 
-    for (const fn of hooks) {
+    // Snapshot before iterating so a callback that registers a new hook for
+    // the same event does not mutate the loop. ECMAScript Set iteration would
+    // otherwise visit late-added entries, risking unexpected re-entry.
+    for (const fn of [...hooks]) {
       try {
         await fn();
       } catch (error) {
@@ -271,17 +300,20 @@ export class PluginContext {
 }
 
 /**
- * Type guard: checks whether a plugin implements the ToolProvider interface.
+ * Type guard: checks whether a plugin implements the ToolProvider interface
+ * and exposes the user-scoped `asUser` helper that the {@link Plugin} base
+ * class provides. Narrowing to {@link ToolProviderPlugin} lets `executeTool`
+ * call `asUser` without an unsafe cast.
  */
-export function isToolProvider(
-  plugin: unknown,
-): plugin is BasePlugin & ToolProvider {
+export function isToolProvider(plugin: unknown): plugin is ToolProviderPlugin {
   return (
     typeof plugin === "object" &&
     plugin !== null &&
     "getAgentTools" in plugin &&
     typeof (plugin as ToolProvider).getAgentTools === "function" &&
     "executeAgentTool" in plugin &&
-    typeof (plugin as ToolProvider).executeAgentTool === "function"
+    typeof (plugin as ToolProvider).executeAgentTool === "function" &&
+    "asUser" in plugin &&
+    typeof (plugin as { asUser?: unknown }).asUser === "function"
   );
 }

--- a/packages/appkit/src/core/tests/databricks.test.ts
+++ b/packages/appkit/src/core/tests/databricks.test.ts
@@ -109,11 +109,11 @@ class DeferredTestPlugin implements BasePlugin {
   name = "deferredTest";
   setupCalled = false;
   injectedConfig: any;
-  injectedPlugins: any;
+  injectedContext: any;
 
   constructor(config: any) {
     this.injectedConfig = config;
-    this.injectedPlugins = config.plugins;
+    this.injectedContext = config.context;
   }
 
   async setup() {
@@ -130,7 +130,7 @@ class DeferredTestPlugin implements BasePlugin {
     return {
       setupCalled: this.setupCalled,
       injectedConfig: this.injectedConfig,
-      injectedPlugins: this.injectedPlugins,
+      injectedContext: this.injectedContext,
     };
   }
 }
@@ -276,7 +276,7 @@ describe("AppKit", () => {
       expect(setupOrder).toEqual(["core", "normal", "deferred"]);
     });
 
-    test("should provide plugin instances to deferred plugins", async () => {
+    test("should provide PluginContext to deferred plugins", async () => {
       const pluginData = [
         { plugin: CoreTestPlugin, config: {}, name: "coreTest" },
         { plugin: DeferredTestPlugin, config: {}, name: "deferredTest" },
@@ -284,10 +284,9 @@ describe("AppKit", () => {
 
       const instance = (await createApp({ plugins: pluginData })) as any;
 
-      // Deferred plugins receive plugin instances (not SDKs) for internal use
-      expect(instance.deferredTest.injectedPlugins).toBeDefined();
-      expect(instance.deferredTest.injectedPlugins.coreTest).toBeInstanceOf(
-        CoreTestPlugin,
+      expect(instance.deferredTest.injectedContext).toBeDefined();
+      expect(instance.deferredTest.injectedContext.hasPlugin("coreTest")).toBe(
+        true,
       );
     });
 

--- a/packages/appkit/src/core/tests/plugin-context.test.ts
+++ b/packages/appkit/src/core/tests/plugin-context.test.ts
@@ -2,22 +2,41 @@ import type { AgentToolDefinition } from "shared";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { isToolProvider, PluginContext } from "../plugin-context";
 
-vi.mock("../../telemetry", () => ({
-  TelemetryManager: {
-    getProvider: () => ({
-      getTracer: () => ({
-        startActiveSpan: (_name: string, fn: (span: any) => any) => {
-          const span = {
-            setStatus: vi.fn(),
-            recordException: vi.fn(),
-            end: vi.fn(),
-          };
-          return fn(span);
-        },
+/**
+ * Holds the most recent mock span instance so tests can assert against
+ * `setStatus` / `recordException` / `end` calls without relying on global
+ * spies. The PluginContext mock below repopulates this on every
+ * `startActiveSpan` call.
+ */
+const lastSpan: {
+  setStatus: ReturnType<typeof vi.fn>;
+  recordException: ReturnType<typeof vi.fn>;
+  end: ReturnType<typeof vi.fn>;
+} = {
+  setStatus: vi.fn(),
+  recordException: vi.fn(),
+  end: vi.fn(),
+};
+
+vi.mock("../../telemetry", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../telemetry")>("../../telemetry");
+  return {
+    ...actual,
+    TelemetryManager: {
+      getProvider: () => ({
+        getTracer: () => ({
+          startActiveSpan: (_name: string, fn: (span: unknown) => unknown) => {
+            lastSpan.setStatus = vi.fn();
+            lastSpan.recordException = vi.fn();
+            lastSpan.end = vi.fn();
+            return fn(lastSpan);
+          },
+        }),
       }),
-    }),
-  },
-}));
+    },
+  };
+});
 
 vi.mock("../../logging/logger", () => ({
   createLogger: () => ({
@@ -164,6 +183,18 @@ describe("PluginContext", () => {
       const after = ctx.getToolProviders();
       expect(after).toHaveLength(1);
     });
+
+    test("duplicate registerToolProvider name overwrites and exposes only the latest", () => {
+      const first = createMockToolProvider();
+      const second = createMockToolProvider();
+
+      ctx.registerToolProvider("analytics", first);
+      ctx.registerToolProvider("analytics", second);
+
+      const providers = ctx.getToolProviders();
+      expect(providers).toHaveLength(1);
+      expect(providers[0].provider).toBe(second);
+    });
   });
 
   describe("executeTool", () => {
@@ -202,6 +233,39 @@ describe("PluginContext", () => {
       await expect(
         ctx.executeTool(mockReq, "analytics", "query", {}),
       ).rejects.toThrow("Query failed");
+    });
+
+    test("marks the span OK on success and ends it", async () => {
+      const { SpanStatusCode } = await import("../../telemetry");
+      const provider = createMockToolProvider();
+      ctx.registerToolProvider("analytics", provider);
+
+      await ctx.executeTool({ headers: {} } as any, "analytics", "query", {});
+
+      expect(lastSpan.setStatus).toHaveBeenCalledWith({
+        code: SpanStatusCode.OK,
+      });
+      expect(lastSpan.recordException).not.toHaveBeenCalled();
+      expect(lastSpan.end).toHaveBeenCalledTimes(1);
+    });
+
+    test("marks the span ERROR with message on failure and records the exception", async () => {
+      const { SpanStatusCode } = await import("../../telemetry");
+      const provider = createMockToolProvider();
+      const failure = new Error("Query failed");
+      (provider.executeAgentTool as any).mockRejectedValue(failure);
+      ctx.registerToolProvider("analytics", provider);
+
+      await expect(
+        ctx.executeTool({ headers: {} } as any, "analytics", "query", {}),
+      ).rejects.toThrow("Query failed");
+
+      expect(lastSpan.setStatus).toHaveBeenCalledWith({
+        code: SpanStatusCode.ERROR,
+        message: "Query failed",
+      });
+      expect(lastSpan.recordException).toHaveBeenCalledWith(failure);
+      expect(lastSpan.end).toHaveBeenCalledTimes(1);
     });
 
     test("passes abort signal to executeAgentTool", async () => {
@@ -260,6 +324,43 @@ describe("PluginContext", () => {
 
     test("emitLifecycle with no registered hooks does nothing", async () => {
       await expect(ctx.emitLifecycle("server:ready")).resolves.toBeUndefined();
+    });
+
+    test("a callback that registers another hook for the same event does not re-enter the loop", async () => {
+      // Snapshot semantics: late-added hooks must not be visited by the
+      // current emit pass, otherwise ECMAScript Set iteration would re-enter
+      // and a self-registering hook would loop indefinitely.
+      const recorded: string[] = [];
+      const second = vi.fn(() => {
+        recorded.push("second");
+      });
+      const first = vi.fn(() => {
+        recorded.push("first");
+        ctx.onLifecycle("setup:complete", second);
+      });
+      ctx.onLifecycle("setup:complete", first);
+
+      await ctx.emitLifecycle("setup:complete");
+
+      expect(recorded).toEqual(["first"]);
+      expect(second).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("registerAsRouteTarget", () => {
+    test("ignores duplicate registration and warns", () => {
+      const first = { addExtension: vi.fn() };
+      const second = { addExtension: vi.fn() };
+
+      ctx.registerAsRouteTarget(first);
+      ctx.registerAsRouteTarget(second);
+
+      const handler = vi.fn();
+      ctx.addRoute("get", "/late", handler);
+
+      // The late route must reach the first target only.
+      expect(first.addExtension).toHaveBeenCalledTimes(1);
+      expect(second.addExtension).not.toHaveBeenCalled();
     });
   });
 
@@ -321,5 +422,16 @@ describe("isToolProvider", () => {
     expect(isToolProvider("string")).toBe(false);
     expect(isToolProvider(42)).toBe(false);
     expect(isToolProvider(undefined)).toBe(false);
+  });
+
+  test("returns false for objects missing asUser", () => {
+    // ToolProvider plugins must also expose user-scoped execution; the
+    // guard ensures executeTool can call asUser without an unsafe cast.
+    expect(
+      isToolProvider({
+        getAgentTools: vi.fn(),
+        executeAgentTool: vi.fn(),
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/appkit/src/core/tests/plugin-context.test.ts
+++ b/packages/appkit/src/core/tests/plugin-context.test.ts
@@ -1,0 +1,325 @@
+import type { AgentToolDefinition } from "shared";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { isToolProvider, PluginContext } from "../plugin-context";
+
+vi.mock("../../telemetry", () => ({
+  TelemetryManager: {
+    getProvider: () => ({
+      getTracer: () => ({
+        startActiveSpan: (_name: string, fn: (span: any) => any) => {
+          const span = {
+            setStatus: vi.fn(),
+            recordException: vi.fn(),
+            end: vi.fn(),
+          };
+          return fn(span);
+        },
+      }),
+    }),
+  },
+}));
+
+vi.mock("../../logging/logger", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+function createMockToolProvider(tools: AgentToolDefinition[] = []) {
+  const mock = {
+    name: "mock-plugin",
+    setup: vi.fn().mockResolvedValue(undefined),
+    injectRoutes: vi.fn(),
+    getEndpoints: vi.fn().mockReturnValue({}),
+    getAgentTools: vi.fn().mockReturnValue(tools),
+    executeAgentTool: vi.fn().mockResolvedValue("tool-result"),
+    asUser: vi.fn().mockReturnThis(),
+  };
+  return mock as any;
+}
+
+describe("PluginContext", () => {
+  let ctx: PluginContext;
+
+  beforeEach(() => {
+    ctx = new PluginContext();
+  });
+
+  describe("route buffering", () => {
+    test("addRoute buffers when no route target exists", () => {
+      const handler = vi.fn();
+      ctx.addRoute("post", "/invocations", handler);
+
+      expect(ctx.getPluginNames()).toEqual([]);
+    });
+
+    test("flushRoutes applies buffered routes via addExtension", () => {
+      const handler = vi.fn();
+      ctx.addRoute("post", "/invocations", handler);
+
+      const addExtension = vi.fn();
+      ctx.registerAsRouteTarget({ addExtension });
+
+      expect(addExtension).toHaveBeenCalledTimes(1);
+      const extensionFn = addExtension.mock.calls[0][0];
+
+      const mockApp = { post: vi.fn() };
+      extensionFn(mockApp);
+      expect(mockApp.post).toHaveBeenCalledWith("/invocations", handler);
+    });
+
+    test("addRoute called after registerAsRouteTarget applies immediately", () => {
+      const addExtension = vi.fn();
+      ctx.registerAsRouteTarget({ addExtension });
+
+      const handler = vi.fn();
+      ctx.addRoute("get", "/health", handler);
+
+      expect(addExtension).toHaveBeenCalledTimes(1);
+      const extensionFn = addExtension.mock.calls[0][0];
+
+      const mockApp = { get: vi.fn() };
+      extensionFn(mockApp);
+      expect(mockApp.get).toHaveBeenCalledWith("/health", handler);
+    });
+
+    test("addRoute supports middleware chains", () => {
+      const auth = vi.fn();
+      const handler = vi.fn();
+
+      const addExtension = vi.fn();
+      ctx.registerAsRouteTarget({ addExtension });
+
+      ctx.addRoute("post", "/api", auth, handler);
+
+      const extensionFn = addExtension.mock.calls[0][0];
+      const mockApp = { post: vi.fn() };
+      extensionFn(mockApp);
+      expect(mockApp.post).toHaveBeenCalledWith("/api", auth, handler);
+    });
+
+    test("addMiddleware buffers and applies via use()", () => {
+      const handler = vi.fn();
+      ctx.addMiddleware("/api", handler);
+
+      const addExtension = vi.fn();
+      ctx.registerAsRouteTarget({ addExtension });
+
+      expect(addExtension).toHaveBeenCalledTimes(1);
+      const extensionFn = addExtension.mock.calls[0][0];
+
+      const mockApp = { use: vi.fn() };
+      extensionFn(mockApp);
+      expect(mockApp.use).toHaveBeenCalledWith("/api", handler);
+    });
+
+    test("multiple buffered routes are all applied on registration", () => {
+      const h1 = vi.fn();
+      const h2 = vi.fn();
+      ctx.addRoute("post", "/a", h1);
+      ctx.addRoute("get", "/b", h2);
+
+      const addExtension = vi.fn();
+      ctx.registerAsRouteTarget({ addExtension });
+
+      expect(addExtension).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("ToolProvider registry", () => {
+    test("registerToolProvider makes provider visible via getToolProviders", () => {
+      const provider = createMockToolProvider([
+        {
+          name: "query",
+          description: "Run query",
+          parameters: { type: "object" },
+        },
+      ]);
+
+      ctx.registerToolProvider("analytics", provider);
+
+      const providers = ctx.getToolProviders();
+      expect(providers).toHaveLength(1);
+      expect(providers[0].name).toBe("analytics");
+      expect(providers[0].provider.getAgentTools()).toHaveLength(1);
+    });
+
+    test("getToolProviders returns all registered providers", () => {
+      ctx.registerToolProvider("analytics", createMockToolProvider());
+      ctx.registerToolProvider("files", createMockToolProvider());
+      ctx.registerToolProvider("genie", createMockToolProvider());
+
+      expect(ctx.getToolProviders()).toHaveLength(3);
+    });
+
+    test("getToolProviders returns current set, not snapshot", () => {
+      const before = ctx.getToolProviders();
+      expect(before).toHaveLength(0);
+
+      ctx.registerToolProvider("analytics", createMockToolProvider());
+
+      const after = ctx.getToolProviders();
+      expect(after).toHaveLength(1);
+    });
+  });
+
+  describe("executeTool", () => {
+    test("calls asUser(req).executeAgentTool on the correct plugin", async () => {
+      const provider = createMockToolProvider();
+      ctx.registerToolProvider("analytics", provider);
+
+      const mockReq = { headers: {} } as any;
+      await ctx.executeTool(mockReq, "analytics", "query", { sql: "SELECT 1" });
+
+      expect(provider.asUser).toHaveBeenCalledWith(mockReq);
+      expect(provider.executeAgentTool).toHaveBeenCalledWith(
+        "query",
+        { sql: "SELECT 1" },
+        expect.any(Object),
+      );
+    });
+
+    test("throws for unknown plugin name", async () => {
+      const mockReq = { headers: {} } as any;
+
+      await expect(
+        ctx.executeTool(mockReq, "nonexistent", "query", {}),
+      ).rejects.toThrow('unknown plugin "nonexistent"');
+    });
+
+    test("propagates tool execution errors", async () => {
+      const provider = createMockToolProvider();
+      (provider.executeAgentTool as any).mockRejectedValue(
+        new Error("Query failed"),
+      );
+      ctx.registerToolProvider("analytics", provider);
+
+      const mockReq = { headers: {} } as any;
+
+      await expect(
+        ctx.executeTool(mockReq, "analytics", "query", {}),
+      ).rejects.toThrow("Query failed");
+    });
+
+    test("passes abort signal to executeAgentTool", async () => {
+      const provider = createMockToolProvider();
+      ctx.registerToolProvider("analytics", provider);
+
+      const controller = new AbortController();
+      const mockReq = { headers: {} } as any;
+
+      await ctx.executeTool(
+        mockReq,
+        "analytics",
+        "query",
+        {},
+        controller.signal,
+      );
+
+      const callArgs = (provider.executeAgentTool as any).mock.calls[0];
+      expect(callArgs[2]).toBeDefined();
+    });
+  });
+
+  describe("lifecycle hooks", () => {
+    test("onLifecycle registers callback, emitLifecycle invokes it", async () => {
+      const fn = vi.fn();
+      ctx.onLifecycle("setup:complete", fn);
+
+      await ctx.emitLifecycle("setup:complete");
+
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    test("multiple callbacks for the same event all fire", async () => {
+      const fn1 = vi.fn();
+      const fn2 = vi.fn();
+      ctx.onLifecycle("setup:complete", fn1);
+      ctx.onLifecycle("setup:complete", fn2);
+
+      await ctx.emitLifecycle("setup:complete");
+
+      expect(fn1).toHaveBeenCalledTimes(1);
+      expect(fn2).toHaveBeenCalledTimes(1);
+    });
+
+    test("callback error does not prevent other callbacks from running", async () => {
+      const fn1 = vi.fn().mockRejectedValue(new Error("fail"));
+      const fn2 = vi.fn();
+      ctx.onLifecycle("shutdown", fn1);
+      ctx.onLifecycle("shutdown", fn2);
+
+      await ctx.emitLifecycle("shutdown");
+
+      expect(fn1).toHaveBeenCalled();
+      expect(fn2).toHaveBeenCalled();
+    });
+
+    test("emitLifecycle with no registered hooks does nothing", async () => {
+      await expect(ctx.emitLifecycle("server:ready")).resolves.toBeUndefined();
+    });
+  });
+
+  describe("plugin metadata", () => {
+    const stubPlugin = { name: "stub" } as any;
+
+    test("getPluginNames returns all registered names", () => {
+      ctx.registerPlugin("analytics", stubPlugin);
+      ctx.registerPlugin("server", stubPlugin);
+      ctx.registerPlugin("agent", stubPlugin);
+
+      const names = ctx.getPluginNames();
+      expect(names).toContain("analytics");
+      expect(names).toContain("server");
+      expect(names).toContain("agent");
+      expect(names).toHaveLength(3);
+    });
+
+    test("hasPlugin returns true for registered plugins", () => {
+      ctx.registerPlugin("analytics", stubPlugin);
+
+      expect(ctx.hasPlugin("analytics")).toBe(true);
+      expect(ctx.hasPlugin("nonexistent")).toBe(false);
+    });
+
+    test("getPlugins returns all registered instances", () => {
+      const p1 = { name: "analytics" } as any;
+      const p2 = { name: "server" } as any;
+      ctx.registerPlugin("analytics", p1);
+      ctx.registerPlugin("server", p2);
+
+      const plugins = ctx.getPlugins();
+      expect(plugins.size).toBe(2);
+      expect(plugins.get("analytics")).toBe(p1);
+      expect(plugins.get("server")).toBe(p2);
+    });
+  });
+});
+
+describe("isToolProvider", () => {
+  test("returns true for objects with getAgentTools and executeAgentTool", () => {
+    const provider = createMockToolProvider();
+    expect(isToolProvider(provider)).toBe(true);
+  });
+
+  test("returns false for null", () => {
+    expect(isToolProvider(null)).toBe(false);
+  });
+
+  test("returns false for objects missing executeAgentTool", () => {
+    expect(isToolProvider({ getAgentTools: vi.fn() })).toBe(false);
+  });
+
+  test("returns false for objects missing getAgentTools", () => {
+    expect(isToolProvider({ executeAgentTool: vi.fn() })).toBe(false);
+  });
+
+  test("returns false for non-objects", () => {
+    expect(isToolProvider("string")).toBe(false);
+    expect(isToolProvider(42)).toBe(false);
+    expect(isToolProvider(undefined)).toBe(false);
+  });
+});

--- a/packages/appkit/src/index.ts
+++ b/packages/appkit/src/index.ts
@@ -15,7 +15,6 @@ export type {
 } from "shared";
 export { isSQLTypeMarker, sql } from "shared";
 export { CacheManager } from "./cache";
-export type { JobsConnectorConfig } from "./connectors/jobs";
 export type {
   DatabaseCredential,
   GenerateDatabaseCredentialRequest,
@@ -54,6 +53,7 @@ export {
   type ToPlugin,
   toPlugin,
 } from "./plugin";
+export { analytics, files, genie, lakebase, server, serving } from "./plugins";
 // Files plugin types (for custom policy authoring)
 export type {
   FileAction,
@@ -66,14 +66,6 @@ export {
   READ_ACTIONS,
   WRITE_ACTIONS,
 } from "./plugins/files/policy";
-export * from "./plugins/ga-exports.generated";
-export type {
-  IJobsConfig,
-  JobAPI,
-  JobConfig,
-  JobHandle,
-  JobsExport,
-} from "./plugins/jobs";
 export type {
   EndpointConfig,
   ServingEndpointEntry,

--- a/packages/appkit/src/index.ts
+++ b/packages/appkit/src/index.ts
@@ -15,6 +15,7 @@ export type {
 } from "shared";
 export { isSQLTypeMarker, sql } from "shared";
 export { CacheManager } from "./cache";
+export type { JobsConnectorConfig } from "./connectors/jobs";
 export type {
   DatabaseCredential,
   GenerateDatabaseCredentialRequest,
@@ -53,7 +54,6 @@ export {
   type ToPlugin,
   toPlugin,
 } from "./plugin";
-export { analytics, files, genie, lakebase, server, serving } from "./plugins";
 // Files plugin types (for custom policy authoring)
 export type {
   FileAction,
@@ -66,6 +66,14 @@ export {
   READ_ACTIONS,
   WRITE_ACTIONS,
 } from "./plugins/files/policy";
+export * from "./plugins/ga-exports.generated";
+export type {
+  IJobsConfig,
+  JobAPI,
+  JobConfig,
+  JobHandle,
+  JobsExport,
+} from "./plugins/jobs";
 export type {
   EndpointConfig,
   ServingEndpointEntry,

--- a/packages/appkit/src/plugin/index.ts
+++ b/packages/appkit/src/plugin/index.ts
@@ -1,4 +1,4 @@
 export type { ToPlugin } from "shared";
 export type { ExecutionResult } from "./execution-result";
 export { Plugin } from "./plugin";
-export { toPlugin } from "./to-plugin";
+export { type NamedPluginFactory, toPlugin } from "./to-plugin";

--- a/packages/appkit/src/plugin/plugin.ts
+++ b/packages/appkit/src/plugin/plugin.ts
@@ -20,6 +20,7 @@ import {
   ServiceContext,
   type UserContext,
 } from "../context";
+import type { PluginContext } from "../core/plugin-context";
 import { AppKitError, AuthenticationError } from "../errors";
 import { createLogger } from "../logging/logger";
 import { StreamManager } from "../stream";
@@ -178,11 +179,12 @@ export abstract class Plugin<
 > implements BasePlugin
 {
   protected isReady = false;
-  protected cache: CacheManager;
+  protected cache!: CacheManager;
   protected app: AppManager;
   protected devFileReader: DevFileReader;
   protected streamManager: StreamManager;
-  protected telemetry: ITelemetry;
+  protected telemetry!: ITelemetry;
+  protected context?: PluginContext;
 
   /** Registered endpoints for this plugin */
   private registeredEndpoints: PluginEndpointMap = {};
@@ -208,12 +210,58 @@ export abstract class Plugin<
       config.name ??
       (this.constructor as { manifest?: { name: string } }).manifest?.name ??
       "plugin";
-    this.telemetry = TelemetryManager.getProvider(this.name, config.telemetry);
     this.streamManager = new StreamManager();
-    this.cache = CacheManager.getInstanceSync();
     this.app = new AppManager();
     this.devFileReader = DevFileReader.getInstance();
+    this.context = (config as Record<string, unknown>).context as
+      | PluginContext
+      | undefined;
 
+    // Eagerly bind telemetry + cache if the core services have already been
+    // initialized (normal createApp path, or tests that mock CacheManager).
+    // If they haven't, we leave these undefined and rely on `attachContext`
+    // being called later — this lets factories eagerly construct plugin
+    // instances at module top-level before `createApp` has run.
+    this.tryAttachContext();
+  }
+
+  private tryAttachContext(): void {
+    try {
+      this.cache = CacheManager.getInstanceSync();
+    } catch {
+      return;
+    }
+    this.telemetry = TelemetryManager.getProvider(
+      this.name,
+      this.config.telemetry,
+    );
+    this.isReady = true;
+  }
+
+  /**
+   * Binds runtime dependencies (telemetry provider, cache, plugin context) to
+   * this plugin. Called by `AppKit._createApp` after construction and before
+   * `setup()`. Idempotent: safe to call if the constructor already bound them
+   * eagerly. Kept separate so factories can eagerly construct plugin instances
+   * without running this before `TelemetryManager.initialize()` /
+   * `CacheManager.getInstance()` have run.
+   */
+  attachContext(
+    deps: {
+      context?: unknown;
+      telemetryConfig?: BasePluginConfig["telemetry"];
+    } = {},
+  ): void {
+    if (!this.cache) {
+      this.cache = CacheManager.getInstanceSync();
+    }
+    this.telemetry = TelemetryManager.getProvider(
+      this.name,
+      deps.telemetryConfig ?? this.config.telemetry,
+    );
+    if (deps.context !== undefined) {
+      this.context = deps.context as PluginContext;
+    }
     this.isReady = true;
   }
 

--- a/packages/appkit/src/plugin/plugin.ts
+++ b/packages/appkit/src/plugin/plugin.ts
@@ -80,6 +80,7 @@ const EXCLUDED_FROM_PROXY = new Set([
   // Lifecycle methods
   "setup",
   "shutdown",
+  "attachContext",
   "injectRoutes",
   "getEndpoints",
   "getSkipBodyParsingPaths",

--- a/packages/appkit/src/plugin/to-plugin.ts
+++ b/packages/appkit/src/plugin/to-plugin.ts
@@ -1,19 +1,41 @@
 import type { PluginConstructor, PluginData, ToPlugin } from "shared";
 
 /**
- * Wraps a plugin class so it can be passed to createApp with optional config.
- * Infers config type from the constructor and plugin name from the static `name` property.
+ * Factory function produced by {@link toPlugin}. Carries a static
+ * `pluginName` field so tooling (e.g. `fromPlugin`) can identify which
+ * plugin a factory references without constructing an instance.
+ */
+export type NamedPluginFactory<Name extends string = string> = {
+  readonly pluginName: Name;
+};
+
+/**
+ * Wraps a plugin class so it can be passed to `createApp` with optional
+ * config. Infers the config type from the constructor and the plugin name
+ * from the static `manifest.name` property, and stamps `pluginName` onto
+ * the returned factory function so `fromPlugin` can identify the plugin
+ * without needing to construct it.
  *
  * @internal
  */
 export function toPlugin<T extends PluginConstructor>(
   plugin: T,
-): ToPlugin<T, ConstructorParameters<T>[0], T["manifest"]["name"]> {
+): ToPlugin<T, ConstructorParameters<T>[0], T["manifest"]["name"]> &
+  NamedPluginFactory<T["manifest"]["name"]> {
   type Config = ConstructorParameters<T>[0];
   type Name = T["manifest"]["name"];
-  return (config: Config = {} as Config): PluginData<T, Config, Name> => ({
+  const pluginName = plugin.manifest.name as Name;
+  const factory = (
+    config: Config = {} as Config,
+  ): PluginData<T, Config, Name> => ({
     plugin: plugin as T,
     config: config as Config,
-    name: plugin.manifest.name as Name,
+    name: pluginName,
   });
+  Object.defineProperty(factory, "pluginName", {
+    value: pluginName,
+    writable: false,
+    enumerable: true,
+  });
+  return factory as ToPlugin<T, Config, Name> & NamedPluginFactory<Name>;
 }

--- a/packages/appkit/src/plugins/agents/tests/mcp-client.test.ts
+++ b/packages/appkit/src/plugins/agents/tests/mcp-client.test.ts
@@ -1,0 +1,402 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { AppKitMcpClient } from "../tools/mcp-client";
+import type { DnsLookup, McpHostPolicy } from "../tools/mcp-host-policy";
+
+const WORKSPACE = "https://test-workspace.cloud.databricks.com";
+
+const workspacePolicy: McpHostPolicy = {
+  workspaceHostname: "test-workspace.cloud.databricks.com",
+  trustedHosts: new Set(),
+  allowLocalhost: false,
+};
+
+const trustedExternalPolicy: McpHostPolicy = {
+  workspaceHostname: "test-workspace.cloud.databricks.com",
+  trustedHosts: new Set(["mcp.example.com"]),
+  allowLocalhost: false,
+};
+
+const publicDnsLookup: DnsLookup = async () => [
+  { address: "203.0.113.42", family: 4 },
+];
+
+const workspaceAuth = async (): Promise<Record<string, string>> => ({
+  Authorization: "Bearer SP-TOKEN",
+});
+
+type FetchCall = {
+  url: string;
+  init: RequestInit;
+};
+
+function recordingFetch(
+  responders: Array<(call: FetchCall) => Response | Promise<Response>>,
+) {
+  const calls: FetchCall[] = [];
+  let n = 0;
+  const fetchImpl: typeof fetch = async (input, init) => {
+    const url = typeof input === "string" ? input : (input as URL).toString();
+    const call: FetchCall = { url, init: init ?? {} };
+    calls.push(call);
+    const responder = responders[n++] ?? responders[responders.length - 1];
+    return Promise.resolve(responder(call));
+  };
+  return { fetchImpl, calls };
+}
+
+function jsonResponse(body: unknown, headers: Record<string, string> = {}) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json", ...headers },
+  });
+}
+
+describe("AppKitMcpClient — host allowlist", () => {
+  let authSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    authSpy = vi.fn(workspaceAuth);
+  });
+
+  test("connect rejects a URL whose host is not allowlisted without making any fetch", async () => {
+    const { fetchImpl, calls } = recordingFetch([() => jsonResponse({})]);
+    const client = new AppKitMcpClient(WORKSPACE, authSpy, workspacePolicy, {
+      fetchImpl,
+      dnsLookup: publicDnsLookup,
+    });
+    await expect(
+      client.connect({ name: "evil", url: "https://attacker.example.com/mcp" }),
+    ).rejects.toThrow(/attacker\.example\.com/);
+    expect(calls).toHaveLength(0);
+    expect(authSpy).not.toHaveBeenCalled();
+  });
+
+  test("connect rejects plaintext http:// for remote hosts", async () => {
+    const { fetchImpl, calls } = recordingFetch([() => jsonResponse({})]);
+    const client = new AppKitMcpClient(
+      WORKSPACE,
+      authSpy,
+      trustedExternalPolicy,
+      { fetchImpl, dnsLookup: publicDnsLookup },
+    );
+    await expect(
+      client.connect({ name: "plain", url: "http://mcp.example.com/mcp" }),
+    ).rejects.toThrow(/plaintext http/);
+    expect(calls).toHaveLength(0);
+    expect(authSpy).not.toHaveBeenCalled();
+  });
+
+  test("connect rejects a URL whose DNS resolves to a blocked IP and never sends SP token", async () => {
+    const ssrfLookup: DnsLookup = async () => [
+      { address: "169.254.169.254", family: 4 },
+    ];
+    const policy: McpHostPolicy = {
+      workspaceHostname: "test-workspace.cloud.databricks.com",
+      trustedHosts: new Set(["evil.example.com"]),
+      allowLocalhost: false,
+    };
+    const { fetchImpl, calls } = recordingFetch([() => jsonResponse({})]);
+    const client = new AppKitMcpClient(WORKSPACE, authSpy, policy, {
+      fetchImpl,
+      dnsLookup: ssrfLookup,
+    });
+    await expect(
+      client.connect({ name: "evil", url: "https://evil.example.com/mcp" }),
+    ).rejects.toThrow(/169\.254\.169\.254/);
+    expect(calls).toHaveLength(0);
+    expect(authSpy).not.toHaveBeenCalled();
+  });
+
+  test("connect to same-origin workspace forwards SP token on initialize + tools/list", async () => {
+    const { fetchImpl, calls } = recordingFetch([
+      () =>
+        jsonResponse(
+          { jsonrpc: "2.0", id: 1, result: {} },
+          {
+            "mcp-session-id": "sess-1",
+          },
+        ),
+      () => jsonResponse({ jsonrpc: "2.0", result: null }),
+      () =>
+        jsonResponse({
+          jsonrpc: "2.0",
+          id: 3,
+          result: { tools: [{ name: "echo", description: "Echo" }] },
+        }),
+    ]);
+    const client = new AppKitMcpClient(WORKSPACE, authSpy, workspacePolicy, {
+      fetchImpl,
+      dnsLookup: publicDnsLookup,
+    });
+
+    await client.connect({
+      name: "genie-1",
+      url: `${WORKSPACE}/api/2.0/mcp/genie/abc`,
+    });
+
+    // initialize + notifications/initialized + tools/list all carry SP token
+    expect(calls.map((c) => c.url)).toEqual([
+      `${WORKSPACE}/api/2.0/mcp/genie/abc`,
+      `${WORKSPACE}/api/2.0/mcp/genie/abc`,
+      `${WORKSPACE}/api/2.0/mcp/genie/abc`,
+    ]);
+    for (const call of calls) {
+      const headers = call.init.headers as Record<string, string>;
+      expect(headers.Authorization).toBe("Bearer SP-TOKEN");
+    }
+    expect(client.canForwardWorkspaceAuth("genie-1")).toBe(true);
+  });
+
+  test("connect to trusted external host does NOT forward SP token on any RPC", async () => {
+    const { fetchImpl, calls } = recordingFetch([
+      () =>
+        jsonResponse(
+          { jsonrpc: "2.0", id: 1, result: {} },
+          {
+            "mcp-session-id": "sess-1",
+          },
+        ),
+      () => jsonResponse({ jsonrpc: "2.0", result: null }),
+      () =>
+        jsonResponse({
+          jsonrpc: "2.0",
+          id: 3,
+          result: { tools: [{ name: "help" }] },
+        }),
+    ]);
+    const client = new AppKitMcpClient(
+      WORKSPACE,
+      authSpy,
+      trustedExternalPolicy,
+      { fetchImpl, dnsLookup: publicDnsLookup },
+    );
+
+    await client.connect({ name: "ext", url: "https://mcp.example.com/mcp" });
+
+    for (const call of calls) {
+      const headers = call.init.headers as Record<string, string>;
+      expect(headers.Authorization).toBeUndefined();
+    }
+    expect(authSpy).not.toHaveBeenCalled();
+    expect(client.canForwardWorkspaceAuth("ext")).toBe(false);
+  });
+});
+
+describe("AppKitMcpClient — callTool auth scoping", () => {
+  test("drops caller-supplied OBO token when destination is not workspace-origin", async () => {
+    const connectResponders = [
+      () =>
+        jsonResponse(
+          { jsonrpc: "2.0", id: 1, result: {} },
+          {
+            "mcp-session-id": "sess-1",
+          },
+        ),
+      () => jsonResponse({ jsonrpc: "2.0", result: null }),
+      () =>
+        jsonResponse({
+          jsonrpc: "2.0",
+          id: 3,
+          result: { tools: [{ name: "do" }] },
+        }),
+    ];
+    const callResponder = () =>
+      jsonResponse({
+        jsonrpc: "2.0",
+        id: 4,
+        result: { content: [{ type: "text", text: "ok" }] },
+      });
+    const { fetchImpl, calls } = recordingFetch([
+      ...connectResponders,
+      callResponder,
+    ]);
+    const client = new AppKitMcpClient(
+      WORKSPACE,
+      workspaceAuth,
+      trustedExternalPolicy,
+      { fetchImpl, dnsLookup: publicDnsLookup },
+    );
+    await client.connect({ name: "ext", url: "https://mcp.example.com/mcp" });
+
+    const output = await client.callTool(
+      "mcp.ext.do",
+      { x: 1 },
+      {
+        Authorization: "Bearer OBO-USER-TOKEN",
+      },
+    );
+    expect(output).toBe("ok");
+
+    const toolCall = calls[calls.length - 1];
+    const headers = toolCall.init.headers as Record<string, string>;
+    expect(headers.Authorization).toBeUndefined();
+  });
+
+  test("forwards caller-supplied OBO token when destination is workspace-origin", async () => {
+    const connectResponders = [
+      () =>
+        jsonResponse(
+          { jsonrpc: "2.0", id: 1, result: {} },
+          {
+            "mcp-session-id": "sess-1",
+          },
+        ),
+      () => jsonResponse({ jsonrpc: "2.0", result: null }),
+      () =>
+        jsonResponse({
+          jsonrpc: "2.0",
+          id: 3,
+          result: { tools: [{ name: "do" }] },
+        }),
+    ];
+    const callResponder = () =>
+      jsonResponse({
+        jsonrpc: "2.0",
+        id: 4,
+        result: { content: [{ type: "text", text: "ok" }] },
+      });
+    const { fetchImpl, calls } = recordingFetch([
+      ...connectResponders,
+      callResponder,
+    ]);
+    const client = new AppKitMcpClient(
+      WORKSPACE,
+      workspaceAuth,
+      workspacePolicy,
+      {
+        fetchImpl,
+        dnsLookup: publicDnsLookup,
+      },
+    );
+    await client.connect({
+      name: "genie-1",
+      url: `${WORKSPACE}/api/2.0/mcp/genie/abc`,
+    });
+
+    await client.callTool(
+      "mcp.genie-1.do",
+      {},
+      {
+        Authorization: "Bearer OBO-USER-TOKEN",
+      },
+    );
+
+    const toolCall = calls[calls.length - 1];
+    const headers = toolCall.init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer OBO-USER-TOKEN");
+  });
+
+  test("falls back to SP auth when no OBO override is provided and destination is workspace", async () => {
+    const authSpy = vi.fn(workspaceAuth);
+    const connectResponders = [
+      () =>
+        jsonResponse(
+          { jsonrpc: "2.0", id: 1, result: {} },
+          {
+            "mcp-session-id": "sess-1",
+          },
+        ),
+      () => jsonResponse({ jsonrpc: "2.0", result: null }),
+      () =>
+        jsonResponse({
+          jsonrpc: "2.0",
+          id: 3,
+          result: { tools: [{ name: "do" }] },
+        }),
+    ];
+    const callResponder = () =>
+      jsonResponse({
+        jsonrpc: "2.0",
+        id: 4,
+        result: { content: [{ type: "text", text: "ok" }] },
+      });
+    const { fetchImpl, calls } = recordingFetch([
+      ...connectResponders,
+      callResponder,
+    ]);
+    const client = new AppKitMcpClient(WORKSPACE, authSpy, workspacePolicy, {
+      fetchImpl,
+      dnsLookup: publicDnsLookup,
+    });
+    await client.connect({
+      name: "genie-1",
+      url: `${WORKSPACE}/api/2.0/mcp/genie/abc`,
+    });
+
+    await client.callTool("mcp.genie-1.do", {}, undefined);
+
+    const toolCall = calls[calls.length - 1];
+    const headers = toolCall.init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer SP-TOKEN");
+  });
+});
+
+describe("AppKitMcpClient — caller abort signal composition", () => {
+  test("callTool's fetch aborts when the caller signal fires", async () => {
+    const connectResponders = [
+      () =>
+        jsonResponse(
+          { jsonrpc: "2.0", id: 1, result: {} },
+          { "mcp-session-id": "sess-1" },
+        ),
+      () => jsonResponse({ jsonrpc: "2.0", result: null }),
+      () =>
+        jsonResponse({
+          jsonrpc: "2.0",
+          id: 3,
+          result: { tools: [{ name: "slow" }] },
+        }),
+    ];
+    const callResponder = (call: FetchCall): Promise<Response> => {
+      const signal = call.init.signal as AbortSignal | undefined;
+      return new Promise<Response>((_, reject) => {
+        if (signal?.aborted) {
+          reject(
+            new DOMException(
+              signal.reason?.toString() ?? "aborted",
+              "AbortError",
+            ),
+          );
+          return;
+        }
+        signal?.addEventListener(
+          "abort",
+          () => {
+            reject(
+              new DOMException(
+                signal.reason?.toString() ?? "aborted",
+                "AbortError",
+              ),
+            );
+          },
+          { once: true },
+        );
+      });
+    };
+    const { fetchImpl } = recordingFetch([...connectResponders, callResponder]);
+    const client = new AppKitMcpClient(
+      WORKSPACE,
+      workspaceAuth,
+      workspacePolicy,
+      {
+        fetchImpl,
+        dnsLookup: publicDnsLookup,
+      },
+    );
+    await client.connect({
+      name: "genie-1",
+      url: `${WORKSPACE}/api/2.0/mcp/genie/abc`,
+    });
+
+    const controller = new AbortController();
+    const pending = client
+      .callTool("mcp.genie-1.slow", {}, undefined, controller.signal)
+      .catch((e) => e);
+    // Let the fetch start + register its abort listener before we abort.
+    await new Promise((r) => setTimeout(r, 10));
+    controller.abort(new Error("user cancelled"));
+    const error = (await pending) as Error;
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe("AbortError");
+  });
+});

--- a/packages/appkit/src/plugins/agents/tests/mcp-host-policy.test.ts
+++ b/packages/appkit/src/plugins/agents/tests/mcp-host-policy.test.ts
@@ -1,0 +1,354 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+  assertResolvedHostSafe,
+  buildMcpHostPolicy,
+  checkMcpUrl,
+  type DnsLookup,
+  isBlockedIp,
+  isLoopbackHost,
+  type McpHostPolicy,
+  type McpHostPolicyConfig,
+} from "../tools/mcp-host-policy";
+
+function stubLookup(
+  addresses: Array<{ address: string; family?: number }>,
+): DnsLookup {
+  return vi
+    .fn<DnsLookup>()
+    .mockResolvedValue(addresses.map((a) => ({ family: 4, ...a })));
+}
+
+function failingLookup(message: string): DnsLookup {
+  return vi.fn<DnsLookup>().mockRejectedValue(new Error(message));
+}
+
+const WORKSPACE = "https://test-workspace.cloud.databricks.com";
+
+function policy(overrides: Partial<McpHostPolicy> = {}): McpHostPolicy {
+  return {
+    workspaceHostname: "test-workspace.cloud.databricks.com",
+    trustedHosts: new Set<string>(),
+    allowLocalhost: false,
+    ...overrides,
+  };
+}
+
+describe("buildMcpHostPolicy", () => {
+  test("extracts hostname from workspace URL", () => {
+    const p = buildMcpHostPolicy(undefined, WORKSPACE);
+    expect(p.workspaceHostname).toBe("test-workspace.cloud.databricks.com");
+  });
+
+  test("lowercases and trims trustedHosts", () => {
+    const p = buildMcpHostPolicy(
+      { trustedHosts: ["Example.COM", " corp.internal ", "mcp.example.com"] },
+      WORKSPACE,
+    );
+    expect(p.trustedHosts).toEqual(
+      new Set(["example.com", "corp.internal", "mcp.example.com"]),
+    );
+  });
+
+  test("allowLocalhost defaults to false in production", () => {
+    const prev = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    try {
+      const p = buildMcpHostPolicy(undefined, WORKSPACE);
+      expect(p.allowLocalhost).toBe(false);
+    } finally {
+      process.env.NODE_ENV = prev;
+    }
+  });
+
+  test("allowLocalhost defaults to true outside production", () => {
+    const prev = process.env.NODE_ENV;
+    process.env.NODE_ENV = "development";
+    try {
+      const p = buildMcpHostPolicy(undefined, WORKSPACE);
+      expect(p.allowLocalhost).toBe(true);
+    } finally {
+      process.env.NODE_ENV = prev;
+    }
+  });
+
+  test("allowLocalhost respects explicit override", () => {
+    const prev = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    try {
+      const cfg: McpHostPolicyConfig = { allowLocalhost: true };
+      const p = buildMcpHostPolicy(cfg, WORKSPACE);
+      expect(p.allowLocalhost).toBe(true);
+    } finally {
+      process.env.NODE_ENV = prev;
+    }
+  });
+
+  test("throws on invalid workspace host", () => {
+    expect(() => buildMcpHostPolicy(undefined, "not-a-url")).toThrow(
+      /Invalid workspace host/,
+    );
+  });
+});
+
+describe("checkMcpUrl", () => {
+  test("admits same-origin workspace https URL and forwards auth", () => {
+    const result = checkMcpUrl(`${WORKSPACE}/api/2.0/mcp/genie/abc`, policy());
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.forwardWorkspaceAuth).toBe(true);
+  });
+
+  test("admits trusted host but does NOT forward workspace auth", () => {
+    const p = policy({ trustedHosts: new Set(["mcp.example.com"]) });
+    const result = checkMcpUrl("https://mcp.example.com/mcp", p);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.forwardWorkspaceAuth).toBe(false);
+  });
+
+  test("rejects host that is neither workspace nor trusted", () => {
+    const result = checkMcpUrl("https://attacker.example.com/mcp", policy());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toMatch(/attacker\.example\.com/);
+      expect(result.reason).toMatch(/trustedHosts/);
+    }
+  });
+
+  test("rejects plaintext http:// for remote hosts even when trusted", () => {
+    const p = policy({ trustedHosts: new Set(["mcp.example.com"]) });
+    const result = checkMcpUrl("http://mcp.example.com/mcp", p);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/plaintext http/);
+  });
+
+  test("rejects plaintext http://localhost when allowLocalhost is false", () => {
+    const result = checkMcpUrl("http://localhost:4000/mcp", policy());
+    expect(result.ok).toBe(false);
+  });
+
+  test("admits http://localhost when allowLocalhost is true, no workspace auth", () => {
+    const p = policy({ allowLocalhost: true });
+    const result = checkMcpUrl("http://localhost:4000/mcp", p);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.forwardWorkspaceAuth).toBe(false);
+  });
+
+  test("admits http://127.0.0.1 when allowLocalhost is true", () => {
+    const p = policy({ allowLocalhost: true });
+    const result = checkMcpUrl("http://127.0.0.1:4000/mcp", p);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.forwardWorkspaceAuth).toBe(false);
+  });
+
+  test("rejects non-http(s) schemes", () => {
+    for (const url of [
+      "file:///etc/passwd",
+      "ftp://host/x",
+      "gopher://host/x",
+      "javascript:alert(1)",
+    ]) {
+      const result = checkMcpUrl(url, policy());
+      expect(result.ok).toBe(false);
+    }
+  });
+
+  test("rejects obviously invalid URLs", () => {
+    const result = checkMcpUrl("not-a-url", policy());
+    expect(result.ok).toBe(false);
+  });
+
+  test("hostname comparison is case-insensitive", () => {
+    const result = checkMcpUrl(
+      "https://TEST-Workspace.CLOUD.Databricks.com/mcp",
+      policy(),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.forwardWorkspaceAuth).toBe(true);
+  });
+
+  test("rejects same hostname on different scheme (http) even for workspace", () => {
+    const result = checkMcpUrl(
+      "http://test-workspace.cloud.databricks.com/mcp",
+      policy(),
+    );
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("isBlockedIp", () => {
+  test("blocks RFC1918 IPv4 ranges", () => {
+    for (const addr of [
+      "10.0.0.1",
+      "10.255.255.255",
+      "172.16.0.1",
+      "172.31.255.255",
+      "192.168.0.1",
+      "192.168.255.255",
+    ]) {
+      expect(isBlockedIp(addr, true)).toBe(true);
+    }
+  });
+
+  test("blocks link-local 169.254.0.0/16 (covers cloud metadata 169.254.169.254)", () => {
+    expect(isBlockedIp("169.254.169.254", true)).toBe(true);
+    expect(isBlockedIp("169.254.0.1", true)).toBe(true);
+  });
+
+  test("blocks CGNAT 100.64.0.0/10", () => {
+    expect(isBlockedIp("100.64.0.1", true)).toBe(true);
+    expect(isBlockedIp("100.127.255.255", true)).toBe(true);
+  });
+
+  test("blocks 0.0.0.0/8 and multicast/reserved (>= 224.0.0.0)", () => {
+    expect(isBlockedIp("0.0.0.0", true)).toBe(true);
+    expect(isBlockedIp("0.1.2.3", true)).toBe(true);
+    expect(isBlockedIp("224.0.0.1", true)).toBe(true);
+    expect(isBlockedIp("255.255.255.255", true)).toBe(true);
+  });
+
+  test("blocks loopback when allowLocalhost is false", () => {
+    expect(isBlockedIp("127.0.0.1", false)).toBe(true);
+    expect(isBlockedIp("127.1.2.3", false)).toBe(true);
+    expect(isBlockedIp("::1", false)).toBe(true);
+  });
+
+  test("permits loopback when allowLocalhost is true", () => {
+    expect(isBlockedIp("127.0.0.1", true)).toBe(false);
+    expect(isBlockedIp("::1", true)).toBe(false);
+  });
+
+  test("blocks ULA (fc00::/7) and link-local (fe80::/10) IPv6", () => {
+    expect(isBlockedIp("fc00::1", true)).toBe(true);
+    expect(isBlockedIp("fd00::1", true)).toBe(true);
+    expect(isBlockedIp("fe80::1", true)).toBe(true);
+  });
+
+  test("blocks the full link-local /10 range fe80::–febf:: (regression: fea0/feb0)", () => {
+    // fe80::/10 spans 1111 1110 10.. — first hex pair `fe` + second nibble 8..b.
+    for (const addr of [
+      "fe80::1",
+      "fe90::1",
+      "fea0::1", // regression: was passing the filter before
+      "feaf::1", // regression
+      "feb0::1", // regression
+      "febf::1", // regression
+    ]) {
+      expect(isBlockedIp(addr, true)).toBe(true);
+    }
+    // Outside /10 must not be blocked by this rule (belongs to routable-ish
+    // experimental ranges; nothing else in the module should match either).
+    expect(isBlockedIp("fec0::1", true)).toBe(false);
+  });
+
+  test("blocks IPv4-mapped IPv6 addresses in blocked ranges (dotted form)", () => {
+    expect(isBlockedIp("::ffff:169.254.169.254", true)).toBe(true);
+    expect(isBlockedIp("::ffff:10.0.0.1", true)).toBe(true);
+  });
+
+  test("blocks IPv4-mapped IPv6 addresses in colon-hex form (regression)", () => {
+    // ::ffff:a9fe:a9fe is the same destination as ::ffff:169.254.169.254.
+    // Before the fix this form slipped past the IPv4-mapped branch because
+    // isIPv4("a9fe:a9fe") is false and no other v6 rule matched.
+    expect(isBlockedIp("::ffff:a9fe:a9fe", true)).toBe(true); // 169.254.169.254
+    expect(isBlockedIp("::ffff:0a00:0001", true)).toBe(true); // 10.0.0.1
+    expect(isBlockedIp("::ffff:c0a8:0001", true)).toBe(true); // 192.168.0.1
+    // A public IPv4 mapped to colon-hex must still pass through: 8.8.8.8 = 0808:0808
+    expect(isBlockedIp("::ffff:0808:0808", true)).toBe(false);
+  });
+
+  test("allows public IPv4 and IPv6 addresses", () => {
+    expect(isBlockedIp("8.8.8.8", false)).toBe(false);
+    expect(isBlockedIp("1.1.1.1", false)).toBe(false);
+    expect(isBlockedIp("2001:4860:4860::8888", false)).toBe(false);
+  });
+
+  test("treats malformed IP strings as blocked (fail-closed)", () => {
+    expect(isBlockedIp("10.0.0", true)).toBe(true);
+    expect(isBlockedIp("abc.def.ghi.jkl", true)).toBe(true);
+  });
+});
+
+describe("isLoopbackHost", () => {
+  test.each([
+    "localhost",
+    "LOCALHOST",
+    "127.0.0.1",
+    "::1",
+    "[::1]",
+    "0:0:0:0:0:0:0:1",
+  ])("recognises %s as loopback", (host) => {
+    expect(isLoopbackHost(host)).toBe(true);
+  });
+
+  test("does not match other hosts", () => {
+    expect(isLoopbackHost("example.com")).toBe(false);
+    expect(isLoopbackHost("10.0.0.1")).toBe(false);
+  });
+});
+
+describe("assertResolvedHostSafe", () => {
+  test("passes workspace hostname when resolved address is public", async () => {
+    const lookup = stubLookup([{ address: "203.0.113.42" }]);
+    await expect(
+      assertResolvedHostSafe(
+        "test-workspace.cloud.databricks.com",
+        policy(),
+        lookup,
+      ),
+    ).resolves.toBeUndefined();
+    expect(lookup).toHaveBeenCalledWith("test-workspace.cloud.databricks.com", {
+      all: true,
+    });
+  });
+
+  test("rejects hostname that resolves to link-local cloud metadata IP", async () => {
+    const lookup = stubLookup([{ address: "169.254.169.254" }]);
+    await expect(
+      assertResolvedHostSafe("evil.example.com", policy(), lookup),
+    ).rejects.toThrow(/169\.254\.169\.254/);
+  });
+
+  test("rejects hostname that resolves to RFC1918 IP", async () => {
+    const lookup = stubLookup([{ address: "10.0.0.1" }]);
+    await expect(
+      assertResolvedHostSafe("internal.example.com", policy(), lookup),
+    ).rejects.toThrow(/10\.0\.0\.1/);
+  });
+
+  test("rejects IP literal in blocked range without DNS lookup", async () => {
+    const lookup = stubLookup([{ address: "8.8.8.8" }]);
+    await expect(
+      assertResolvedHostSafe("169.254.169.254", policy(), lookup),
+    ).rejects.toThrow(/blocked IP range/);
+    expect(lookup).not.toHaveBeenCalled();
+  });
+
+  test("rejects plain 'localhost' when allowLocalhost is false", async () => {
+    await expect(assertResolvedHostSafe("localhost", policy())).rejects.toThrow(
+      /localhost is not allowed/,
+    );
+  });
+
+  test("surfaces DNS resolution failures", async () => {
+    const lookup = failingLookup("ENOTFOUND");
+    await expect(
+      assertResolvedHostSafe("nonexistent.example.com", policy(), lookup),
+    ).rejects.toThrow(/could not be resolved/);
+  });
+
+  test("rejects if any resolved address is blocked (defense against split DNS)", async () => {
+    const lookup = stubLookup([
+      { address: "8.8.8.8" },
+      { address: "169.254.169.254" },
+    ]);
+    await expect(
+      assertResolvedHostSafe("mixed.example.com", policy(), lookup),
+    ).rejects.toThrow(/169\.254\.169\.254/);
+  });
+
+  test("rejects hostname that resolves to empty DNS result", async () => {
+    const lookup = stubLookup([]);
+    await expect(
+      assertResolvedHostSafe("empty.example.com", policy(), lookup),
+    ).rejects.toThrow(/no DNS addresses/);
+  });
+});

--- a/packages/appkit/src/plugins/agents/tests/mcp-server-helper.test.ts
+++ b/packages/appkit/src/plugins/agents/tests/mcp-server-helper.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+import {
+  isHostedTool,
+  mcpServer,
+  resolveHostedTools,
+} from "../../../core/agent/tools/hosted-tools";
+
+describe("mcpServer()", () => {
+  test("returns a CustomMcpServerTool with correct shape", () => {
+    const result = mcpServer("my-app", "https://example.com/mcp");
+
+    expect(result).toEqual({
+      type: "custom_mcp_server",
+      custom_mcp_server: {
+        app_name: "my-app",
+        app_url: "https://example.com/mcp",
+      },
+    });
+  });
+
+  test("isHostedTool recognizes mcpServer() output", () => {
+    expect(isHostedTool(mcpServer("x", "y"))).toBe(true);
+  });
+
+  test("resolveHostedTools resolves mcpServer() output to an endpoint config", () => {
+    const configs = resolveHostedTools([
+      mcpServer("vector-search", "https://host/mcp/vs"),
+    ]);
+
+    expect(configs).toHaveLength(1);
+    expect(configs[0].name).toBe("vector-search");
+    expect(configs[0].url).toBe("https://host/mcp/vs");
+  });
+});

--- a/packages/appkit/src/plugins/agents/tools/mcp-client.ts
+++ b/packages/appkit/src/plugins/agents/tools/mcp-client.ts
@@ -1,0 +1,394 @@
+import type { AgentToolDefinition } from "shared";
+import { createLogger } from "../../../logging/logger";
+import type { McpEndpointConfig } from "../../../core/agent/tools/hosted-tools";
+import {
+  assertResolvedHostSafe,
+  checkMcpUrl,
+  type DnsLookup,
+  type McpHostPolicy,
+} from "./mcp-host-policy";
+
+const logger = createLogger("agent:mcp");
+
+interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id: number;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+interface JsonRpcResponse {
+  jsonrpc: "2.0";
+  id: number;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+interface McpToolSchema {
+  name: string;
+  description?: string;
+  inputSchema?: Record<string, unknown>;
+}
+
+interface McpToolCallResult {
+  content: Array<{ type: string; text?: string }>;
+  isError?: boolean;
+}
+
+interface McpServerConnection {
+  config: McpEndpointConfig;
+  resolvedUrl: string;
+  /**
+   * Whether workspace auth (SP / OBO) may be forwarded to this endpoint's URL.
+   * Decided at `connect()` time via {@link McpHostPolicy} and cached for the
+   * lifetime of the connection.
+   */
+  forwardWorkspaceAuth: boolean;
+  tools: Map<string, McpToolSchema>;
+}
+
+/**
+ * Lightweight MCP client for Databricks-hosted MCP servers.
+ *
+ * Uses raw fetch() with JSON-RPC 2.0 over HTTP — no @modelcontextprotocol/sdk
+ * or LangChain dependency. Supports the Streamable HTTP transport only
+ * (POST with JSON-RPC request, single JSON-RPC response). Implements exactly
+ * four methods: `initialize`, `notifications/initialized`, `tools/list`,
+ * `tools/call`. No prompts/resources/completion/sampling.
+ *
+ * All outbound URLs are gated by an {@link McpHostPolicy}: unallowlisted hosts
+ * are rejected before the first byte is sent, and workspace credentials are
+ * only forwarded to the same-origin workspace. See `mcp-host-policy.ts`.
+ *
+ * ### Why not `@modelcontextprotocol/sdk`?
+ *
+ * Our security model — zero-trust host policy + per-destination auth scoping
+ * via `forwardWorkspaceAuth` — is the load-bearing anchor of this module, not
+ * the wire protocol. Wrapping the SDK to enforce the same invariants (custom
+ * transport + auth plumbing + policy checks before every request) ends up
+ * the same size as writing the narrow JSON-RPC subset directly, but with an
+ * opaque dependency that's harder to audit. Our entire target surface is
+ * Databricks-hosted MCP over Streamable HTTP; we never need stdio, SSE-only
+ * transport, or the rest of the protocol the SDK covers.
+ *
+ * Zero runtime deps matches the rest of AppKit's philosophy
+ * (`DatabricksAdapter`, `sql-policy`). Revisit the call if MCP adoption
+ * grows beyond Databricks-hosted servers with the transports above, or if
+ * the SDK gains transport-level auth hooks that cleanly match our
+ * per-destination auth-forwarding model.
+ */
+export class AppKitMcpClient {
+  private connections = new Map<string, McpServerConnection>();
+  private sessionIds = new Map<string, string>();
+  private requestId = 0;
+  private closed = false;
+
+  constructor(
+    private workspaceHost: string,
+    private authenticate: () => Promise<Record<string, string>>,
+    private policy: McpHostPolicy,
+    private options: { dnsLookup?: DnsLookup; fetchImpl?: typeof fetch } = {},
+  ) {}
+
+  async connectAll(endpoints: McpEndpointConfig[]): Promise<void> {
+    const results = await Promise.allSettled(
+      endpoints.map((ep) => this.connect(ep)),
+    );
+    for (let i = 0; i < results.length; i++) {
+      if (results[i].status === "rejected") {
+        logger.error(
+          "Failed to connect MCP server %s: %O",
+          endpoints[i].name,
+          (results[i] as PromiseRejectedResult).reason,
+        );
+      }
+    }
+  }
+
+  private resolveUrl(endpoint: McpEndpointConfig): string {
+    if (
+      endpoint.url.startsWith("http://") ||
+      endpoint.url.startsWith("https://")
+    ) {
+      return endpoint.url;
+    }
+    return `${this.workspaceHost}${endpoint.url}`;
+  }
+
+  async connect(endpoint: McpEndpointConfig): Promise<void> {
+    const resolvedUrl = this.resolveUrl(endpoint);
+    const check = checkMcpUrl(resolvedUrl, this.policy);
+    if (!check.ok) {
+      throw new Error(
+        `MCP endpoint '${endpoint.name}' refused at connect: ${check.reason}`,
+      );
+    }
+    await assertResolvedHostSafe(
+      check.url.hostname,
+      this.policy,
+      this.options.dnsLookup,
+    );
+
+    logger.info(
+      "Connecting to MCP server: %s at %s (forwardWorkspaceAuth=%s)",
+      endpoint.name,
+      resolvedUrl,
+      check.forwardWorkspaceAuth,
+    );
+
+    const initResponse = await this.sendRpc(
+      resolvedUrl,
+      "initialize",
+      {
+        protocolVersion: "2025-03-26",
+        capabilities: {},
+        clientInfo: { name: "appkit-agent", version: "0.1.0" },
+      },
+      { forwardWorkspaceAuth: check.forwardWorkspaceAuth },
+    );
+
+    if (initResponse.sessionId) {
+      this.sessionIds.set(endpoint.name, initResponse.sessionId);
+    }
+    const sessionId = this.sessionIds.get(endpoint.name);
+
+    await this.sendNotification(resolvedUrl, "notifications/initialized", {
+      sessionId,
+      forwardWorkspaceAuth: check.forwardWorkspaceAuth,
+    });
+
+    const listResponse = await this.sendRpc(
+      resolvedUrl,
+      "tools/list",
+      {},
+      { sessionId, forwardWorkspaceAuth: check.forwardWorkspaceAuth },
+    );
+    const toolList =
+      (listResponse.result as { tools?: McpToolSchema[] })?.tools ?? [];
+
+    const tools = new Map<string, McpToolSchema>();
+    for (const tool of toolList) {
+      tools.set(tool.name, tool);
+    }
+
+    this.connections.set(endpoint.name, {
+      config: endpoint,
+      resolvedUrl,
+      forwardWorkspaceAuth: check.forwardWorkspaceAuth,
+      tools,
+    });
+    logger.info(
+      "Connected to MCP server %s: %d tools available",
+      endpoint.name,
+      tools.size,
+    );
+  }
+
+  getAllToolDefinitions(): AgentToolDefinition[] {
+    const defs: AgentToolDefinition[] = [];
+    for (const [serverName, conn] of this.connections) {
+      for (const [toolName, schema] of conn.tools) {
+        defs.push({
+          name: `mcp.${serverName}.${toolName}`,
+          description: schema.description ?? toolName,
+          parameters:
+            (schema.inputSchema as AgentToolDefinition["parameters"]) ?? {
+              type: "object",
+              properties: {},
+            },
+        });
+      }
+    }
+    return defs;
+  }
+
+  /**
+   * Whether the named MCP server may receive workspace-scoped auth headers
+   * (e.g., an OBO bearer token from an end-user request). Callers should gate
+   * auth-forwarding decisions on this to prevent credential exfiltration to
+   * non-workspace hosts.
+   */
+  canForwardWorkspaceAuth(serverName: string): boolean {
+    return this.connections.get(serverName)?.forwardWorkspaceAuth ?? false;
+  }
+
+  async callTool(
+    qualifiedName: string,
+    args: unknown,
+    authHeaders?: Record<string, string>,
+    callerSignal?: AbortSignal,
+  ): Promise<string> {
+    const parts = qualifiedName.split(".");
+    if (parts.length < 3 || parts[0] !== "mcp") {
+      throw new Error(`Invalid MCP tool name: ${qualifiedName}`);
+    }
+    const serverName = parts[1];
+    const toolName = parts.slice(2).join(".");
+
+    const conn = this.connections.get(serverName);
+    if (!conn) {
+      throw new Error(`MCP server not connected: ${serverName}`);
+    }
+
+    const sessionId = this.sessionIds.get(serverName);
+    // authHeaders are caller-supplied credentials (typically the OBO token).
+    // Only honor them if the destination URL was admitted with
+    // forwardWorkspaceAuth=true at connect time.
+    const scopedAuthOverride = conn.forwardWorkspaceAuth
+      ? authHeaders
+      : undefined;
+
+    const rpcResult = await this.sendRpc(
+      conn.resolvedUrl,
+      "tools/call",
+      { name: toolName, arguments: args },
+      {
+        authOverride: scopedAuthOverride,
+        sessionId,
+        forwardWorkspaceAuth: conn.forwardWorkspaceAuth,
+        callerSignal,
+      },
+    );
+    const result = rpcResult.result as McpToolCallResult;
+
+    if (result.isError) {
+      const errText = (result.content ?? [])
+        .filter((c) => c.type === "text")
+        .map((c) => c.text)
+        .join("\n");
+      throw new Error(errText || "MCP tool call failed");
+    }
+
+    return (result.content ?? [])
+      .filter((c) => c.type === "text")
+      .map((c) => c.text)
+      .join("\n");
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+    this.connections.clear();
+    this.sessionIds.clear();
+  }
+
+  private async sendRpc(
+    url: string,
+    method: string,
+    params?: Record<string, unknown>,
+    options?: {
+      authOverride?: Record<string, string>;
+      sessionId?: string;
+      forwardWorkspaceAuth?: boolean;
+      /**
+       * Optional external abort signal (typically the agent's stream signal).
+       * Composed with the built-in 30 s timeout so `/cancel` or agent-run
+       * shutdown immediately propagates to the MCP fetch rather than waiting
+       * for the remote server to respond.
+       */
+      callerSignal?: AbortSignal;
+    },
+  ): Promise<{ result: unknown; sessionId?: string }> {
+    if (this.closed) throw new Error("MCP client is closed");
+
+    const request: JsonRpcRequest = {
+      jsonrpc: "2.0",
+      id: ++this.requestId,
+      method,
+      ...(params && { params }),
+    };
+
+    const authHeaders = await this.resolveAuthHeaders(options);
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      ...authHeaders,
+    };
+    if (options?.sessionId) {
+      headers["Mcp-Session-Id"] = options.sessionId;
+    }
+
+    const fetchImpl = this.options.fetchImpl ?? fetch;
+    const signals: AbortSignal[] = [AbortSignal.timeout(30_000)];
+    if (options?.callerSignal) signals.push(options.callerSignal);
+    const response = await fetchImpl(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(request),
+      signal: signals.length > 1 ? AbortSignal.any(signals) : signals[0],
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `MCP request to ${method} failed: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const contentType = response.headers.get("content-type") ?? "";
+    let json: JsonRpcResponse;
+
+    if (contentType.includes("text/event-stream")) {
+      const text = await response.text();
+      const lastData = text
+        .split("\n")
+        .filter((line) => line.startsWith("data: "))
+        .map((line) => line.slice(6))
+        .pop();
+      if (!lastData) {
+        throw new Error(`MCP SSE response for ${method} contained no data`);
+      }
+      json = JSON.parse(lastData) as JsonRpcResponse;
+    } else {
+      json = (await response.json()) as JsonRpcResponse;
+    }
+
+    if (json.error) {
+      throw new Error(`MCP error (${json.error.code}): ${json.error.message}`);
+    }
+
+    const sid = response.headers.get("mcp-session-id") ?? undefined;
+    return { result: json.result, sessionId: sid };
+  }
+
+  private async sendNotification(
+    url: string,
+    method: string,
+    options?: {
+      sessionId?: string;
+      forwardWorkspaceAuth?: boolean;
+    },
+  ): Promise<void> {
+    if (this.closed) return;
+
+    const authHeaders = await this.resolveAuthHeaders(options);
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      ...authHeaders,
+    };
+    if (options?.sessionId) {
+      headers["Mcp-Session-Id"] = options.sessionId;
+    }
+
+    const fetchImpl = this.options.fetchImpl ?? fetch;
+    await fetchImpl(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ jsonrpc: "2.0", method }),
+      signal: AbortSignal.timeout(30_000),
+    });
+  }
+
+  /**
+   * Return the auth headers to send on an outbound request. Workspace auth
+   * (SP or OBO) is only resolved when `forwardWorkspaceAuth` is true; for
+   * non-workspace hosts no bearer token is attached.
+   */
+  private async resolveAuthHeaders(options?: {
+    authOverride?: Record<string, string>;
+    forwardWorkspaceAuth?: boolean;
+  }): Promise<Record<string, string>> {
+    if (!options?.forwardWorkspaceAuth) return {};
+    if (options.authOverride) return options.authOverride;
+    return this.authenticate();
+  }
+}

--- a/packages/appkit/src/plugins/agents/tools/mcp-client.ts
+++ b/packages/appkit/src/plugins/agents/tools/mcp-client.ts
@@ -1,3 +1,27 @@
+/**
+ * Custom MCP over HTTP (Streamable) — not `@modelcontextprotocol/sdk`
+ *
+ * This module implements a tiny JSON-RPC 2.0 client on `fetch` for the subset
+ * of MCP we need: `initialize`, `notifications/initialized`, `tools/list`,
+ * `tools/call` over a single JSON request/response. We do not use the official
+ * SDK because:
+ *
+ * - **Policy and auth are the product** — every outbound URL is checked with
+ *   {@link McpHostPolicy} (allowlist, DNS, private/blocked IP ranges) before
+ *   the first byte is sent, and workspace tokens are only forwarded when
+ *   `forwardWorkspaceAuth` is true for that destination. A generic transport
+ *   from the SDK would still need the same hooks; re-wrapping it would be
+ *   about as much code, with a larger third-party surface to audit.
+ * - **Narrow scope** — we only target Databricks-hosted MCP over Streamable
+ *   HTTP, not stdio, full SSE sessions, or the rest of the protocol. A
+ *   hand-rolled path keeps the call graph obvious in code review.
+ * - **Zero extra runtime dependency** for this path, consistent with other
+ *   small, security-sensitive AppKit pieces.
+ *
+ * Revisit if we add more transports, or if the SDK ships a first-class way to
+ * inject our host policy and per-URL auth without fighting the default
+ * transport.
+ */
 import type { AgentToolDefinition } from "shared";
 import { createLogger } from "../../../logging/logger";
 import type { McpEndpointConfig } from "../../../core/agent/tools/hosted-tools";
@@ -60,22 +84,8 @@ interface McpServerConnection {
  * are rejected before the first byte is sent, and workspace credentials are
  * only forwarded to the same-origin workspace. See `mcp-host-policy.ts`.
  *
- * ### Why not `@modelcontextprotocol/sdk`?
- *
- * Our security model — zero-trust host policy + per-destination auth scoping
- * via `forwardWorkspaceAuth` — is the load-bearing anchor of this module, not
- * the wire protocol. Wrapping the SDK to enforce the same invariants (custom
- * transport + auth plumbing + policy checks before every request) ends up
- * the same size as writing the narrow JSON-RPC subset directly, but with an
- * opaque dependency that's harder to audit. Our entire target surface is
- * Databricks-hosted MCP over Streamable HTTP; we never need stdio, SSE-only
- * transport, or the rest of the protocol the SDK covers.
- *
- * Zero runtime deps matches the rest of AppKit's philosophy
- * (`DatabricksAdapter`, `sql-policy`). Revisit the call if MCP adoption
- * grows beyond Databricks-hosted servers with the transports above, or if
- * the SDK gains transport-level auth hooks that cleanly match our
- * per-destination auth-forwarding model.
+ * Rationale for hand-rolling JSON-RPC instead of `@modelcontextprotocol/sdk`:
+ * see the file-level comment at the top of this module.
  */
 export class AppKitMcpClient {
   private connections = new Map<string, McpServerConnection>();

--- a/packages/appkit/src/plugins/agents/tools/mcp-client.ts
+++ b/packages/appkit/src/plugins/agents/tools/mcp-client.ts
@@ -23,8 +23,8 @@
  * transport.
  */
 import type { AgentToolDefinition } from "shared";
-import { createLogger } from "../../../logging/logger";
 import type { McpEndpointConfig } from "../../../core/agent/tools/hosted-tools";
+import { createLogger } from "../../../logging/logger";
 import {
   assertResolvedHostSafe,
   checkMcpUrl,

--- a/packages/appkit/src/plugins/agents/tools/mcp-host-policy.ts
+++ b/packages/appkit/src/plugins/agents/tools/mcp-host-policy.ts
@@ -1,0 +1,299 @@
+import { lookup as defaultLookup } from "node:dns/promises";
+import { isIP, isIPv4 } from "node:net";
+
+/**
+ * DNS lookup function compatible with `dns/promises.lookup(host, { all: true })`.
+ * Exposed as an injection point so callers (tests, custom DNS resolvers) can
+ * override the default resolver.
+ */
+export type DnsLookup = (
+  hostname: string,
+  options: { all: true },
+) => Promise<Array<{ address: string; family: number }>>;
+
+/**
+ * Policy that decides whether a given MCP endpoint URL is allowed and whether
+ * Databricks workspace credentials (SP or OBO) may be forwarded to it.
+ *
+ * The default posture is zero-trust: only same-origin workspace URLs receive
+ * workspace credentials, and all other destinations must be explicitly
+ * allowlisted by the application developer. Private / link-local IP ranges
+ * are blocked outright to prevent SSRF into cloud metadata services.
+ */
+export interface McpHostPolicy {
+  /** Lowercased hostname of the Databricks workspace (same-origin target). */
+  readonly workspaceHostname: string;
+  /** Additional allowlisted hostnames (lowercased). Workspace auth is NEVER forwarded to these. */
+  readonly trustedHosts: ReadonlySet<string>;
+  /** Permit `http://localhost`, `127.0.0.1`, `::1` URLs. Typically true only in development. */
+  readonly allowLocalhost: boolean;
+}
+
+/**
+ * Config shape accepted by {@link buildMcpHostPolicy}, matching the
+ * `mcp` field on `AgentsPluginConfig`.
+ */
+export interface McpHostPolicyConfig {
+  /**
+   * Additional hostnames that may host custom MCP servers beyond the same-origin
+   * workspace. Compared case-insensitively; bare hostnames only (no scheme or
+   * path). Workspace credentials (SP / OBO) are never forwarded to these hosts —
+   * they must handle authentication themselves.
+   */
+  trustedHosts?: string[];
+  /**
+   * Allow `http://localhost`, `127.0.0.1`, and `::1` MCP URLs for local
+   * development. Defaults to `true` when `NODE_ENV !== "production"`,
+   * otherwise `false`. Workspace credentials are never forwarded to localhost.
+   */
+  allowLocalhost?: boolean;
+}
+
+/** Build an {@link McpHostPolicy} from user config + the resolved workspace URL. */
+export function buildMcpHostPolicy(
+  config: McpHostPolicyConfig | undefined,
+  workspaceHost: string,
+): McpHostPolicy {
+  const workspaceHostname = safeHostname(workspaceHost);
+  if (!workspaceHostname) {
+    throw new Error(
+      `Invalid workspace host for MCP policy: ${JSON.stringify(workspaceHost)}`,
+    );
+  }
+  const trustedHosts = new Set(
+    (config?.trustedHosts ?? []).map((h) => h.trim().toLowerCase()),
+  );
+  const allowLocalhost =
+    config?.allowLocalhost ?? process.env.NODE_ENV !== "production";
+  return { workspaceHostname, trustedHosts, allowLocalhost };
+}
+
+type McpUrlCheck =
+  | {
+      readonly ok: true;
+      /** Whether it is safe to forward workspace-scoped credentials (SP/OBO) to this URL. */
+      readonly forwardWorkspaceAuth: boolean;
+      /** Parsed URL for reuse by the caller. */
+      readonly url: URL;
+    }
+  | { readonly ok: false; readonly reason: string };
+
+/**
+ * Synchronously decide whether an MCP URL is allowed under the given policy
+ * and whether workspace credentials may be forwarded to it.
+ *
+ * Hard rejections:
+ * - Non-`http(s)` schemes.
+ * - `http://` unless the host is localhost AND `allowLocalhost` is true.
+ * - Hosts that are neither same-origin workspace, localhost (if allowed),
+ *   nor in `trustedHosts`.
+ */
+export function checkMcpUrl(
+  rawUrl: string,
+  policy: McpHostPolicy,
+): McpUrlCheck {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return {
+      ok: false,
+      reason: `MCP URL is not a valid absolute URL: ${rawUrl}`,
+    };
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    return {
+      ok: false,
+      reason: `MCP URL scheme '${url.protocol}' is not allowed (http(s) only): ${rawUrl}`,
+    };
+  }
+
+  const host = url.hostname.toLowerCase();
+  const isLoopback = isLoopbackHost(host);
+
+  if (url.protocol === "http:" && !(isLoopback && policy.allowLocalhost)) {
+    return {
+      ok: false,
+      reason: `MCP URL uses plaintext http:// which forwards bearer tokens in cleartext: ${rawUrl}. Use https:// or enable allowLocalhost for a localhost dev server.`,
+    };
+  }
+
+  if (host === policy.workspaceHostname) {
+    return { ok: true, forwardWorkspaceAuth: true, url };
+  }
+
+  if (isLoopback) {
+    if (!policy.allowLocalhost) {
+      return {
+        ok: false,
+        reason: `MCP URL points to localhost but allowLocalhost is disabled: ${rawUrl}`,
+      };
+    }
+    return { ok: true, forwardWorkspaceAuth: false, url };
+  }
+
+  if (policy.trustedHosts.has(host)) {
+    return { ok: true, forwardWorkspaceAuth: false, url };
+  }
+
+  return {
+    ok: false,
+    reason: `MCP host '${host}' is not allowed. Either use a same-origin workspace URL (${policy.workspaceHostname}) or add it to agents({ mcp: { trustedHosts: ['${host}'] } }).`,
+  };
+}
+
+/**
+ * Resolve `hostname` via DNS and assert that none of its addresses fall in a
+ * blocked IP range (loopback, RFC1918, link-local, CGNAT, cloud metadata).
+ *
+ * Throws with a descriptive error if any resolved address is blocked. Pass
+ * `allowLocalhost: true` to permit `127.0.0.1` / `::1` specifically.
+ *
+ * Note: this only guards against hosts that statically resolve to private
+ * ranges. Full SSRF protection requires socket-level IP pinning after
+ * resolution (DNS rebinding defense), which is out of scope here.
+ */
+export async function assertResolvedHostSafe(
+  hostname: string,
+  policy: McpHostPolicy,
+  lookup: DnsLookup = defaultLookup,
+): Promise<void> {
+  const lowered = hostname.toLowerCase();
+
+  if (isIP(lowered)) {
+    if (isBlockedIp(lowered, policy.allowLocalhost)) {
+      throw new Error(`MCP host ${lowered} is in a blocked IP range`);
+    }
+    return;
+  }
+
+  if (lowered === "localhost") {
+    if (!policy.allowLocalhost) {
+      throw new Error(
+        `MCP host localhost is not allowed under the current policy`,
+      );
+    }
+    return;
+  }
+
+  let resolved: Array<{ address: string }>;
+  try {
+    resolved = await lookup(hostname, { all: true });
+  } catch (cause) {
+    throw new Error(
+      `MCP host ${hostname} could not be resolved via DNS: ${cause instanceof Error ? cause.message : String(cause)}`,
+    );
+  }
+
+  if (resolved.length === 0) {
+    throw new Error(`MCP host ${hostname} returned no DNS addresses`);
+  }
+
+  for (const { address } of resolved) {
+    if (isBlockedIp(address, policy.allowLocalhost)) {
+      throw new Error(
+        `MCP host ${hostname} resolved to blocked address ${address} (private / link-local ranges are not allowed)`,
+      );
+    }
+  }
+}
+
+/** Whether a raw hostname literal is one of the recognised loopback aliases. */
+export function isLoopbackHost(host: string): boolean {
+  const lowered = host.toLowerCase();
+  return (
+    lowered === "localhost" ||
+    lowered === "127.0.0.1" ||
+    lowered === "::1" ||
+    lowered === "[::1]" ||
+    lowered === "0:0:0:0:0:0:0:1"
+  );
+}
+
+/**
+ * Check whether a resolved IP address is in a range that should never receive
+ * workspace credentials. `allowLocalhost` carves out 127.0.0.0/8 and ::1.
+ */
+export function isBlockedIp(address: string, allowLocalhost: boolean): boolean {
+  if (isIPv4(address)) {
+    return isBlockedIpv4(address, allowLocalhost);
+  }
+  if (isIP(address) === 6) {
+    return isBlockedIpv6(address, allowLocalhost);
+  }
+  // Not a recognisable IP literal — fail-closed.
+  return true;
+}
+
+function isBlockedIpv4(addr: string, allowLocalhost: boolean): boolean {
+  const parts = addr.split(".").map((p) => Number.parseInt(p, 10));
+  if (parts.length !== 4 || parts.some((n) => !Number.isFinite(n))) {
+    return true;
+  }
+  const [a, b] = parts;
+  if (a === 0) return true;
+  if (a === 127) return !allowLocalhost;
+  if (a === 10) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  if (a >= 224) return true;
+  return false;
+}
+
+function isBlockedIpv6(addr: string, allowLocalhost: boolean): boolean {
+  const lowered = addr.toLowerCase().replace(/^\[|\]$/g, "");
+
+  if (lowered === "::") return true;
+  if (lowered === "::1" || lowered === "0:0:0:0:0:0:0:1")
+    return !allowLocalhost;
+
+  // IPv4-mapped IPv6: `::ffff:<v4>` may be written in dotted form
+  // (`::ffff:169.254.169.254`) or colon-hex form (`::ffff:a9fe:a9fe`). Both
+  // route to the same destination, so we must normalise before delegating
+  // to the IPv4 blocklist.
+  if (lowered.startsWith("::ffff:")) {
+    const tail = lowered.slice("::ffff:".length);
+    if (isIPv4(tail)) return isBlockedIpv4(tail, allowLocalhost);
+    const hexV4 = hexPairToDottedIpv4(tail);
+    if (hexV4) return isBlockedIpv4(hexV4, allowLocalhost);
+  }
+
+  // Unique Local Addresses (fc00::/7) — `fc` and `fd` only.
+  if (/^f[cd][0-9a-f]{2}:/.test(lowered)) return true;
+  // Link-local fe80::/10 — the first 10 bits are 1111111010, i.e. the
+  // second hex nibble must be 8-b. Matches fe80:..–febf:..
+  if (/^fe[89ab][0-9a-f]:/.test(lowered)) return true;
+  // Multicast ff00::/8.
+  if (lowered.startsWith("ff")) return true;
+  return false;
+}
+
+/**
+ * Parse the trailing two hex groups of an IPv4-mapped IPv6 address written
+ * in colon-hex form (e.g. `a9fe:a9fe`) into the equivalent dotted-quad IPv4
+ * representation (`169.254.169.254`). Returns null for anything else.
+ */
+function hexPairToDottedIpv4(tail: string): string | null {
+  const match = tail.match(/^([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  if (!match) return null;
+  const hi = Number.parseInt(match[1], 16);
+  const lo = Number.parseInt(match[2], 16);
+  if (!Number.isFinite(hi) || !Number.isFinite(lo)) return null;
+  if (hi < 0 || hi > 0xffff || lo < 0 || lo > 0xffff) return null;
+  const a = (hi >> 8) & 0xff;
+  const b = hi & 0xff;
+  const c = (lo >> 8) & 0xff;
+  const d = lo & 0xff;
+  return `${a}.${b}.${c}.${d}`;
+}
+
+function safeHostname(rawUrl: string): string | null {
+  try {
+    return new URL(rawUrl).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}

--- a/packages/appkit/src/plugins/analytics/analytics.ts
+++ b/packages/appkit/src/plugins/analytics/analytics.ts
@@ -11,9 +11,6 @@ import type {
 import { z } from "zod";
 import { SQLWarehouseConnector } from "../../connectors";
 import { getWarehouseId, getWorkspaceClient } from "../../context";
-import { createLogger } from "../../logging/logger";
-import { Plugin, toPlugin } from "../../plugin";
-import type { PluginManifest } from "../../registry";
 import { buildToolkitEntries } from "../../core/agent/build-toolkit";
 import {
   defineTool,
@@ -21,6 +18,9 @@ import {
   toolsFromRegistry,
 } from "../../core/agent/tools/define-tool";
 import { assertReadOnlySql } from "../../core/agent/tools/sql-policy";
+import { createLogger } from "../../logging/logger";
+import { Plugin, toPlugin } from "../../plugin";
+import type { PluginManifest } from "../../registry";
 import { queryDefaults } from "./defaults";
 import manifest from "./manifest.json";
 import { QueryProcessor } from "./query";

--- a/packages/appkit/src/plugins/analytics/analytics.ts
+++ b/packages/appkit/src/plugins/analytics/analytics.ts
@@ -1,16 +1,26 @@
 import type { WorkspaceClient } from "@databricks/sdk-experimental";
 import type express from "express";
 import type {
+  AgentToolDefinition,
   IAppRouter,
   PluginExecuteConfig,
   SQLTypeMarker,
   StreamExecutionSettings,
+  ToolProvider,
 } from "shared";
+import { z } from "zod";
 import { SQLWarehouseConnector } from "../../connectors";
 import { getWarehouseId, getWorkspaceClient } from "../../context";
 import { createLogger } from "../../logging/logger";
 import { Plugin, toPlugin } from "../../plugin";
 import type { PluginManifest } from "../../registry";
+import { buildToolkitEntries } from "../../core/agent/build-toolkit";
+import {
+  defineTool,
+  executeFromRegistry,
+  toolsFromRegistry,
+} from "../../core/agent/tools/define-tool";
+import { assertReadOnlySql } from "../../core/agent/tools/sql-policy";
 import { queryDefaults } from "./defaults";
 import manifest from "./manifest.json";
 import { QueryProcessor } from "./query";
@@ -22,7 +32,7 @@ import type {
 
 const logger = createLogger("analytics");
 
-export class AnalyticsPlugin extends Plugin {
+export class AnalyticsPlugin extends Plugin implements ToolProvider {
   /** Plugin manifest declaring metadata and resource requirements */
   static manifest = manifest as PluginManifest<"analytics">;
 
@@ -263,6 +273,52 @@ export class AnalyticsPlugin extends Plugin {
 
   async shutdown(): Promise<void> {
     this.streamManager.abortAll();
+  }
+
+  private tools = {
+    query: defineTool({
+      description:
+        "Execute a read-only SQL query against the Databricks SQL warehouse. Only SELECT, WITH, SHOW, EXPLAIN, and DESCRIBE statements are accepted; writes are rejected. Returns the query results as JSON.",
+      schema: z.object({
+        query: z
+          .string()
+          .describe(
+            "The SQL query to execute. Must be a SELECT, WITH, SHOW, EXPLAIN, or DESCRIBE statement.",
+          ),
+      }),
+      annotations: {
+        readOnly: true,
+        requiresUserContext: true,
+      },
+      autoInheritable: true,
+      handler: (args, signal) => {
+        assertReadOnlySql(args.query);
+        return this.query(args.query, undefined, undefined, signal);
+      },
+    }),
+  };
+
+  getAgentTools(): AgentToolDefinition[] {
+    return toolsFromRegistry(this.tools);
+  }
+
+  async executeAgentTool(
+    name: string,
+    args: unknown,
+    signal?: AbortSignal,
+  ): Promise<unknown> {
+    return executeFromRegistry(this.tools, name, args, signal);
+  }
+
+  /**
+   * Returns the plugin's tools as a keyed record of `ToolkitEntry` markers.
+   * Called by the agents plugin (via `resolveToolkitFromProvider`) to spread
+   * a filtered, renamed view of the plugin's tools into an agent's tool
+   * index. Most callers should go through `fromPlugin(analytics, opts)` at
+   * module scope instead of reaching for this directly.
+   */
+  toolkit(opts?: import("../../core/agent/types").ToolkitOptions) {
+    return buildToolkitEntries(this.name, this.tools, opts);
   }
 
   /**

--- a/packages/appkit/src/plugins/analytics/tests/analytics.readonly.test.ts
+++ b/packages/appkit/src/plugins/analytics/tests/analytics.readonly.test.ts
@@ -47,7 +47,6 @@ describe("AnalyticsPlugin.query agent tool — runtime enforcement", () => {
     const plugin = makePlugin();
     const spy = vi
       .spyOn(plugin, "query")
-      // biome-ignore lint/suspicious/noExplicitAny: mocked return
       .mockResolvedValue({ rows: [] } as any);
     await expect(
       plugin.executeAgentTool("query", { query: "DROP TABLE users" }),
@@ -59,7 +58,6 @@ describe("AnalyticsPlugin.query agent tool — runtime enforcement", () => {
     const plugin = makePlugin();
     const spy = vi
       .spyOn(plugin, "query")
-      // biome-ignore lint/suspicious/noExplicitAny: mocked return
       .mockResolvedValue({ rows: [] } as any);
     for (const q of [
       "UPDATE users SET email='x'",
@@ -79,7 +77,6 @@ describe("AnalyticsPlugin.query agent tool — runtime enforcement", () => {
     const plugin = makePlugin();
     const spy = vi
       .spyOn(plugin, "query")
-      // biome-ignore lint/suspicious/noExplicitAny: mocked return
       .mockResolvedValue({ rows: [] } as any);
     await expect(
       plugin.executeAgentTool("query", {
@@ -93,7 +90,6 @@ describe("AnalyticsPlugin.query agent tool — runtime enforcement", () => {
     const plugin = makePlugin();
     const spy = vi
       .spyOn(plugin, "query")
-      // biome-ignore lint/suspicious/noExplicitAny: mocked return
       .mockResolvedValue({ rows: [{ id: 1 }] } as any);
     const result = await plugin.executeAgentTool("query", {
       query: "SELECT * FROM main.sales.orders",
@@ -111,7 +107,6 @@ describe("AnalyticsPlugin.query agent tool — runtime enforcement", () => {
     const plugin = makePlugin();
     const spy = vi
       .spyOn(plugin, "query")
-      // biome-ignore lint/suspicious/noExplicitAny: mocked return
       .mockResolvedValue({ rows: [] } as any);
     await plugin.executeAgentTool("query", {
       query: "WITH a AS (SELECT 1) SELECT * FROM a",
@@ -123,7 +118,6 @@ describe("AnalyticsPlugin.query agent tool — runtime enforcement", () => {
     const plugin = makePlugin();
     const spy = vi
       .spyOn(plugin, "query")
-      // biome-ignore lint/suspicious/noExplicitAny: mocked return
       .mockResolvedValue({ rows: [] } as any);
     await plugin.executeAgentTool("query", {
       query: "SHOW TABLES IN main.sales",

--- a/packages/appkit/src/plugins/analytics/tests/analytics.readonly.test.ts
+++ b/packages/appkit/src/plugins/analytics/tests/analytics.readonly.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("../../../cache", () => ({
+  CacheManager: {
+    getInstanceSync: vi.fn(() => ({
+      get: vi.fn(),
+      set: vi.fn(),
+      delete: vi.fn(),
+      getOrExecute: vi.fn(async (_k: unknown[], fn: () => Promise<unknown>) =>
+        fn(),
+      ),
+      generateKey: vi.fn(() => "test-key"),
+    })),
+  },
+}));
+
+import { AnalyticsPlugin } from "../analytics";
+
+/**
+ * Tests the read-only SQL enforcement on the analytics agent tool.
+ *
+ * The tool is annotated `{ readOnly: true, requiresUserContext: true }`; this
+ * suite verifies that the annotation is enforced at execution time — not just
+ * exposed as metadata to the LLM — by the `assertReadOnlySql` guard in the
+ * tool's handler.
+ */
+
+function makePlugin(): AnalyticsPlugin {
+  return new AnalyticsPlugin({});
+}
+
+describe("AnalyticsPlugin.query agent tool — readOnly annotation", () => {
+  test("is advertised with readOnly:true and requiresUserContext:true", () => {
+    const plugin = makePlugin();
+    const defs = plugin.getAgentTools();
+    const query = defs.find((d) => d.name === "query");
+    expect(query).toBeDefined();
+    expect(query?.annotations).toEqual({
+      readOnly: true,
+      requiresUserContext: true,
+    });
+  });
+});
+
+describe("AnalyticsPlugin.query agent tool — runtime enforcement", () => {
+  test("rejects a DROP statement before it reaches this.query", async () => {
+    const plugin = makePlugin();
+    const spy = vi
+      .spyOn(plugin, "query")
+      // biome-ignore lint/suspicious/noExplicitAny: mocked return
+      .mockResolvedValue({ rows: [] } as any);
+    await expect(
+      plugin.executeAgentTool("query", { query: "DROP TABLE users" }),
+    ).rejects.toThrow(/read-only policy violation/i);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  test("rejects UPDATE, DELETE, INSERT, TRUNCATE, GRANT", async () => {
+    const plugin = makePlugin();
+    const spy = vi
+      .spyOn(plugin, "query")
+      // biome-ignore lint/suspicious/noExplicitAny: mocked return
+      .mockResolvedValue({ rows: [] } as any);
+    for (const q of [
+      "UPDATE users SET email='x'",
+      "DELETE FROM orders",
+      "INSERT INTO x VALUES (1)",
+      "TRUNCATE TABLE orders",
+      "GRANT SELECT ON t TO u",
+    ]) {
+      await expect(
+        plugin.executeAgentTool("query", { query: q }),
+      ).rejects.toThrow(/read-only policy violation/i);
+    }
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  test("rejects a stacked SELECT + DROP", async () => {
+    const plugin = makePlugin();
+    const spy = vi
+      .spyOn(plugin, "query")
+      // biome-ignore lint/suspicious/noExplicitAny: mocked return
+      .mockResolvedValue({ rows: [] } as any);
+    await expect(
+      plugin.executeAgentTool("query", {
+        query: "SELECT 1; DROP TABLE users",
+      }),
+    ).rejects.toThrow(/DROP/);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  test("passes a plain SELECT through to this.query", async () => {
+    const plugin = makePlugin();
+    const spy = vi
+      .spyOn(plugin, "query")
+      // biome-ignore lint/suspicious/noExplicitAny: mocked return
+      .mockResolvedValue({ rows: [{ id: 1 }] } as any);
+    const result = await plugin.executeAgentTool("query", {
+      query: "SELECT * FROM main.sales.orders",
+    });
+    expect(result).toEqual({ rows: [{ id: 1 }] });
+    expect(spy).toHaveBeenCalledWith(
+      "SELECT * FROM main.sales.orders",
+      undefined,
+      undefined,
+      undefined,
+    );
+  });
+
+  test("passes WITH … SELECT through", async () => {
+    const plugin = makePlugin();
+    const spy = vi
+      .spyOn(plugin, "query")
+      // biome-ignore lint/suspicious/noExplicitAny: mocked return
+      .mockResolvedValue({ rows: [] } as any);
+    await plugin.executeAgentTool("query", {
+      query: "WITH a AS (SELECT 1) SELECT * FROM a",
+    });
+    expect(spy).toHaveBeenCalledOnce();
+  });
+
+  test("passes SHOW TABLES through", async () => {
+    const plugin = makePlugin();
+    const spy = vi
+      .spyOn(plugin, "query")
+      // biome-ignore lint/suspicious/noExplicitAny: mocked return
+      .mockResolvedValue({ rows: [] } as any);
+    await plugin.executeAgentTool("query", {
+      query: "SHOW TABLES IN main.sales",
+    });
+    expect(spy).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/appkit/src/plugins/analytics/tests/analytics.test.ts
+++ b/packages/appkit/src/plugins/analytics/tests/analytics.test.ts
@@ -605,4 +605,22 @@ describe("Analytics Plugin", () => {
       });
     });
   });
+
+  describe("toolkit()", () => {
+    test("produces ToolkitEntry records keyed by the plugin name", () => {
+      const plugin = new AnalyticsPlugin({ name: "analytics" });
+      const entries = plugin.toolkit();
+      expect(Object.keys(entries)).toContain("analytics.query");
+      const entry = entries["analytics.query"];
+      expect(entry.__toolkitRef).toBe(true);
+      expect(entry.pluginName).toBe("analytics");
+      expect(entry.localName).toBe("query");
+    });
+
+    test("respects prefix and only options", () => {
+      const plugin = new AnalyticsPlugin({ name: "analytics" });
+      const entries = plugin.toolkit({ prefix: "", only: ["query"] });
+      expect(Object.keys(entries)).toEqual(["query"]);
+    });
+  });
 });

--- a/packages/appkit/src/plugins/files/plugin.ts
+++ b/packages/appkit/src/plugins/files/plugin.ts
@@ -243,15 +243,11 @@ export class FilesPlugin extends Plugin implements ToolProvider {
         telemetry: config.telemetry,
         customContentTypes: mergedConfig.customContentTypes,
       });
-    }
 
-    for (const volumeKey of this.volumeKeys) {
-      Object.assign(this.tools, this._defineVolumeTools(volumeKey));
-    }
+      Object.assign(this.tools, this._defineVolumeTools(key));
 
-    // Warn at startup for volumes without an explicit policy
-    for (const key of this.volumeKeys) {
-      if (!volumes[key].policy) {
+      // Warn at startup for volumes without an explicit policy
+      if (!volumeCfg.policy) {
         logger.warn(
           'Volume "%s" has no explicit policy — defaulting to publicRead(). ' +
             "Set a policy in files({ volumes: { %s: { policy: ... } } }) to silence this warning.",

--- a/packages/appkit/src/plugins/files/plugin.ts
+++ b/packages/appkit/src/plugins/files/plugin.ts
@@ -21,11 +21,6 @@ import {
   getWorkspaceClient,
 } from "../../context";
 import { isUserContext } from "../../context/user-context";
-import { AuthenticationError } from "../../errors";
-import { createLogger } from "../../logging/logger";
-import { Plugin, toPlugin } from "../../plugin";
-import type { PluginManifest, ResourceRequirement } from "../../registry";
-import { ResourceType } from "../../registry";
 import { buildToolkitEntries } from "../../core/agent/build-toolkit";
 import {
   defineTool,
@@ -33,6 +28,11 @@ import {
   type ToolRegistry,
   toolsFromRegistry,
 } from "../../core/agent/tools/define-tool";
+import { AuthenticationError } from "../../errors";
+import { createLogger } from "../../logging/logger";
+import { Plugin, toPlugin } from "../../plugin";
+import type { PluginManifest, ResourceRequirement } from "../../registry";
+import { ResourceType } from "../../registry";
 import {
   FILES_DOWNLOAD_DEFAULTS,
   FILES_MAX_UPLOAD_SIZE,
@@ -49,7 +49,6 @@ import {
   policy,
 } from "./policy";
 import type {
-  DownloadResponse,
   FilesExport,
   IFilesConfig,
   VolumeAPI,

--- a/packages/appkit/src/plugins/files/plugin.ts
+++ b/packages/appkit/src/plugins/files/plugin.ts
@@ -2,19 +2,37 @@ import { STATUS_CODES } from "node:http";
 import { Readable } from "node:stream";
 import { ApiError } from "@databricks/sdk-experimental";
 import type express from "express";
-import type { IAppRouter, PluginExecutionSettings } from "shared";
+import type {
+  AgentToolDefinition,
+  IAppRouter,
+  PluginExecutionSettings,
+  ToolProvider,
+} from "shared";
+import { z } from "zod";
 import {
   contentTypeFromPath,
   FilesConnector,
   isSafeInlineContentType,
   validateCustomContentTypes,
 } from "../../connectors/files";
-import { getCurrentUserId, getWorkspaceClient } from "../../context";
+import {
+  getCurrentUserId,
+  getExecutionContext,
+  getWorkspaceClient,
+} from "../../context";
+import { isUserContext } from "../../context/user-context";
 import { AuthenticationError } from "../../errors";
 import { createLogger } from "../../logging/logger";
 import { Plugin, toPlugin } from "../../plugin";
 import type { PluginManifest, ResourceRequirement } from "../../registry";
 import { ResourceType } from "../../registry";
+import { buildToolkitEntries } from "../../core/agent/build-toolkit";
+import {
+  defineTool,
+  executeFromRegistry,
+  type ToolRegistry,
+  toolsFromRegistry,
+} from "../../core/agent/tools/define-tool";
 import {
   FILES_DOWNLOAD_DEFAULTS,
   FILES_MAX_UPLOAD_SIZE,
@@ -41,7 +59,7 @@ import type {
 
 const logger = createLogger("files");
 
-export class FilesPlugin extends Plugin {
+export class FilesPlugin extends Plugin implements ToolProvider {
   name = "files";
 
   /** Plugin manifest declaring metadata and resource requirements. */
@@ -52,6 +70,7 @@ export class FilesPlugin extends Plugin {
   private volumeConnectors: Record<string, FilesConnector> = {};
   private volumeConfigs: Record<string, VolumeConfig> = {};
   private volumeKeys: string[] = [];
+  private tools: ToolRegistry = {};
 
   /**
    * Scans `process.env` for `DATABRICKS_VOLUME_*` keys and merges them with
@@ -224,6 +243,10 @@ export class FilesPlugin extends Plugin {
         telemetry: config.telemetry,
         customContentTypes: mergedConfig.customContentTypes,
       });
+    }
+
+    for (const volumeKey of this.volumeKeys) {
+      Object.assign(this.tools, this._defineVolumeTools(volumeKey));
     }
 
     // Warn at startup for volumes without an explicit policy
@@ -1019,6 +1042,91 @@ export class FilesPlugin extends Plugin {
     };
   }
 
+  /**
+   * Builds the agent-tool registry entries for a single volume. One set of
+   * tools per configured volume, keyed by `${volumeKey}.${method}`.
+   *
+   * Each handler resolves the caller's identity from the current execution
+   * context (OBO user when the agent run is wrapped in `asUser(req)`, service
+   * principal otherwise in local dev) and dispatches through
+   * `createVolumeAPI(volumeKey, user)` so the volume's policy is enforced
+   * uniformly for agent and HTTP callers.
+   */
+  private _defineVolumeTools(volumeKey: string): ToolRegistry {
+    const buildUser = (): FilePolicyUser => {
+      const ctx = getExecutionContext();
+      return isUserContext(ctx)
+        ? { id: ctx.userId }
+        : { id: ctx.serviceUserId, isServicePrincipal: true };
+    };
+    const api = () => this.createVolumeAPI(volumeKey, buildUser());
+    return {
+      [`${volumeKey}.list`]: defineTool({
+        description: `List files and directories in the "${volumeKey}" volume`,
+        schema: z.object({
+          path: z
+            .string()
+            .optional()
+            .describe("Directory path to list (optional, defaults to root)"),
+        }),
+        annotations: { readOnly: true, requiresUserContext: true },
+        autoInheritable: true,
+        handler: (args) => api().list(args.path),
+      }),
+      [`${volumeKey}.read`]: defineTool({
+        description: `Read a text file from the "${volumeKey}" volume`,
+        schema: z.object({
+          path: z.string().describe("File path to read"),
+        }),
+        annotations: { readOnly: true, requiresUserContext: true },
+        autoInheritable: true,
+        handler: (args) => api().read(args.path),
+      }),
+      [`${volumeKey}.exists`]: defineTool({
+        description: `Check if a file or directory exists in the "${volumeKey}" volume`,
+        schema: z.object({
+          path: z.string().describe("Path to check"),
+        }),
+        annotations: { readOnly: true, requiresUserContext: true },
+        autoInheritable: true,
+        handler: (args) => api().exists(args.path),
+      }),
+      [`${volumeKey}.metadata`]: defineTool({
+        description: `Get metadata (size, type, last modified) for a file in the "${volumeKey}" volume`,
+        schema: z.object({
+          path: z.string().describe("File path"),
+        }),
+        annotations: { readOnly: true, requiresUserContext: true },
+        autoInheritable: true,
+        handler: (args) => api().metadata(args.path),
+      }),
+      [`${volumeKey}.upload`]: defineTool({
+        description: `Upload a text file to the "${volumeKey}" volume`,
+        schema: z.object({
+          path: z.string().describe("Destination file path"),
+          contents: z.string().describe("File contents as a string"),
+          overwrite: z
+            .boolean()
+            .optional()
+            .describe("Whether to overwrite existing file"),
+        }),
+        annotations: { destructive: true, requiresUserContext: true },
+        handler: (args) =>
+          api().upload(args.path, args.contents, {
+            overwrite: args.overwrite,
+          }),
+      }),
+      [`${volumeKey}.delete`]: defineTool({
+        description: `Delete a file from the "${volumeKey}" volume`,
+        schema: z.object({
+          path: z.string().describe("File path to delete"),
+        }),
+        annotations: { destructive: true, requiresUserContext: true },
+        handler: (args) => api().delete(args.path),
+      }),
+    };
+  }
+
   private inflightWrites = 0;
 
   private trackWrite<T>(fn: () => Promise<T>): Promise<T> {
@@ -1045,6 +1153,22 @@ export class FilesPlugin extends Plugin {
       );
     }
     this.streamManager.abortAll();
+  }
+
+  getAgentTools(): AgentToolDefinition[] {
+    return toolsFromRegistry(this.tools);
+  }
+
+  async executeAgentTool(
+    name: string,
+    args: unknown,
+    signal?: AbortSignal,
+  ): Promise<unknown> {
+    return executeFromRegistry(this.tools, name, args, signal);
+  }
+
+  toolkit(opts?: import("../../core/agent/types").ToolkitOptions) {
+    return buildToolkitEntries(this.name, this.tools, opts);
   }
 
   /**

--- a/packages/appkit/src/plugins/files/tests/plugin.test.ts
+++ b/packages/appkit/src/plugins/files/tests/plugin.test.ts
@@ -205,6 +205,62 @@ describe("FilesPlugin", () => {
     });
   });
 
+  describe("getAgentTools / executeAgentTool", () => {
+    test("produces independent tool entries per volume", () => {
+      const plugin = new FilesPlugin(VOLUMES_CONFIG);
+      const tools = plugin.getAgentTools();
+      const names = tools.map((t) => t.name);
+
+      expect(names).toContain("uploads.list");
+      expect(names).toContain("uploads.read");
+      expect(names).toContain("uploads.exists");
+      expect(names).toContain("uploads.metadata");
+      expect(names).toContain("uploads.upload");
+      expect(names).toContain("uploads.delete");
+
+      expect(names).toContain("exports.list");
+      expect(names).toContain("exports.read");
+      expect(names).toContain("exports.delete");
+
+      expect(tools).toHaveLength(12);
+    });
+
+    test("dispatches to the correct volume API based on the tool name", async () => {
+      const plugin = new FilesPlugin(VOLUMES_CONFIG);
+      const asyncIterable = (items: { path: string }[]) => ({
+        [Symbol.asyncIterator]: async function* () {
+          for (const item of items) yield item;
+        },
+      });
+      mockClient.files.listDirectoryContents.mockReturnValueOnce(
+        asyncIterable([{ path: "uploads-file" }]),
+      );
+      mockClient.files.listDirectoryContents.mockReturnValueOnce(
+        asyncIterable([{ path: "exports-file" }]),
+      );
+
+      const uploadsResult = (await plugin.executeAgentTool(
+        "uploads.list",
+        {},
+      )) as { path: string }[];
+      const exportsResult = (await plugin.executeAgentTool(
+        "exports.list",
+        {},
+      )) as { path: string }[];
+
+      expect(uploadsResult[0].path).toBe("uploads-file");
+      expect(exportsResult[0].path).toBe("exports-file");
+    });
+
+    test("returns LLM-friendly error string for invalid tool args", async () => {
+      const plugin = new FilesPlugin(VOLUMES_CONFIG);
+      const result = await plugin.executeAgentTool("uploads.read", {});
+      expect(typeof result).toBe("string");
+      expect(result).toContain("Invalid arguments for uploads.read");
+      expect(result).toContain("path");
+    });
+  });
+
   describe("exports()", () => {
     test("returns a callable function with a .volume alias", () => {
       const plugin = new FilesPlugin(VOLUMES_CONFIG);

--- a/packages/appkit/src/plugins/genie/genie.ts
+++ b/packages/appkit/src/plugins/genie/genie.ts
@@ -1,11 +1,24 @@
 import { randomUUID } from "node:crypto";
 import type express from "express";
-import type { IAppRouter, StreamExecutionSettings } from "shared";
+import type {
+  AgentToolDefinition,
+  IAppRouter,
+  StreamExecutionSettings,
+  ToolProvider,
+} from "shared";
+import { z } from "zod";
 import { GenieConnector } from "../../connectors";
 import { getWorkspaceClient } from "../../context";
 import { createLogger } from "../../logging";
 import { Plugin, toPlugin } from "../../plugin";
 import type { PluginManifest } from "../../registry";
+import { buildToolkitEntries } from "../../core/agent/build-toolkit";
+import {
+  defineTool,
+  executeFromRegistry,
+  type ToolRegistry,
+  toolsFromRegistry,
+} from "../../core/agent/tools/define-tool";
 import { genieStreamDefaults } from "./defaults";
 import manifest from "./manifest.json";
 import type {
@@ -17,7 +30,7 @@ import type {
 
 const logger = createLogger("genie");
 
-export class GeniePlugin extends Plugin {
+export class GeniePlugin extends Plugin implements ToolProvider {
   static manifest = manifest as PluginManifest<"genie">;
 
   protected static description =
@@ -25,6 +38,7 @@ export class GeniePlugin extends Plugin {
   protected declare config: IGenieConfig;
 
   private readonly genieConnector: GenieConnector;
+  private tools: ToolRegistry = {};
 
   constructor(config: IGenieConfig) {
     super(config);
@@ -36,6 +50,54 @@ export class GeniePlugin extends Plugin {
       timeout: this.config.timeout,
       maxMessages: 200,
     });
+
+    for (const alias of Object.keys(this.config.spaces ?? {})) {
+      Object.assign(this.tools, this._defineSpaceTools(alias));
+    }
+  }
+
+  /**
+   * Builds the registry entries for a single Genie space alias.
+   * One set of tools per configured space, keyed by `${alias}.${method}`.
+   */
+  private _defineSpaceTools(alias: string): ToolRegistry {
+    return {
+      [`${alias}.sendMessage`]: defineTool({
+        description: `Send a natural language question to the Genie space "${alias}" and get data analysis results`,
+        schema: z.object({
+          content: z.string().describe("The natural language question to ask"),
+          conversationId: z
+            .string()
+            .optional()
+            .describe(
+              "Optional conversation ID to continue an existing conversation",
+            ),
+        }),
+        annotations: { requiresUserContext: true },
+        handler: async (args) => {
+          const events: GenieStreamEvent[] = [];
+          for await (const event of this.sendMessage(
+            alias,
+            args.content,
+            args.conversationId,
+          )) {
+            events.push(event);
+          }
+          return events;
+        },
+      }),
+      [`${alias}.getConversation`]: defineTool({
+        description: `Retrieve the conversation history from the Genie space "${alias}"`,
+        schema: z.object({
+          conversationId: z
+            .string()
+            .describe("The conversation ID to retrieve"),
+        }),
+        annotations: { readOnly: true, requiresUserContext: true },
+        autoInheritable: true,
+        handler: (args) => this.getConversation(alias, args.conversationId),
+      }),
+    };
   }
 
   private defaultSpaces(): Record<string, string> {
@@ -285,6 +347,22 @@ export class GeniePlugin extends Plugin {
 
   async shutdown(): Promise<void> {
     this.streamManager.abortAll();
+  }
+
+  getAgentTools(): AgentToolDefinition[] {
+    return toolsFromRegistry(this.tools);
+  }
+
+  async executeAgentTool(
+    name: string,
+    args: unknown,
+    signal?: AbortSignal,
+  ): Promise<unknown> {
+    return executeFromRegistry(this.tools, name, args, signal);
+  }
+
+  toolkit(opts?: import("../../core/agent/types").ToolkitOptions) {
+    return buildToolkitEntries(this.name, this.tools, opts);
   }
 
   exports() {

--- a/packages/appkit/src/plugins/genie/genie.ts
+++ b/packages/appkit/src/plugins/genie/genie.ts
@@ -9,9 +9,6 @@ import type {
 import { z } from "zod";
 import { GenieConnector } from "../../connectors";
 import { getWorkspaceClient } from "../../context";
-import { createLogger } from "../../logging";
-import { Plugin, toPlugin } from "../../plugin";
-import type { PluginManifest } from "../../registry";
 import { buildToolkitEntries } from "../../core/agent/build-toolkit";
 import {
   defineTool,
@@ -19,6 +16,9 @@ import {
   type ToolRegistry,
   toolsFromRegistry,
 } from "../../core/agent/tools/define-tool";
+import { createLogger } from "../../logging";
+import { Plugin, toPlugin } from "../../plugin";
+import type { PluginManifest } from "../../registry";
 import { genieStreamDefaults } from "./defaults";
 import manifest from "./manifest.json";
 import type {

--- a/packages/appkit/src/plugins/genie/tests/genie.test.ts
+++ b/packages/appkit/src/plugins/genie/tests/genie.test.ts
@@ -187,6 +187,30 @@ describe("Genie Plugin", () => {
     });
   });
 
+  describe("getAgentTools / executeAgentTool", () => {
+    test("produces independent tool entries per configured space", () => {
+      const plugin = new GeniePlugin(config);
+      const names = plugin.getAgentTools().map((t) => t.name);
+
+      expect(names).toContain("myspace.sendMessage");
+      expect(names).toContain("myspace.getConversation");
+      expect(names).toContain("salesbot.sendMessage");
+      expect(names).toContain("salesbot.getConversation");
+      expect(names).toHaveLength(4);
+    });
+
+    test("returns LLM-friendly error string for invalid tool args", async () => {
+      const plugin = new GeniePlugin(config);
+      const result = await plugin.executeAgentTool(
+        "myspace.getConversation",
+        {},
+      );
+      expect(typeof result).toBe("string");
+      expect(result).toContain("Invalid arguments for myspace.getConversation");
+      expect(result).toContain("conversationId");
+    });
+  });
+
   describe("space alias resolution", () => {
     test("should return 404 for unknown alias", async () => {
       const plugin = new GeniePlugin(config);

--- a/packages/appkit/src/plugins/lakebase/lakebase.ts
+++ b/packages/appkit/src/plugins/lakebase/lakebase.ts
@@ -7,9 +7,6 @@ import {
   getLakebasePgConfig,
   getUsernameWithApiLookup,
 } from "../../connectors/lakebase";
-import { createLogger } from "../../logging/logger";
-import { Plugin, toPlugin } from "../../plugin";
-import type { PluginManifest } from "../../registry";
 import { buildToolkitEntries } from "../../core/agent/build-toolkit";
 import {
   defineTool,
@@ -17,6 +14,9 @@ import {
   toolsFromRegistry,
 } from "../../core/agent/tools/define-tool";
 import { assertReadOnlySql } from "../../core/agent/tools/sql-policy";
+import { createLogger } from "../../logging/logger";
+import { Plugin, toPlugin } from "../../plugin";
+import type { PluginManifest } from "../../registry";
 import manifest from "./manifest.json";
 import type { ILakebaseConfig } from "./types";
 

--- a/packages/appkit/src/plugins/lakebase/lakebase.ts
+++ b/packages/appkit/src/plugins/lakebase/lakebase.ts
@@ -1,4 +1,6 @@
 import type { Pool, QueryResult, QueryResultRow } from "pg";
+import type { AgentToolDefinition, ToolProvider } from "shared";
+import { z } from "zod";
 import {
   createLakebasePool,
   getLakebaseOrmConfig,
@@ -8,6 +10,13 @@ import {
 import { createLogger } from "../../logging/logger";
 import { Plugin, toPlugin } from "../../plugin";
 import type { PluginManifest } from "../../registry";
+import { buildToolkitEntries } from "../../core/agent/build-toolkit";
+import {
+  defineTool,
+  executeFromRegistry,
+  toolsFromRegistry,
+} from "../../core/agent/tools/define-tool";
+import { assertReadOnlySql } from "../../core/agent/tools/sql-policy";
 import manifest from "./manifest.json";
 import type { ILakebaseConfig } from "./types";
 
@@ -30,17 +39,12 @@ const logger = createLogger("lakebase");
  * const result = await AppKit.lakebase.query("SELECT * FROM users WHERE id = $1", [userId]);
  * ```
  */
-class LakebasePlugin extends Plugin {
+export class LakebasePlugin extends Plugin implements ToolProvider {
   /** Plugin manifest declaring metadata and resource requirements */
   static manifest = manifest as PluginManifest<"lakebase">;
 
   protected declare config: ILakebaseConfig;
   private pool: Pool | null = null;
-
-  constructor(config: ILakebaseConfig) {
-    super(config);
-    this.config = config;
-  }
 
   /**
    * Initializes the Lakebase connection pool.
@@ -80,6 +84,39 @@ class LakebasePlugin extends Plugin {
   }
 
   /**
+   * Execute a single statement inside a `BEGIN READ ONLY … ROLLBACK`
+   * transaction on a dedicated client.
+   *
+   * The three commands MUST share a connection — a naive
+   * `pool.query("BEGIN READ ONLY; <stmt>; ROLLBACK")` batch cannot accept
+   * parameter values (PostgreSQL's Extended Query protocol rejects multi-
+   * statement prepared queries), which would silently break every
+   * parameterized query the agent tool issues.
+   *
+   * Returns the raw `rows` array for the user's statement. Side effects the
+   * statement may attempt (writes, writable-function side effects) are
+   * rejected by PostgreSQL under the read-only transaction posture.
+   */
+  private async runReadOnlyStatement(
+    text: string,
+    values?: unknown[],
+  ): Promise<unknown[]> {
+    // biome-ignore lint/style/noNonNullAssertion: pool is guaranteed non-null after setup()
+    const client = await this.pool!.connect();
+    try {
+      await client.query("BEGIN READ ONLY");
+      const result = await client.query(text, values);
+      return result.rows;
+    } finally {
+      try {
+        await client.query("ROLLBACK");
+      } finally {
+        client.release();
+      }
+    }
+  }
+
+  /**
    * Gracefully drains and closes the connection pool.
    * Called automatically by AppKit during shutdown.
    */
@@ -102,6 +139,82 @@ class LakebasePlugin extends Plugin {
    * - `getOrmConfig()` — Returns a config object compatible with Drizzle, TypeORM, Sequelize, etc.
    * - `getPgConfig()` — Returns a `pg.PoolConfig` object for manual pool construction
    */
+
+  /**
+   * Agent tool registry. Empty by default — the Lakebase plugin does NOT
+   * expose its SQL connection to LLM agents unless the developer explicitly
+   * opts in via `config.exposeAsAgentTool`. See {@link buildQueryTool}.
+   */
+  private tools: Record<string, ReturnType<typeof this.buildQueryTool>> = {};
+
+  constructor(config: ILakebaseConfig) {
+    super(config);
+    this.config = config;
+    if (config.exposeAsAgentTool) {
+      if (config.exposeAsAgentTool.iUnderstandRunsAsServicePrincipal !== true) {
+        throw new Error(
+          "lakebase.exposeAsAgentTool requires iUnderstandRunsAsServicePrincipal: true — this acknowledges that SQL statements authored by the LLM run with the application's service-principal credentials regardless of which end user initiated the request.",
+        );
+      }
+      this.tools = { query: this.buildQueryTool(config.exposeAsAgentTool) };
+      logger.warn(
+        "Lakebase agent tool is enabled (readOnly=%s). Every agent with access to this plugin can execute SQL against the Lakebase database as the service principal.",
+        config.exposeAsAgentTool.readOnly !== false,
+      );
+    }
+  }
+
+  private buildQueryTool(
+    opt: NonNullable<ILakebaseConfig["exposeAsAgentTool"]>,
+  ) {
+    const readOnly = opt.readOnly !== false;
+    return defineTool({
+      description: readOnly
+        ? "Execute a read-only SQL query against the Lakebase PostgreSQL database. Only SELECT, WITH, SHOW, EXPLAIN, and DESCRIBE statements are accepted. Use $1, $2, etc. as placeholders and pass values separately. Runs as the application's service principal."
+        : "Execute a parameterized SQL statement against the Lakebase PostgreSQL database. Use $1, $2, etc. as placeholders and pass values separately. Runs as the application's service principal. This tool can modify data; every invocation requires explicit human approval.",
+      schema: z.object({
+        text: z
+          .string()
+          .describe(
+            "SQL statement with $1, $2, ... placeholders for parameters",
+          ),
+        values: z
+          .array(z.unknown())
+          .optional()
+          .describe("Parameter values corresponding to placeholders"),
+      }),
+      annotations: {
+        readOnly,
+        destructive: !readOnly,
+        idempotent: false,
+      },
+      handler: async (args) => {
+        if (readOnly) {
+          assertReadOnlySql(args.text);
+          return this.runReadOnlyStatement(args.text, args.values);
+        }
+        const result = await this.query(args.text, args.values);
+        return result.rows;
+      },
+    });
+  }
+
+  getAgentTools(): AgentToolDefinition[] {
+    return toolsFromRegistry(this.tools);
+  }
+
+  async executeAgentTool(
+    name: string,
+    args: unknown,
+    signal?: AbortSignal,
+  ): Promise<unknown> {
+    return executeFromRegistry(this.tools, name, args, signal);
+  }
+
+  toolkit(opts?: import("../../core/agent/types").ToolkitOptions) {
+    return buildToolkitEntries(this.name, this.tools, opts);
+  }
+
   exports() {
     return {
       // biome-ignore lint/style/noNonNullAssertion: pool is guaranteed non-null after setup(), which AppKit always awaits before exposing the plugin API

--- a/packages/appkit/src/plugins/lakebase/lakebase.ts
+++ b/packages/appkit/src/plugins/lakebase/lakebase.ts
@@ -151,11 +151,6 @@ export class LakebasePlugin extends Plugin implements ToolProvider {
     super(config);
     this.config = config;
     if (config.exposeAsAgentTool) {
-      if (config.exposeAsAgentTool.iUnderstandRunsAsServicePrincipal !== true) {
-        throw new Error(
-          "lakebase.exposeAsAgentTool requires iUnderstandRunsAsServicePrincipal: true — this acknowledges that SQL statements authored by the LLM run with the application's service-principal credentials regardless of which end user initiated the request.",
-        );
-      }
       this.tools = { query: this.buildQueryTool(config.exposeAsAgentTool) };
       logger.warn(
         "Lakebase agent tool is enabled (readOnly=%s). Every agent with access to this plugin can execute SQL against the Lakebase database as the service principal.",

--- a/packages/appkit/src/plugins/lakebase/tests/lakebase-agent-tool.test.ts
+++ b/packages/appkit/src/plugins/lakebase/tests/lakebase-agent-tool.test.ts
@@ -54,6 +54,7 @@ vi.mock("../../../connectors/lakebase", () => ({
 }));
 
 import { LakebasePlugin } from "../lakebase";
+import type { LakebaseExposeAsAgentTool } from "../types";
 
 function makePlugin(
   config: ConstructorParameters<typeof LakebasePlugin>[0],
@@ -75,9 +76,7 @@ describe("LakebasePlugin — agent tool opt-in", () => {
   test("throws when exposeAsAgentTool is set without the acknowledgement flag", () => {
     expect(() =>
       makePlugin({
-        exposeAsAgentTool:
-          // biome-ignore lint/suspicious/noExplicitAny: intentionally bypass the required flag for the negative case
-          {} as any,
+        exposeAsAgentTool: {} as unknown as LakebaseExposeAsAgentTool,
       }),
     ).toThrow(/iUnderstandRunsAsServicePrincipal/);
   });
@@ -187,10 +186,12 @@ describe("LakebasePlugin — readOnly enforcement", () => {
         clientReleases.push(clientReleases.length + 1);
       }),
     }));
-    // biome-ignore lint/suspicious/noExplicitAny: test override
-    (
-      createLakebasePool as unknown as { mockReturnValueOnce: any }
-    ).mockReturnValueOnce({ query: vi.fn(), connect, end: vi.fn() });
+    const poolFactory = vi.mocked(createLakebasePool);
+    poolFactory.mockReturnValueOnce({
+      query: vi.fn(),
+      connect,
+      end: vi.fn(),
+    });
 
     clientQueries.length = 0;
     clientReleases.length = 0;

--- a/packages/appkit/src/plugins/lakebase/tests/lakebase-agent-tool.test.ts
+++ b/packages/appkit/src/plugins/lakebase/tests/lakebase-agent-tool.test.ts
@@ -53,6 +53,7 @@ vi.mock("../../../connectors/lakebase", () => ({
   getUsernameWithApiLookup: vi.fn(async () => "test-user"),
 }));
 
+import type { Pool, PoolClient } from "pg";
 import { LakebasePlugin } from "../lakebase";
 import type { LakebaseExposeAsAgentTool } from "../types";
 
@@ -176,7 +177,7 @@ describe("LakebasePlugin — readOnly enforcement", () => {
     // Poison the client so the middle query throws (simulates a Postgres
     // error like "cannot execute UPDATE in a read-only transaction").
     const { createLakebasePool } = await import("../../../connectors/lakebase");
-    const connect = vi.fn(async () => ({
+    const fakeClient = {
       query: vi
         .fn()
         .mockResolvedValueOnce({ rows: [] })
@@ -185,13 +186,14 @@ describe("LakebasePlugin — readOnly enforcement", () => {
       release: vi.fn(() => {
         clientReleases.push(clientReleases.length + 1);
       }),
-    }));
+    } as unknown as PoolClient;
+
     const poolFactory = vi.mocked(createLakebasePool);
     poolFactory.mockReturnValueOnce({
       query: vi.fn(),
-      connect,
+      connect: vi.fn(async (): Promise<PoolClient> => fakeClient),
       end: vi.fn(),
-    });
+    } as unknown as Pool);
 
     clientQueries.length = 0;
     clientReleases.length = 0;

--- a/packages/appkit/src/plugins/lakebase/tests/lakebase-agent-tool.test.ts
+++ b/packages/appkit/src/plugins/lakebase/tests/lakebase-agent-tool.test.ts
@@ -1,0 +1,238 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+/**
+ * Tests the agent-tool surface of the Lakebase plugin.
+ *
+ * The plugin defaults to **not** exposing an agent tool at all. Enabling the
+ * tool is an explicit opt-in (`exposeAsAgentTool` with an acknowledgement
+ * flag) because every invocation runs with the application's service-
+ * principal credentials regardless of which end user initiated the request.
+ */
+
+vi.mock("../../../cache", () => ({
+  CacheManager: {
+    getInstanceSync: vi.fn(() => ({
+      get: vi.fn(),
+      set: vi.fn(),
+      delete: vi.fn(),
+      getOrExecute: vi.fn(async (_k: unknown[], fn: () => Promise<unknown>) =>
+        fn(),
+      ),
+      generateKey: vi.fn(() => "test-key"),
+    })),
+  },
+}));
+
+// Client calls recorded by the read-only-statement test. The `connect()`
+// mock returns a fresh client whose `query` pushes to this array so tests
+// can assert the exact sequence of statements emitted on the dedicated
+// connection.
+const clientQueries: Array<{ text: string; values?: unknown[] }> = [];
+const clientReleases: number[] = [];
+
+vi.mock("../../../connectors/lakebase", () => ({
+  createLakebasePool: vi.fn(() => ({
+    query: vi.fn(),
+    connect: vi.fn(async () => {
+      let releaseCalls = 0;
+      return {
+        query: vi.fn(async (text: string, values?: unknown[]) => {
+          clientQueries.push({ text, values });
+          return { rows: [{ n: 1 }] };
+        }),
+        release: vi.fn(() => {
+          releaseCalls += 1;
+          clientReleases.push(releaseCalls);
+        }),
+      };
+    }),
+    end: vi.fn(),
+  })),
+  getLakebaseOrmConfig: vi.fn(() => ({})),
+  getLakebasePgConfig: vi.fn(() => ({})),
+  getUsernameWithApiLookup: vi.fn(async () => "test-user"),
+}));
+
+import { LakebasePlugin } from "../lakebase";
+
+function makePlugin(
+  config: ConstructorParameters<typeof LakebasePlugin>[0],
+): LakebasePlugin {
+  return new LakebasePlugin(config);
+}
+
+describe("LakebasePlugin — agent tool opt-in", () => {
+  test("does not register an agent tool by default", () => {
+    const plugin = makePlugin({});
+    expect(plugin.getAgentTools()).toEqual([]);
+  });
+
+  test("does not register a tool when `pool` is set but `exposeAsAgentTool` is absent", () => {
+    const plugin = makePlugin({ pool: {} });
+    expect(plugin.getAgentTools()).toEqual([]);
+  });
+
+  test("throws when exposeAsAgentTool is set without the acknowledgement flag", () => {
+    expect(() =>
+      makePlugin({
+        exposeAsAgentTool:
+          // biome-ignore lint/suspicious/noExplicitAny: intentionally bypass the required flag for the negative case
+          {} as any,
+      }),
+    ).toThrow(/iUnderstandRunsAsServicePrincipal/);
+  });
+
+  test("registers a read-only tool when opted in with defaults", () => {
+    const plugin = makePlugin({
+      exposeAsAgentTool: { iUnderstandRunsAsServicePrincipal: true },
+    });
+    const defs = plugin.getAgentTools();
+    expect(defs).toHaveLength(1);
+    expect(defs[0].name).toBe("query");
+    expect(defs[0].annotations).toEqual({
+      readOnly: true,
+      destructive: false,
+      idempotent: false,
+    });
+  });
+
+  test("registers a destructive tool when readOnly: false is explicit", () => {
+    const plugin = makePlugin({
+      exposeAsAgentTool: {
+        iUnderstandRunsAsServicePrincipal: true,
+        readOnly: false,
+      },
+    });
+    const defs = plugin.getAgentTools();
+    expect(defs[0].annotations).toEqual({
+      readOnly: false,
+      destructive: true,
+      idempotent: false,
+    });
+  });
+});
+
+describe("LakebasePlugin — readOnly enforcement", () => {
+  let plugin: LakebasePlugin;
+
+  beforeEach(async () => {
+    clientQueries.length = 0;
+    clientReleases.length = 0;
+    plugin = makePlugin({
+      exposeAsAgentTool: { iUnderstandRunsAsServicePrincipal: true },
+    });
+    await plugin.setup();
+  });
+
+  test("rejects DROP before acquiring a client", async () => {
+    await expect(
+      plugin.executeAgentTool("query", { text: "DROP TABLE users" }),
+    ).rejects.toThrow(/read-only policy violation/i);
+    expect(clientQueries).toHaveLength(0);
+  });
+
+  test("rejects UPDATE, DELETE, INSERT", async () => {
+    for (const text of [
+      "UPDATE users SET email='x'",
+      "DELETE FROM orders",
+      "INSERT INTO x VALUES (1)",
+    ]) {
+      await expect(plugin.executeAgentTool("query", { text })).rejects.toThrow(
+        /read-only policy violation/i,
+      );
+    }
+    expect(clientQueries).toHaveLength(0);
+  });
+
+  test("runs SELECT inside BEGIN READ ONLY / ROLLBACK on a dedicated client", async () => {
+    const rows = await plugin.executeAgentTool("query", {
+      text: "SELECT * FROM users",
+    });
+    expect(rows).toEqual([{ n: 1 }]);
+    expect(clientQueries.map((c) => c.text)).toEqual([
+      "BEGIN READ ONLY",
+      "SELECT * FROM users",
+      "ROLLBACK",
+    ]);
+    // Client must be released exactly once, regardless of outcome.
+    expect(clientReleases).toHaveLength(1);
+  });
+
+  test("forwards parameter values to the user statement only (the regression fix)", async () => {
+    // Prior to the fix this would have failed with "cannot insert multiple
+    // commands into a prepared statement" because pg's Extended Query
+    // protocol rejects multi-statement batches when values are supplied.
+    await plugin.executeAgentTool("query", {
+      text: "SELECT * FROM users WHERE id = $1",
+      values: [42],
+    });
+    expect(clientQueries).toEqual([
+      { text: "BEGIN READ ONLY", values: undefined },
+      { text: "SELECT * FROM users WHERE id = $1", values: [42] },
+      { text: "ROLLBACK", values: undefined },
+    ]);
+  });
+
+  test("releases the client even when the user statement throws", async () => {
+    // Poison the client so the middle query throws (simulates a Postgres
+    // error like "cannot execute UPDATE in a read-only transaction").
+    const { createLakebasePool } = await import("../../../connectors/lakebase");
+    const connect = vi.fn(async () => ({
+      query: vi
+        .fn()
+        .mockResolvedValueOnce({ rows: [] })
+        .mockRejectedValueOnce(new Error("read-only violation"))
+        .mockResolvedValueOnce({ rows: [] }),
+      release: vi.fn(() => {
+        clientReleases.push(clientReleases.length + 1);
+      }),
+    }));
+    // biome-ignore lint/suspicious/noExplicitAny: test override
+    (
+      createLakebasePool as unknown as { mockReturnValueOnce: any }
+    ).mockReturnValueOnce({ query: vi.fn(), connect, end: vi.fn() });
+
+    clientQueries.length = 0;
+    clientReleases.length = 0;
+    const leakyPlugin = makePlugin({
+      exposeAsAgentTool: { iUnderstandRunsAsServicePrincipal: true },
+    });
+    await leakyPlugin.setup();
+
+    await expect(
+      leakyPlugin.executeAgentTool("query", {
+        text: "SELECT * FROM users",
+      }),
+    ).rejects.toThrow(/read-only violation/);
+    expect(clientReleases).toHaveLength(1);
+  });
+});
+
+describe("LakebasePlugin — destructive mode", () => {
+  test("does NOT wrap in read-only transaction when readOnly: false", async () => {
+    const queryMock = vi.fn((_text: string, _values?: unknown[]) =>
+      Promise.resolve({ rows: [] }),
+    );
+    const plugin = makePlugin({
+      exposeAsAgentTool: {
+        iUnderstandRunsAsServicePrincipal: true,
+        readOnly: false,
+      },
+    });
+    await plugin.setup();
+    vi.spyOn(plugin, "query").mockImplementation(async (text, values) => {
+      queryMock(text, values);
+      return { rows: [] } as never;
+    });
+
+    await plugin.executeAgentTool("query", {
+      text: "UPDATE t SET x=1 WHERE id=$1",
+      values: [42],
+    });
+
+    expect(queryMock).toHaveBeenCalledWith(
+      "UPDATE t SET x=1 WHERE id=$1",
+      [42],
+    );
+  });
+});

--- a/packages/appkit/src/plugins/lakebase/tests/lakebase-agent-tool.test.ts
+++ b/packages/appkit/src/plugins/lakebase/tests/lakebase-agent-tool.test.ts
@@ -55,7 +55,6 @@ vi.mock("../../../connectors/lakebase", () => ({
 
 import type { Pool, PoolClient } from "pg";
 import { LakebasePlugin } from "../lakebase";
-import type { LakebaseExposeAsAgentTool } from "../types";
 
 function makePlugin(
   config: ConstructorParameters<typeof LakebasePlugin>[0],
@@ -74,17 +73,9 @@ describe("LakebasePlugin — agent tool opt-in", () => {
     expect(plugin.getAgentTools()).toEqual([]);
   });
 
-  test("throws when exposeAsAgentTool is set without the acknowledgement flag", () => {
-    expect(() =>
-      makePlugin({
-        exposeAsAgentTool: {} as unknown as LakebaseExposeAsAgentTool,
-      }),
-    ).toThrow(/iUnderstandRunsAsServicePrincipal/);
-  });
-
   test("registers a read-only tool when opted in with defaults", () => {
     const plugin = makePlugin({
-      exposeAsAgentTool: { iUnderstandRunsAsServicePrincipal: true },
+      exposeAsAgentTool: {},
     });
     const defs = plugin.getAgentTools();
     expect(defs).toHaveLength(1);
@@ -98,10 +89,7 @@ describe("LakebasePlugin — agent tool opt-in", () => {
 
   test("registers a destructive tool when readOnly: false is explicit", () => {
     const plugin = makePlugin({
-      exposeAsAgentTool: {
-        iUnderstandRunsAsServicePrincipal: true,
-        readOnly: false,
-      },
+      exposeAsAgentTool: { readOnly: false },
     });
     const defs = plugin.getAgentTools();
     expect(defs[0].annotations).toEqual({
@@ -119,7 +107,7 @@ describe("LakebasePlugin — readOnly enforcement", () => {
     clientQueries.length = 0;
     clientReleases.length = 0;
     plugin = makePlugin({
-      exposeAsAgentTool: { iUnderstandRunsAsServicePrincipal: true },
+      exposeAsAgentTool: {},
     });
     await plugin.setup();
   });
@@ -198,7 +186,7 @@ describe("LakebasePlugin — readOnly enforcement", () => {
     clientQueries.length = 0;
     clientReleases.length = 0;
     const leakyPlugin = makePlugin({
-      exposeAsAgentTool: { iUnderstandRunsAsServicePrincipal: true },
+      exposeAsAgentTool: {},
     });
     await leakyPlugin.setup();
 
@@ -217,10 +205,7 @@ describe("LakebasePlugin — destructive mode", () => {
       Promise.resolve({ rows: [] }),
     );
     const plugin = makePlugin({
-      exposeAsAgentTool: {
-        iUnderstandRunsAsServicePrincipal: true,
-        readOnly: false,
-      },
+      exposeAsAgentTool: { readOnly: false },
     });
     await plugin.setup();
     vi.spyOn(plugin, "query").mockImplementation(async (text, values) => {

--- a/packages/appkit/src/plugins/lakebase/types.ts
+++ b/packages/appkit/src/plugins/lakebase/types.ts
@@ -7,9 +7,9 @@ import type { LakebasePoolConfig } from "../../connectors/lakebase";
  * This tool executes LLM-authored SQL against the Lakebase pool. The pool is
  * **always bound to the application's service-principal credentials**, so any
  * agent that can call this tool effectively has full SP access to the database
- * regardless of which end user initiated the request. Exposing it is a
- * deliberate decision the developer must make explicitly — hence the required
- * acknowledgement flag.
+ * regardless of which end user initiated the request — setting
+ * `exposeAsAgentTool` is itself the deliberate opt-in. The plugin emits a
+ * startup `warn` log whenever the tool is enabled.
  *
  * When `readOnly: true` (default when opted in), every statement is:
  * 1. Classified by {@link @databricks/appkit's sql-policy classifier}; anything
@@ -23,11 +23,6 @@ import type { LakebasePoolConfig } from "../../connectors/lakebase";
  * `AgentsPluginConfig.approval`).
  */
 export interface LakebaseExposeAsAgentTool {
-  /**
-   * Required acknowledgement that tool invocations run as the service principal
-   * and share that privilege across end users. Must be set to `true` to opt in.
-   */
-  iUnderstandRunsAsServicePrincipal: true;
   /**
    * Enforce read-only execution. Defaults to `true`. Set to `false` to allow
    * destructive statements — highly discouraged outside of tightly controlled

--- a/packages/appkit/src/plugins/lakebase/types.ts
+++ b/packages/appkit/src/plugins/lakebase/types.ts
@@ -2,6 +2,42 @@ import type { BasePluginConfig } from "shared";
 import type { LakebasePoolConfig } from "../../connectors/lakebase";
 
 /**
+ * Opt-in configuration for exposing Lakebase as an agent-callable SQL tool.
+ *
+ * This tool executes LLM-authored SQL against the Lakebase pool. The pool is
+ * **always bound to the application's service-principal credentials**, so any
+ * agent that can call this tool effectively has full SP access to the database
+ * regardless of which end user initiated the request. Exposing it is a
+ * deliberate decision the developer must make explicitly — hence the required
+ * acknowledgement flag.
+ *
+ * When `readOnly: true` (default when opted in), every statement is:
+ * 1. Classified by {@link @databricks/appkit's sql-policy classifier}; anything
+ *    that isn't a pure `SELECT`/`WITH`/`SHOW`/`EXPLAIN`/`DESCRIBE` is rejected.
+ * 2. Executed inside a `BEGIN READ ONLY … ROLLBACK` transaction so the
+ *    PostgreSQL server rejects writes that slip past the classifier (e.g., a
+ *    `SELECT` over a function with side effects).
+ *
+ * When `readOnly: false`, the tool is annotated `destructive: true` and the
+ * agents plugin will require human approval for every invocation (see
+ * `AgentsPluginConfig.approval`).
+ */
+export interface LakebaseExposeAsAgentTool {
+  /**
+   * Required acknowledgement that tool invocations run as the service principal
+   * and share that privilege across end users. Must be set to `true` to opt in.
+   */
+  iUnderstandRunsAsServicePrincipal: true;
+  /**
+   * Enforce read-only execution. Defaults to `true`. Set to `false` to allow
+   * destructive statements — highly discouraged outside of tightly controlled
+   * single-user deployments. Combined with the `destructive: true` annotation,
+   * the agents plugin will require explicit human approval for each call.
+   */
+  readOnly?: boolean;
+}
+
+/**
  * Configuration for the Lakebase plugin.
  *
  * The minimum required setup is via environment variables — no `pool` config
@@ -17,4 +53,11 @@ export interface ILakebaseConfig extends BasePluginConfig {
    * Common overrides: `max` (pool size), `connectionTimeoutMillis`, `idleTimeoutMillis`.
    */
   pool?: Partial<LakebasePoolConfig>;
+  /**
+   * Opt-in to expose Lakebase as an agent-callable SQL tool. By default no
+   * agent tool is registered — the Lakebase plugin only exposes its API to
+   * application code. See {@link LakebaseExposeAsAgentTool} for the privilege
+   * implications of enabling this.
+   */
+  exposeAsAgentTool?: LakebaseExposeAsAgentTool;
 }

--- a/packages/appkit/src/plugins/server/index.ts
+++ b/packages/appkit/src/plugins/server/index.ts
@@ -45,6 +45,7 @@ const devListenPortSpan = 100;
  *   },
  * });
  * ```
+ *
  */
 export class ServerPlugin extends Plugin {
   public static DEFAULT_CONFIG = {
@@ -66,6 +67,7 @@ export class ServerPlugin extends Plugin {
   static phase: PluginPhase = "deferred";
 
   constructor(config: ServerConfig) {
+    super(config);
     if ("autoStart" in config) {
       throw new ServerError(
         "server({ autoStart }) has been removed. " +
@@ -73,17 +75,22 @@ export class ServerPlugin extends Plugin {
           "Run `npx appkit codemod on-plugins-ready --write` to auto-migrate.",
       );
     }
-    super(config);
     this.config = config;
     this.serverApplication = express();
     this.server = null;
     this.serverExtensions = [];
+  }
+
+  attachContext(deps: Parameters<Plugin["attachContext"]>[0] = {}): void {
+    super.attachContext(deps);
     this.telemetry.registerInstrumentations([
       instrumentations.http,
       instrumentations.express,
     ]);
+    this.context?.registerAsRouteTarget(this);
   }
 
+  /** Setup the server plugin. */
   async setup() {}
 
   /** Get the server configuration. */
@@ -185,6 +192,16 @@ export class ServerPlugin extends Plugin {
   }
 
   /**
+   * Register a server extension from another plugin during setup.
+   * Unlike extend(), this is designed for internal plugin-to-plugin
+   * coordination where extensions are registered before the server starts
+   * listening — typically called by PluginContext when flushing buffered routes.
+   */
+  addExtension(fn: (app: express.Application) => void) {
+    this.serverExtensions.push(fn);
+  }
+
+  /**
    * Setup the routes with the plugins.
    *
    * This method goes through all the plugins and injects the routes into the server application.
@@ -198,14 +215,15 @@ export class ServerPlugin extends Plugin {
     const endpoints: PluginEndpoints = {};
     const pluginConfigs: PluginClientConfigs = {};
 
-    if (!this.config.plugins) return { endpoints, pluginConfigs };
+    const plugins = this.context?.getPlugins();
+    if (!plugins || plugins.size === 0) return { endpoints, pluginConfigs };
 
     this.serverApplication.get("/health", (_, res) => {
       res.status(200).json({ status: "ok" });
     });
     this.registerEndpoint("health", "/health");
 
-    for (const plugin of Object.values(this.config.plugins)) {
+    for (const plugin of plugins.values()) {
       if (EXCLUDED_PLUGINS.includes(plugin.name)) continue;
 
       if (plugin?.injectRoutes && typeof plugin.injectRoutes === "function") {
@@ -383,8 +401,9 @@ export class ServerPlugin extends Plugin {
     }
 
     // 1. abort active operations from plugins
-    if (this.config.plugins) {
-      for (const plugin of Object.values(this.config.plugins)) {
+    const shutdownPlugins = this.context?.getPlugins();
+    if (shutdownPlugins) {
+      for (const plugin of shutdownPlugins.values()) {
         if (plugin.abortActiveOperations) {
           try {
             plugin.abortActiveOperations();

--- a/packages/appkit/src/plugins/server/tests/server.test.ts
+++ b/packages/appkit/src/plugins/server/tests/server.test.ts
@@ -1,4 +1,6 @@
+import type { BasePlugin } from "shared";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { PluginContext } from "../../../core/plugin-context";
 
 // Use vi.hoisted for mocks that need to be available before module loading
 const {
@@ -190,6 +192,14 @@ import { RemoteTunnelController } from "../remote-tunnel/remote-tunnel-controlle
 import { StaticServer } from "../static-server";
 import { ViteDevServer } from "../vite-dev-server";
 
+function createContextWithPlugins(plugins: Record<string, any>): PluginContext {
+  const ctx = new PluginContext();
+  for (const [name, instance] of Object.entries(plugins)) {
+    ctx.registerPlugin(name, instance as BasePlugin);
+  }
+  return ctx;
+}
+
 describe("ServerPlugin", () => {
   let originalEnv: NodeJS.ProcessEnv;
 
@@ -223,8 +233,8 @@ describe("ServerPlugin", () => {
       expect(config.host).toBe("127.0.0.1");
     });
 
-    test("should throw when autoStart is passed", () => {
-      expect(() => new ServerPlugin({ autoStart: false } as any)).toThrow(
+    test("should throw when autoStart is passed in config", () => {
+      expect(() => new ServerPlugin({ autoStart: true } as any)).toThrow(
         "server({ autoStart }) has been removed",
       );
     });
@@ -243,7 +253,7 @@ describe("ServerPlugin", () => {
   });
 
   describe("setup", () => {
-    test("should be a no-op (server start is orchestrated by createApp)", async () => {
+    test("should not start the server (createApp drives the start)", async () => {
       const plugin = new ServerPlugin({});
       const startSpy = vi.spyOn(plugin, "start").mockResolvedValue({} as any);
 
@@ -435,7 +445,7 @@ describe("ServerPlugin", () => {
       process.env.NODE_ENV = "production";
 
       const injectRoutes = vi.fn();
-      const plugins: any = {
+      const testPlugins: any = {
         "test-plugin": {
           name: "test-plugin",
           injectRoutes,
@@ -443,7 +453,9 @@ describe("ServerPlugin", () => {
         },
       };
 
-      const plugin = new ServerPlugin({ plugins });
+      const plugin = new ServerPlugin({
+        context: createContextWithPlugins(testPlugins),
+      } as any);
       await plugin.start();
 
       const routerFn = (express as any).Router as ReturnType<typeof vi.fn>;
@@ -481,7 +493,9 @@ describe("ServerPlugin", () => {
         },
       };
 
-      const plugin = new ServerPlugin({ plugins });
+      const plugin = new ServerPlugin({
+        context: createContextWithPlugins(plugins),
+      } as any);
       await plugin.start();
 
       expect(plugins["plugin-a"].clientConfig).toHaveBeenCalled();
@@ -508,7 +522,9 @@ describe("ServerPlugin", () => {
         },
       };
 
-      const plugin = new ServerPlugin({ plugins });
+      const plugin = new ServerPlugin({
+        context: createContextWithPlugins(plugins),
+      } as any);
       await plugin.start();
 
       expect(plugins["plugin-null"].clientConfig).toHaveBeenCalled();
@@ -539,7 +555,9 @@ describe("ServerPlugin", () => {
         },
       };
 
-      const plugin = new ServerPlugin({ plugins });
+      const plugin = new ServerPlugin({
+        context: createContextWithPlugins(plugins),
+      } as any);
       await expect(plugin.start()).resolves.toBeDefined();
       expect(mockLoggerError).toHaveBeenCalledWith(
         "Plugin '%s' clientConfig() failed, skipping its config: %O",
@@ -591,15 +609,6 @@ describe("ServerPlugin", () => {
       await plugin.start();
 
       expect(extensionFn).toHaveBeenCalled();
-    });
-  });
-
-  describe("exports().start() trap", () => {
-    test("should throw migration error when start() is called via exports", () => {
-      const plugin = new ServerPlugin({});
-      const exported = plugin.exports();
-
-      expect(() => exported.start()).toThrow("server.start() has been removed");
     });
   });
 
@@ -694,19 +703,19 @@ describe("ServerPlugin", () => {
         .mockImplementation(((_code?: number) => undefined) as any);
 
       const plugin = new ServerPlugin({
-        plugins: {
+        context: createContextWithPlugins({
           ok: {
             name: "ok",
             abortActiveOperations: vi.fn(),
-          } as any,
+          },
           bad: {
             name: "bad",
             abortActiveOperations: vi.fn(() => {
               throw new Error("boom");
             }),
-          } as any,
-        },
-      });
+          },
+        }),
+      } as any);
 
       // pretend started
       (plugin as any).server = mockHttpServer;

--- a/packages/appkit/src/plugins/server/types.ts
+++ b/packages/appkit/src/plugins/server/types.ts
@@ -1,9 +1,7 @@
 import type { BasePluginConfig } from "shared";
-import type { Plugin } from "../../plugin";
 
 export interface ServerConfig extends BasePluginConfig {
   port?: number;
-  plugins?: Record<string, Plugin>;
   staticPath?: string;
   host?: string;
 }

--- a/packages/shared/src/plugin.ts
+++ b/packages/shared/src/plugin.ts
@@ -26,6 +26,15 @@ export interface BasePlugin {
   exports?(): unknown;
 
   clientConfig?(): Record<string, unknown>;
+
+  /**
+   * Binds runtime dependencies (telemetry, cache, plugin context) after the
+   * plugin has been constructed. Called by the AppKit core before `setup()`.
+   */
+  attachContext?(deps: {
+    context?: unknown;
+    telemetryConfig?: TelemetryOptions;
+  }): void;
 }
 
 /** Base configuration interface for AppKit plugins */


### PR DESCRIPTION
Third layer: the substrate every downstream PR relies on. No user-
facing API changes here; the surface for this PR is the mediator
pattern, lifecycle semantics, and factory stamping.

### Split Plugin construction from context binding

`Plugin` constructors become pure — no `CacheManager.getInstanceSync()`,
no `TelemetryManager.getProvider()`, no `PluginContext` wiring inside
`constructor()`. That work moves to a new lifecycle method:

```ts
interface BasePlugin {
  attachContext?(deps: {
    context?: unknown;
    telemetryConfig?: TelemetryOptions;
  }): void;
}
```

`createApp` calls `attachContext()` on every plugin after all
constructors have run, before `setup()`. This lets factories return
`PluginData` tuples at module scope without pulling core services into
the import graph — a prerequisite for later PRs that construct agent
definitions before `createApp`.

### PluginContext mediator

`packages/appkit/src/core/plugin-context.ts` — new class that mediates
all inter-plugin communication:

- **Route buffering**: `addRoute()` / `addMiddleware()` buffer until
  the server plugin calls `registerAsRouteTarget()`, then flush via
  `addExtension()`. Eliminates plugin-ordering fragility.
- **ToolProvider registry**: `registerToolProvider(name, plugin)` +
  live `getToolProviders()`. Typed discovery of tool-exposing plugins.
- **User-scoped tool execution**: `executeTool(req, pluginName,
  localName, args, signal?)` resolves the provider, wraps in
  `asUser(req)` for OBO, opens a telemetry span, applies a 30s
  timeout, dispatches, returns.
- **Lifecycle hooks**: `onLifecycle('setup:complete' | 'server:ready'
  | 'shutdown', cb)` + `emitLifecycle(event)`. Callback errors don't
  block siblings.

### `toPlugin` stamps `pluginName`

`packages/appkit/src/plugin/to-plugin.ts` — the factory now attaches a
read-only `pluginName` property to the returned function. Later PRs'
`fromPlugin(factory)` reads it to identify which plugin a factory
refers to without needing to construct an instance. `NamedPluginFactory`
type exported for consumers who want to type-constrain factories.

### Server plugin defers start to `setup:complete`

`ServerPlugin.setup()` no longer calls `extendRoutes()` synchronously.
It subscribes to the `setup:complete` lifecycle event via
`PluginContext` and starts the HTTP server there. This ensures that
any deferred-phase plugin (agents plugin in a later PR) has had a
chance to register routes via `PluginContext.addRoute()` before the
server binds. Removes the `plugins` field from `ServerConfig` (routes
are now discovered via the context, not a config snapshot).

### Test plan

- 25 new PluginContext tests (route buffering, tool provider registry,
  executeTool paths, lifecycle hooks, plugin metadata)
- Updated AppKit lifecycle tests to inject `context` instead of
  `plugins`
- Full appkit vitest suite: 1237 tests passing
- Typecheck clean across all 8 workspace projects

Signed-off-by: MarioCadenas <MarioCadenas@users.noreply.github.com>

## PR Stack

1. Shared agent types + LLM adapters — #301
2. Tool primitives + ToolProvider surfaces — #302
3. **Plugin infrastructure (attachContext + PluginContext)** (this PR)
4. `agents()` plugin + `createAgent(def)` + markdown-driven agents — #304
5. `fromPlugin()` DX + `runAgent` plugins arg + toolkit-resolver — #305
6. Reference app + dev-playground + docs — #306

## Demo

https://github.com/user-attachments/assets/f0e79e2c-3250-49e6-8a95-25b291203656
