### PR TITLE
docs: fix Model Serving plugin heading for consistency

### DIFF
--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -16,7 +16,7 @@ AppKit provides built-in integrations with the following Databricks services via
 | [Lakebase](./plugins/lakebase) | Lakebase Autoscaling (PostgreSQL) | Relational database access via standard pg.Pool with automatic OAuth token refresh |
 | [Genie](./plugins/genie) | AI/BI Genie Spaces | Natural language data queries with conversation management and streaming |
 | [Files](./plugins/files) | Unity Catalog Volumes | Multi-volume file operations (list, read, upload, download, delete, preview) |
-| [Serving](./plugins/serving) | Model Serving | Authenticated proxy to Model Serving endpoints with invoke and streaming support |
+| [Model Serving](./plugins/model-serving) | Model Serving | Authenticated proxy to Model Serving endpoints with invoke and streaming support |
 | [Server](./plugins/server) | N/A | Express HTTP server with static file serving, Vite dev mode, and plugin route injection |
 
 Stay tuned for new plugins as we constantly expand integrations!

--- a/docs/docs/plugins/model-serving.md
+++ b/docs/docs/plugins/model-serving.md
@@ -2,7 +2,7 @@
 sidebar_position: 7
 ---
 
-# Serving plugin
+# Model Serving plugin
 
 Provides an authenticated proxy to [Databricks Model Serving](https://docs.databricks.com/aws/en/machine-learning/model-serving) endpoints, with invoke and streaming support.
 


### PR DESCRIPTION
## Summary
- Fixed the docs heading from "Serving plugin" to "Model Serving plugin" for consistency with the manifest `displayName` and the official Databricks product name.

## Test plan
- [x] `pnpm docs:build` passes
- [x] Verify sidebar shows "Model Serving plugin" on the docs site