### PR TITLE
feat(playground): add files policy test harness

### DIFF
--- a/apps/dev-playground/app.yaml
+++ b/apps/dev-playground/app.yaml
@@ -1,6 +1,15 @@
 env:
   - name: DATABRICKS_WAREHOUSE_ID
     valueFrom: sql-warehouse
+  - name: DATABRICKS_GENIE_SPACE_ID
+    valueFrom: genie-space
+  - name: DATABRICKS_SERVING_ENDPOINT_NAME
+    valueFrom: serving-endpoint
+  # Files plugin manifest declares a static DATABRICKS_VOLUME_FILES
+  # requirement; keep it bound so appkit's runtime validation passes
+  # even though the policy harness below uses its own keys.
+  - name: DATABRICKS_VOLUME_FILES
+    valueFrom: volume
   # Policy test harness: seven logical volumes, all bound to the same
   # underlying UC volume. Policy enforcement runs in-process, so the
   # shared physical path is fine.
@@ -18,5 +27,3 @@ env:
     valueFrom: volume
   - name: DATABRICKS_VOLUME_IMPLICIT
     valueFrom: volume
-  - name: DATABRICKS_VS_INDEX_NAME
-    valueFrom: vs-index

--- a/apps/dev-playground/app.yaml
+++ b/apps/dev-playground/app.yaml
@@ -1,9 +1,22 @@
 env:
   - name: DATABRICKS_WAREHOUSE_ID
     valueFrom: sql-warehouse
-  - name: DATABRICKS_VOLUME_PLAYGROUND
+  # Policy test harness: seven logical volumes, all bound to the same
+  # underlying UC volume. Policy enforcement runs in-process, so the
+  # shared physical path is fine.
+  - name: DATABRICKS_VOLUME_ALLOW_ALL
     valueFrom: volume
-  - name: DATABRICKS_VOLUME_OTHER
-    valueFrom: other-volume
+  - name: DATABRICKS_VOLUME_PUBLIC_READ
+    valueFrom: volume
+  - name: DATABRICKS_VOLUME_DENY_ALL
+    valueFrom: volume
+  - name: DATABRICKS_VOLUME_SP_ONLY
+    valueFrom: volume
+  - name: DATABRICKS_VOLUME_ADMIN_ONLY
+    valueFrom: volume
+  - name: DATABRICKS_VOLUME_WRITE_ONLY
+    valueFrom: volume
+  - name: DATABRICKS_VOLUME_IMPLICIT
+    valueFrom: volume
   - name: DATABRICKS_VS_INDEX_NAME
     valueFrom: vs-index

--- a/apps/dev-playground/client/src/routeTree.gen.ts
+++ b/apps/dev-playground/client/src/routeTree.gen.ts
@@ -9,11 +9,13 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as VectorSearchRouteRouteImport } from './routes/vector-search.route'
 import { Route as TypeSafetyRouteRouteImport } from './routes/type-safety.route'
 import { Route as TelemetryRouteRouteImport } from './routes/telemetry.route'
 import { Route as SqlHelpersRouteRouteImport } from './routes/sql-helpers.route'
 import { Route as ServingRouteRouteImport } from './routes/serving.route'
 import { Route as ReconnectRouteRouteImport } from './routes/reconnect.route'
+import { Route as PolicyMatrixRouteRouteImport } from './routes/policy-matrix.route'
 import { Route as LakebaseRouteRouteImport } from './routes/lakebase.route'
 import { Route as GenieRouteRouteImport } from './routes/genie.route'
 import { Route as FilesRouteRouteImport } from './routes/files.route'
@@ -23,6 +25,11 @@ import { Route as ArrowAnalyticsRouteRouteImport } from './routes/arrow-analytic
 import { Route as AnalyticsRouteRouteImport } from './routes/analytics.route'
 import { Route as IndexRouteImport } from './routes/index'
 
