### PR TITLE
ci: disable cancel-in-progress for prepare-release workflows

### DIFF
--- a/.github/workflows/prepare-release-lakebase.yml
+++ b/.github/workflows/prepare-release-lakebase.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: prepare-release-lakebase
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: prepare-release
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Switches `cancel-in-progress` from `true` to `false` in both `prepare-release` and `prepare-release-lakebase` workflows.

### Why this was originally `true`

When prepare-release was a simple single-job workflow, cancelling an older run on a new push was fine — the newer push always superseded it and there was no downside to aborting mid-build.

### What changed

The `prepare-release` workflow now also builds the **template artifact** in a second job (`template-artifact`). With `cancel-in-progress: true`, a quick follow-up push can cancel the in-progress run *before* the template artifact job completes, meaning the latest successful run might be missing the template artifact.

### Why this is safe

The downstream consumer (the [secure release cron](https://github.com/databricks/secure-public-registry-releases-eng/blob/main/.github/workflows/databricks-appkit.yml) in the Seahorse repo) always picks the latest successful run by `created_at` DESC via `status=success&per_page=1`. The concurrency group still ensures runs are serialized (one at a time) — the only behavioral change is that a queued run now **waits** instead of cancelling the in-progress one.

Reruns are not a concern either — a GitHub Actions rerun keeps the same `run_id` and `created_at`, so it cannot produce a "newer" run that would confuse ordering.

This pull request and its description were written by Isaac.