### PR TITLE
chore: disable type generation auto-migration for dev-playground

### DIFF
--- a/apps/dev-playground/package.json
+++ b/apps/dev-playground/package.json
@@ -23,6 +23,9 @@
   "author": "",
   "license": "ISC",
   "description": "",
+  "appkit": {
+    "autoMigrate": false
+  },
   "dependencies": {
     "@databricks/appkit": "workspace:*",
     "drizzle-orm": "0.45.1",


### PR DESCRIPTION
## Summary
- Adds `"appkit": { "autoMigrate": false }` to the dev-playground `package.json`
- Prevents the type generator from auto-migrating `tsconfig` files and build scripts in the dev-playground app

## Test plan
- [x] Run `pnpm build` and verify no migration summary is printed for dev-playground
- [x] Confirm `apps/dev-playground/tsconfig.server.json` and `tsconfig.client.json` are unchanged after build