+const VectorSearchRouteRoute = VectorSearchRouteRouteImport.update({
+  id: '/vector-search',
+  path: '/vector-search',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const TypeSafetyRouteRoute = TypeSafetyRouteRouteImport.update({
   id: '/type-safety',
   path: '/type-safety',
@@ -46,6 +53,11 @@ const ServingRouteRoute = ServingRouteRouteImport.update({
 const ReconnectRouteRoute = ReconnectRouteRouteImport.update({
   id: '/reconnect',
   path: '/reconnect',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PolicyMatrixRouteRoute = PolicyMatrixRouteRouteImport.update({
+  id: '/policy-matrix',
+  path: '/policy-matrix',
   getParentRoute: () => rootRouteImport,
 } as any)
 const LakebaseRouteRoute = LakebaseRouteRouteImport.update({
@@ -98,11 +110,13 @@ export interface FileRoutesByFullPath {
   '/files': typeof FilesRouteRoute
   '/genie': typeof GenieRouteRoute
   '/lakebase': typeof LakebaseRouteRoute
+  '/policy-matrix': typeof PolicyMatrixRouteRoute
   '/reconnect': typeof ReconnectRouteRoute
   '/serving': typeof ServingRouteRoute
   '/sql-helpers': typeof SqlHelpersRouteRoute
   '/telemetry': typeof TelemetryRouteRoute
   '/type-safety': typeof TypeSafetyRouteRoute
+  '/vector-search': typeof VectorSearchRouteRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -113,11 +127,13 @@ export interface FileRoutesByTo {
   '/files': typeof FilesRouteRoute
   '/genie': typeof GenieRouteRoute
   '/lakebase': typeof LakebaseRouteRoute
+  '/policy-matrix': typeof PolicyMatrixRouteRoute
   '/reconnect': typeof ReconnectRouteRoute
   '/serving': typeof ServingRouteRoute
   '/sql-helpers': typeof SqlHelpersRouteRoute
   '/telemetry': typeof TelemetryRouteRoute
   '/type-safety': typeof TypeSafetyRouteRoute
+  '/vector-search': typeof VectorSearchRouteRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -129,11 +145,13 @@ export interface FileRoutesById {
   '/files': typeof FilesRouteRoute
   '/genie': typeof GenieRouteRoute
   '/lakebase': typeof LakebaseRouteRoute
+  '/policy-matrix': typeof PolicyMatrixRouteRoute
   '/reconnect': typeof ReconnectRouteRoute
   '/serving': typeof ServingRouteRoute
   '/sql-helpers': typeof SqlHelpersRouteRoute
   '/telemetry': typeof TelemetryRouteRoute
   '/type-safety': typeof TypeSafetyRouteRoute
+  '/vector-search': typeof VectorSearchRouteRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -146,11 +164,13 @@ export interface FileRouteTypes {
     | '/files'
     | '/genie'
     | '/lakebase'
+    | '/policy-matrix'
     | '/reconnect'
     | '/serving'
     | '/sql-helpers'
     | '/telemetry'
     | '/type-safety'
+    | '/vector-search'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -161,11 +181,13 @@ export interface FileRouteTypes {
     | '/files'
     | '/genie'
     | '/lakebase'
+    | '/policy-matrix'
     | '/reconnect'
     | '/serving'
     | '/sql-helpers'
     | '/telemetry'
     | '/type-safety'
+    | '/vector-search'
   id:
     | '__root__'
     | '/'
@@ -176,11 +198,13 @@ export interface FileRouteTypes {
     | '/files'
     | '/genie'
     | '/lakebase'
+    | '/policy-matrix'
     | '/reconnect'
     | '/serving'
     | '/sql-helpers'
     | '/telemetry'
     | '/type-safety'
+    | '/vector-search'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -192,15 +216,24 @@ export interface RootRouteChildren {
   FilesRouteRoute: typeof FilesRouteRoute
   GenieRouteRoute: typeof GenieRouteRoute
   LakebaseRouteRoute: typeof LakebaseRouteRoute
+  PolicyMatrixRouteRoute: typeof PolicyMatrixRouteRoute
   ReconnectRouteRoute: typeof ReconnectRouteRoute
   ServingRouteRoute: typeof ServingRouteRoute
   SqlHelpersRouteRoute: typeof SqlHelpersRouteRoute
   TelemetryRouteRoute: typeof TelemetryRouteRoute
   TypeSafetyRouteRoute: typeof TypeSafetyRouteRoute
+  VectorSearchRouteRoute: typeof VectorSearchRouteRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/vector-search': {
+      id: '/vector-search'
+      path: '/vector-search'
+      fullPath: '/vector-search'
+      preLoaderRoute: typeof VectorSearchRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/type-safety': {
       id: '/type-safety'
       path: '/type-safety'
@@ -234,6 +267,13 @@ declare module '@tanstack/react-router' {
       path: '/reconnect'
       fullPath: '/reconnect'
       preLoaderRoute: typeof ReconnectRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/policy-matrix': {
+      id: '/policy-matrix'
+      path: '/policy-matrix'
+      fullPath: '/policy-matrix'
+      preLoaderRoute: typeof PolicyMatrixRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/lakebase': {
@@ -304,11 +344,13 @@ const rootRouteChildren: RootRouteChildren = {
   FilesRouteRoute: FilesRouteRoute,
   GenieRouteRoute: GenieRouteRoute,
   LakebaseRouteRoute: LakebaseRouteRoute,
+  PolicyMatrixRouteRoute: PolicyMatrixRouteRoute,
   ReconnectRouteRoute: ReconnectRouteRoute,
   ServingRouteRoute: ServingRouteRoute,
   SqlHelpersRouteRoute: SqlHelpersRouteRoute,
   TelemetryRouteRoute: TelemetryRouteRoute,
   TypeSafetyRouteRoute: TypeSafetyRouteRoute,
+  VectorSearchRouteRoute: VectorSearchRouteRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/dev-playground/client/src/routes/__root.tsx
+++ b/apps/dev-playground/client/src/routes/__root.tsx
@@ -104,6 +104,14 @@ function RootComponent() {
                     Files
                   </Button>
                 </Link>
+                <Link to="/policy-matrix" className="no-underline">
+                  <Button
+                    variant="ghost"
+                    className="text-foreground hover:text-secondary-foreground"
+                  >
+                    Policy Matrix
+                  </Button>
+                </Link>
                 <Link to="/serving" className="no-underline">
                   <Button
                     variant="ghost"

--- a/apps/dev-playground/client/src/routes/policy-matrix.route.tsx
+++ b/apps/dev-playground/client/src/routes/policy-matrix.route.tsx
@@ -1,0 +1,471 @@
+import {
+  Badge,
+  Button,
+  usePluginClientConfig,
+} from "@databricks/appkit-ui/react";
+import { createFileRoute } from "@tanstack/react-router";
+import { Loader2, Play, RotateCcw } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { Header } from "@/components/layout/header";
+
+export const Route = createFileRoute("/policy-matrix")({
+  component: PolicyMatrixRoute,
+});
+
+interface FilesClientConfig {
+  volumes?: string[];
+}
+
+/**
+ * Every action the files plugin exposes over HTTP. Kept in display order
+ * (read actions first, then writes) so the matrix reads naturally.
+ */
+const ACTIONS = [
+  "list",
+  "read",
+  "download",
+  "raw",
+  "exists",
+  "metadata",
+  "preview",
+  "upload",
+  "mkdir",
+  "delete",
+] as const;
+
+const WRITE_ACTIONS: ReadonlySet<string> = new Set([
+  "upload",
+  "mkdir",
+  "delete",
+]);
+
+type Action = (typeof ACTIONS)[number];
+
+/**
+ * For policy testing purposes, the important distinction is 403-denied
+ * vs. anything else. Within "anything else" we break out 404 separately
+ * because the matrix probes against a synthetic path that may not exist
+ * — 404 means "policy passed, file missing", which is still a pass.
+ */
+type PolicyVerdict = "allowed" | "allowed-missing" | "denied" | "error";
+
+type ProbeOutcome =
+  | { status: "idle" }
+  | { status: "loading" }
+  | {
+      status: "done";
+      httpStatus: number;
+      verdict: PolicyVerdict;
+      message: string;
+    };
+
+function classify(httpStatus: number): PolicyVerdict {
+  if (httpStatus >= 200 && httpStatus < 300) return "allowed";
+  if (httpStatus === 403) return "denied";
+  if (httpStatus === 404) return "allowed-missing";
+  return "error";
+}
+
+type MatrixState = Record<string, Record<Action, ProbeOutcome>>;
+
+/** Per-probe test path. Kept short so cleanup is easy if a write succeeds. */
+const PROBE_PATH = "__policy_probe__.txt";
+const PROBE_DIR = "__policy_probe_dir__";
+
+interface WhoAmI {
+  xForwardedUser: string | null;
+  adminUserId: string | null;
+  isAdmin: boolean;
+}
+
+function PolicyMatrixRoute() {
+  const { volumes = [] } = usePluginClientConfig<FilesClientConfig>("files");
+  const [state, setState] = useState<MatrixState>({});
+  const [whoami, setWhoami] = useState<WhoAmI | null>(null);
+  const [runningAll, setRunningAll] = useState(false);
+  const [spResult, setSpResult] = useState<string | null>(null);
+  const [oboResult, setOboResult] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch("/whoami")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => setWhoami(data))
+      .catch(() => setWhoami(null));
+  }, []);
+
+  const initialState = useMemo<MatrixState>(() => {
+    const s: MatrixState = {};
+    for (const v of volumes) {
+      s[v] = {} as Record<Action, ProbeOutcome>;
+      for (const a of ACTIONS) s[v][a] = { status: "idle" };
+    }
+    return s;
+  }, [volumes]);
+
+  useEffect(() => {
+    setState(initialState);
+  }, [initialState]);
+
+  const setCell = useCallback(
+    (volume: string, action: Action, next: ProbeOutcome) => {
+      setState((prev) => ({
+        ...prev,
+        [volume]: { ...prev[volume], [action]: next },
+      }));
+    },
+    [],
+  );
+
+  /** Fire the real HTTP route the action maps to and capture status/body. */
+  const runProbe = useCallback(
+    async (volume: string, action: Action) => {
+      setCell(volume, action, { status: "loading" });
+
+      try {
+        const response = await probe(volume, action);
+        const body = await response
+          .json()
+          .catch(() => ({}) as Record<string, unknown>);
+        const message =
+          typeof body === "object" && body !== null && "error" in body
+            ? String((body as { error?: unknown }).error)
+            : response.ok
+              ? "ok"
+              : response.statusText;
+        const verdict = classify(response.status);
+        setCell(volume, action, {
+          status: "done",
+          httpStatus: response.status,
+          verdict,
+          message,
+        });
+      } catch (err) {
+        setCell(volume, action, {
+          status: "done",
+          httpStatus: 0,
+          verdict: "error",
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+    [setCell],
+  );
+
+  const runAll = useCallback(async () => {
+    setRunningAll(true);
+    try {
+      // Seed the probe file on volumes where writes are expected to be
+      // allowed, so reads return real content instead of 404. We don't
+      // know the policies client-side, so we try a best-effort upload
+      // and ignore the result — volumes that deny will just show 404
+      // on read actions, which the UI now renders as "allowed*".
+      await Promise.all(
+        volumes.map((v) =>
+          fetch(
+            `/api/files/${v}/upload?${new URLSearchParams({
+              path: PROBE_PATH,
+            }).toString()}`,
+            {
+              method: "POST",
+              body: new Blob(["policy probe seed"], { type: "text/plain" }),
+            },
+          ).catch(() => {}),
+        ),
+      );
+      await Promise.all(
+        volumes.map(async (v) => {
+          for (const a of ACTIONS) {
+            await runProbe(v, a);
+          }
+        }),
+      );
+    } finally {
+      setRunningAll(false);
+    }
+  }, [volumes, runProbe]);
+
+  const runSpSmoke = useCallback(async () => {
+    setSpResult("…");
+    const r = await fetch("/policy/sp");
+    setSpResult(JSON.stringify(await r.json(), null, 2));
+  }, []);
+
+  const runOboSmoke = useCallback(async () => {
+    setOboResult("…");
+    const r = await fetch("/policy/obo");
+    setOboResult(JSON.stringify(await r.json(), null, 2));
+  }, []);
+
+  const reset = useCallback(() => setState(initialState), [initialState]);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="max-w-7xl mx-auto px-6 py-12">
+        <Header
+          title="Files Policy Matrix"
+          description="Probe every (volume × action) pair to verify SP policy enforcement on the deployed app."
+          tooltip="Each cell fires the real HTTP route and shows the status code returned by the server. Expected outcomes are summarized in the legend."
+        />
+
+        <WhoAmI whoami={whoami} />
+
+        <div className="mb-6 flex items-center gap-3">
+          <Button
+            onClick={runAll}
+            disabled={runningAll || volumes.length === 0}
+          >
+            {runningAll ? (
+              <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+            ) : (
+              <Play className="h-4 w-4 mr-2" />
+            )}
+            Run all
+          </Button>
+          <Button variant="outline" onClick={reset} disabled={runningAll}>
+            <RotateCcw className="h-4 w-4 mr-2" />
+            Reset
+          </Button>
+          <Legend />
+        </div>
+
+        {volumes.length === 0 ? (
+          <p className="text-muted-foreground">
+            No volumes configured. Set <code>DATABRICKS_VOLUME_*</code> env vars
+            and restart the server.
+          </p>
+        ) : (
+          <div className="overflow-x-auto border rounded-md">
+            <table className="w-full text-sm">
+              <thead className="bg-muted/50">
+                <tr>
+                  <th className="text-left px-3 py-2 sticky left-0 bg-muted/50">
+                    Volume
+                  </th>
+                  {ACTIONS.map((a) => (
+                    <th key={a} className="text-left px-2 py-2">
+                      <div className="flex flex-col gap-1">
+                        <span>{a}</span>
+                        <span className="text-[10px] text-muted-foreground uppercase">
+                          {WRITE_ACTIONS.has(a) ? "write" : "read"}
+                        </span>
+                      </div>
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {volumes.map((volume) => (
+                  <tr key={volume} className="border-t">
+                    <td className="px-3 py-2 font-mono sticky left-0 bg-background">
+                      {volume}
+                    </td>
+                    {ACTIONS.map((a) => (
+                      <td key={a} className="px-1 py-1">
+                        <Cell
+                          outcome={state[volume]?.[a] ?? { status: "idle" }}
+                          onRun={() => runProbe(volume, a)}
+                        />
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        <div className="mt-10">
+          <h2 className="text-xl font-semibold mb-2">
+            Programmatic API smoke tests
+          </h2>
+          <p className="text-sm text-muted-foreground mb-4">
+            Confirms <code>PolicyDeniedError</code> is thrown from the SDK path
+            (not just HTTP 403). These hit the dev-playground's{" "}
+            <code>/policy/sp</code> and <code>/policy/obo</code> routes.
+          </p>
+          <div className="flex gap-3 mb-4">
+            <Button variant="outline" onClick={runSpSmoke}>
+              Run SP smoke
+            </Button>
+            <Button variant="outline" onClick={runOboSmoke}>
+              Run OBO smoke
+            </Button>
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <SmokePanel title="Service principal" body={spResult} />
+            <SmokePanel title="On-behalf-of user" body={oboResult} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Cell({
+  outcome,
+  onRun,
+}: {
+  outcome: ProbeOutcome;
+  onRun: () => void;
+}) {
+  if (outcome.status === "idle") {
+    return (
+      <Button variant="outline" size="sm" className="w-full" onClick={onRun}>
+        Run
+      </Button>
+    );
+  }
+  if (outcome.status === "loading") {
+    return (
+      <Button variant="outline" size="sm" className="w-full" disabled>
+        <Loader2 className="h-3 w-3 animate-spin" />
+      </Button>
+    );
+  }
+  return (
+    <button
+      type="button"
+      onClick={onRun}
+      className="w-full text-left"
+      title={outcome.message}
+    >
+      <StatusBadge
+        httpStatus={outcome.httpStatus}
+        verdict={outcome.verdict}
+        message={outcome.message}
+      />
+    </button>
+  );
+}
+
+function StatusBadge({
+  httpStatus,
+  verdict,
+  message,
+}: {
+  httpStatus: number;
+  verdict: PolicyVerdict;
+  message: string;
+}) {
+  switch (verdict) {
+    case "allowed":
+      return <Badge variant="default">{httpStatus} allowed</Badge>;
+    case "allowed-missing":
+      return (
+        <Badge variant="outline" title={message}>
+          404 allowed*
+        </Badge>
+      );
+    case "denied":
+      return (
+        <Badge variant="secondary" title={message}>
+          403 denied
+        </Badge>
+      );
+    case "error":
+      return (
+        <Badge variant="destructive" title={message}>
+          {httpStatus || "err"}
+        </Badge>
+      );
+  }
+}
+
+function Legend() {
+  return (
+    <div className="flex items-center gap-3 ml-auto text-xs text-muted-foreground">
+      <span className="flex items-center gap-1">
+        <Badge variant="default">2xx allowed</Badge>
+        policy passed, op succeeded
+      </span>
+      <span className="flex items-center gap-1">
+        <Badge variant="outline">404 allowed*</Badge>
+        policy passed, probe file missing
+      </span>
+      <span className="flex items-center gap-1">
+        <Badge variant="secondary">403 denied</Badge>
+        policy rejection
+      </span>
+      <span className="flex items-center gap-1">
+        <Badge variant="destructive">err</Badge>
+        other failure
+      </span>
+    </div>
+  );
+}
+
+function WhoAmI({ whoami }: { whoami: WhoAmI | null }) {
+  if (!whoami) return null;
+  return (
+    <div className="mb-6 border rounded-md p-3 text-sm font-mono bg-muted/30">
+      <div>
+        <span className="text-muted-foreground">x-forwarded-user:</span>{" "}
+        {whoami.xForwardedUser ?? "(none)"}
+      </div>
+      <div>
+        <span className="text-muted-foreground">ADMIN_USER_ID:</span>{" "}
+        {whoami.adminUserId ?? "(unset)"}
+        {whoami.isAdmin && (
+          <Badge variant="default" className="ml-2">
+            admin
+          </Badge>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SmokePanel({ title, body }: { title: string; body: string | null }) {
+  return (
+    <div className="border rounded-md p-3">
+      <div className="font-semibold text-sm mb-2">{title}</div>
+      <pre className="text-xs overflow-auto max-h-80 whitespace-pre-wrap">
+        {body ?? "(not run)"}
+      </pre>
+    </div>
+  );
+}
+
+/**
+ * Maps a logical action to the concrete HTTP request the files plugin
+ * exposes. Keeps this table in one place so the matrix stays honest
+ * about what it's actually testing.
+ */
+function probe(volume: string, action: Action): Promise<Response> {
+  const base = `/api/files/${volume}`;
+  const qs = (params: Record<string, string>) =>
+    new URLSearchParams(params).toString();
+
+  switch (action) {
+    case "list":
+      return fetch(`${base}/list`);
+    case "read":
+      return fetch(`${base}/read?${qs({ path: PROBE_PATH })}`);
+    case "download":
+      return fetch(`${base}/download?${qs({ path: PROBE_PATH })}`);
+    case "raw":
+      return fetch(`${base}/raw?${qs({ path: PROBE_PATH })}`);
+    case "exists":
+      return fetch(`${base}/exists?${qs({ path: PROBE_PATH })}`);
+    case "metadata":
+      return fetch(`${base}/metadata?${qs({ path: PROBE_PATH })}`);
+    case "preview":
+      return fetch(`${base}/preview?${qs({ path: PROBE_PATH })}`);
+    case "upload":
+      return fetch(`${base}/upload?${qs({ path: PROBE_PATH })}`, {
+        method: "POST",
+        body: new Blob(["policy probe"], { type: "text/plain" }),
+      });
+    case "mkdir":
+      return fetch(`${base}/mkdir`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ path: PROBE_DIR }),
+      });
+    case "delete":
+      return fetch(`${base}?${qs({ path: PROBE_PATH })}`, {
+        method: "DELETE",
+      });
+  }
+}

--- a/apps/dev-playground/server/index.ts
+++ b/apps/dev-playground/server/index.ts
@@ -2,10 +2,13 @@ import "reflect-metadata";
 import {
   analytics,
   createApp,
+  type FilePolicy,
   files,
   genie,
+  PolicyDeniedError,
   server,
   serving,
+  WRITE_ACTIONS,
 } from "@databricks/appkit";
 import { WorkspaceClient } from "@databricks/sdk-experimental";
 // TODO: re-enable once vector-search is exported from @databricks/appkit
@@ -24,6 +27,27 @@ function createMockClient() {
   return client;
 }
 
+/**
+ * Policy test harness.
+ *
+ * Each volume key below is backed by a `DATABRICKS_VOLUME_*` env var in
+ * `app.yaml` — all seven point at the same underlying UC volume path.
+ * The different policies are evaluated in-process, so the shared path
+ * is fine; the logical volume key is what drives enforcement.
+ *
+ * Exercises every policy shape the plugin ships with, plus the new
+ * "no policy configured" default (v0.21.0+).
+ */
+const ADMIN_USER_ID = process.env.ADMIN_USER_ID ?? "";
+
+/** Writes allowed only for the configured admin user ID; reads open. */
+const adminOnly: FilePolicy = (action, _resource, user) => {
+  if (WRITE_ACTIONS.has(action)) {
+    return ADMIN_USER_ID !== "" && user.id === ADMIN_USER_ID;
+  }
+  return true;
+};
+
 createApp({
   plugins: [
     server({ autoStart: false }),
@@ -34,7 +58,29 @@ createApp({
       spaces: { demo: process.env.DATABRICKS_GENIE_SPACE_ID ?? "placeholder" },
     }),
     lakebaseExamples(),
-    files({ volumes: { default: { policy: files.policy.allowAll() } } }),
+    files({
+      volumes: {
+        // baseline: everything allowed
+        allow_all: { policy: files.policy.allowAll() },
+        // read-only: uploads/mkdir/delete return 403
+        public_read: { policy: files.policy.publicRead() },
+        // locked: every action returns 403 (yes, even list)
+        deny_all: { policy: files.policy.denyAll() },
+        // SP can do everything, users can only read (docs example)
+        sp_only: {
+          policy: files.policy.any(
+            (_action, _resource, user) => !!user.isServicePrincipal,
+            files.policy.publicRead(),
+          ),
+        },
+        // writes gated on ADMIN_USER_ID env var, reads open
+        admin_only: { policy: adminOnly },
+        // drop-box: writes only, reads denied (not(publicRead))
+        write_only: { policy: files.policy.not(files.policy.publicRead()) },
+        // no explicit policy → falls back to publicRead() + startup warning
+        implicit: {},
+      },
+    }),
     serving(),
     // TODO: re-enable once vector-search is exported from @databricks/appkit
     // vectorSearch({
@@ -86,6 +132,99 @@ createApp({
             });
           });
       });
+
+      /**
+       * Echoes the user identity the server sees. Useful for confirming
+       * that `x-forwarded-user` is forwarded in the deployed environment.
+       */
+      app.get("/whoami", (req, res) => {
+        res.json({
+          xForwardedUser: req.header("x-forwarded-user") ?? null,
+          adminUserId: ADMIN_USER_ID || null,
+          isAdmin:
+            ADMIN_USER_ID !== "" &&
+            req.header("x-forwarded-user") === ADMIN_USER_ID,
+        });
+      });
+
+      /**
+       * Programmatic API smoke test — service principal path.
+       *
+       * All probes are read-only and deny-oriented, so nothing is
+       * written to the UC volume. Expected results:
+       * - `allow_all.list`      → ok (real SDK call)
+       * - `deny_all.list`       → PolicyDeniedError (deny wins even for SP)
+       * - `write_only.list`     → PolicyDeniedError (reads denied)
+       *
+       * Confirms `isServicePrincipal: true` is set on the SP path.
+       */
+      app.get("/policy/sp", async (_req, res) => {
+        const results = await runProbes([
+          ["allow_all", "list", () => appkit.files("allow_all").list()],
+          ["deny_all", "list", () => appkit.files("deny_all").list()],
+          ["write_only", "list", () => appkit.files("write_only").list()],
+        ]);
+        res.json({ identity: "service_principal", results });
+      });
+
+      /**
+       * Programmatic API smoke test — OBO (on-behalf-of user) path.
+       *
+       * All probes are read-only; no files are written. Expected:
+       * - `public_read.list` → ok (reads open)
+       * - `deny_all.list`    → PolicyDeniedError
+       * - `sp_only.list`     → ok (publicRead arm of `any()` allows reads)
+       */
+      app.get("/policy/obo", async (req, res) => {
+        const results = await runProbes([
+          [
+            "public_read",
+            "list",
+            () => appkit.files("public_read").asUser(req).list(),
+          ],
+          [
+            "deny_all",
+            "list",
+            () => appkit.files("deny_all").asUser(req).list(),
+          ],
+          ["sp_only", "list", () => appkit.files("sp_only").asUser(req).list()],
+        ]);
+        res.json({
+          identity: "user",
+          xForwardedUser: req.header("x-forwarded-user") ?? null,
+          results,
+        });
+      });
     })
     .start();
 });
+
+type ProbeResult = {
+  volume: string;
+  action: string;
+  ok: boolean;
+  denied: boolean;
+  error?: string;
+};
+
+async function runProbes(
+  probes: Array<[string, string, () => Promise<unknown>]>,
+): Promise<ProbeResult[]> {
+  const out: ProbeResult[] = [];
+  for (const [volume, action, fn] of probes) {
+    try {
+      await fn();
+      out.push({ volume, action, ok: true, denied: false });
+    } catch (error) {
+      const denied = error instanceof PolicyDeniedError;
+      out.push({
+        volume,
+        action,
+        ok: false,
+        denied,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

Stacks on top of `files/service-principal-policies` to turn the dev-playground into a live test harness for the new `FilePolicy` system. Lets us deploy the app and visually verify every policy shape works end-to-end against a real Databricks workspace — something that's hard to prove in unit tests because HTTP routes always run as the SP while policies read `x-forwarded-user`.

**One volume per policy shape**, all bound to the same underlying UC volume in `app.yaml` (policies are evaluated in-process, so the shared physical path is fine):

| Volume | Policy | What it proves |
|---|---|---|
| `allow_all` | `allowAll()` | baseline smoke |
| `public_read` | `publicRead()` | writes → 403 |
| `deny_all` | `denyAll()` | every action → 403 |
| `sp_only` | `any(isServicePrincipal, publicRead())` | SP bypass via combinator (docs example) |
| `admin_only` | custom, writes gated on `ADMIN_USER_ID` | custom `FilePolicy` with real user IDs |
| `write_only` | `not(publicRead())` | drop-box shape |
| `implicit` | *(no policy)* | v0.21 default + startup warning |

**`/policy-matrix` page** probes every (volume × action) pair against the real HTTP routes and classifies each result as `allowed` (2xx), `allowed*` (404 — policy passed, probe file missing), `denied` (403), or `error`. A "Run all" button seeds a probe file per volume via upload first, so reads return real content where policy allows writes.

**Three server helpers**:
- `GET /whoami` — echoes `x-forwarded-user` + admin status (for debugging the auth proxy in the deployed app)
- `GET /policy/sp` — programmatic SP-path smoke test, confirms `PolicyDeniedError` propagates from the SDK (not just HTTP 403)
- `GET /policy/obo` — same but via `asUser(req)`, confirms the OBO path sees the user identity and gets denied as expected

## Test plan

- [ ] Local: set all seven `DATABRICKS_VOLUME_*` env vars in `apps/dev-playground/.env` (all pointing at the same UC volume is fine); `pnpm dev`; open `/policy-matrix`; Run all. Expected pattern: `deny_all` all 403, `allow_all` all 2xx, `write_only` reads 403 / writes 2xx, etc.
- [ ] Deploy: `pnpm deploy:playground`; optionally add `ADMIN_USER_ID` to `app.yaml` to exercise the admin path. Verify `x-forwarded-user` is forwarded by hitting `/whoami`.
- [ ] `/policy/sp` returns `denied: true` with `PolicyDeniedError` message for `deny_all` / `write_only` entries.
- [ ] `/policy/obo` returns `denied: true` for `deny_all`, `allowed` for `public_read.list` and `sp_only.list`.