### PR TITLE
chore: format generated type files in their generators

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:watch": "pnpm -r --filter=!dev-playground --filter=!docs build:watch",
     "check:fix": "biome check --write .",
     "check": "biome check .",
-    "generate:types": "tsx tools/generate-schema-types.ts && tsx tools/generate-registry-types.ts && biome check --write packages/shared/src/schemas/plugin-manifest.generated.ts packages/appkit/src/registry/types.generated.ts",
+    "generate:types": "tsx tools/generate-schema-types.ts && tsx tools/generate-registry-types.ts",
     "generate:app-templates": "tsx tools/generate-app-templates.ts",
     "check:licenses": "tsx tools/check-licenses.ts",
     "build:notice": "tsx tools/build-notice.ts > NOTICE.md",

--- a/tools/format-with-biome.ts
+++ b/tools/format-with-biome.ts
@@ -1,0 +1,22 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.join(__dirname, "..");
+
+/**
+ * Run Biome on a generated file so its formatting matches the rest of the
+ * repo. Without this, every `pnpm build`/`pnpm dev` would leave generated
+ * files dirty until `pnpm format` is run.
+ */
+export function formatWithBiome(filePath: string): void {
+  const result = spawnSync(
+    "pnpm",
+    ["exec", "biome", "check", "--write", "--no-errors-on-unmatched", filePath],
+    { cwd: REPO_ROOT, stdio: "inherit" },
+  );
+  if (result.status !== 0) {
+    throw new Error(`biome check --write failed for ${filePath}`);
+  }
+}

--- a/tools/generate-registry-types.ts
+++ b/tools/generate-registry-types.ts
@@ -4,6 +4,7 @@
  *
  * Run from repo root: pnpm exec tsx tools/generate-registry-types.ts
  */
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -149,7 +150,24 @@ function main(): void {
   const out = generate(schema);
   fs.mkdirSync(path.dirname(OUT_PATH), { recursive: true });
   fs.writeFileSync(OUT_PATH, out, "utf-8");
+  formatWithBiome(OUT_PATH);
   console.log("Wrote", OUT_PATH);
+}
+
+/**
+ * Run Biome on the generated file so its formatting matches the rest of the
+ * repo. Without this, every `pnpm build`/`pnpm dev` would leave the file dirty
+ * until `pnpm format` is run.
+ */
+function formatWithBiome(filePath: string): void {
+  const result = spawnSync(
+    "pnpm",
+    ["exec", "biome", "check", "--write", "--no-errors-on-unmatched", filePath],
+    { cwd: REPO_ROOT, stdio: "inherit" },
+  );
+  if (result.status !== 0) {
+    throw new Error(`biome check --write failed for ${filePath}`);
+  }
 }
 
 main();

--- a/tools/generate-registry-types.ts
+++ b/tools/generate-registry-types.ts
@@ -4,10 +4,10 @@
  *
  * Run from repo root: pnpm exec tsx tools/generate-registry-types.ts
  */
-import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { formatWithBiome } from "./format-with-biome.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.join(__dirname, "..");
@@ -152,22 +152,6 @@ function main(): void {
   fs.writeFileSync(OUT_PATH, out, "utf-8");
   formatWithBiome(OUT_PATH);
   console.log("Wrote", OUT_PATH);
-}
-
-/**
- * Run Biome on the generated file so its formatting matches the rest of the
- * repo. Without this, every `pnpm build`/`pnpm dev` would leave the file dirty
- * until `pnpm format` is run.
- */
-function formatWithBiome(filePath: string): void {
-  const result = spawnSync(
-    "pnpm",
-    ["exec", "biome", "check", "--write", "--no-errors-on-unmatched", filePath],
-    { cwd: REPO_ROOT, stdio: "inherit" },
-  );
-  if (result.status !== 0) {
-    throw new Error(`biome check --write failed for ${filePath}`);
-  }
 }
 
 main();

--- a/tools/generate-schema-types.ts
+++ b/tools/generate-schema-types.ts
@@ -5,11 +5,11 @@
  *
  * Run from repo root: pnpm exec tsx tools/generate-schema-types.ts
  */
-import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { compileFromFile } from "json-schema-to-typescript";
+import { formatWithBiome } from "./format-with-biome.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.join(__dirname, "..");
@@ -51,22 +51,6 @@ async function main(): Promise<void> {
   fs.writeFileSync(OUT_PATH, result, "utf-8");
   formatWithBiome(OUT_PATH);
   console.log("Wrote", OUT_PATH);
-}
-
-/**
- * Run Biome on the generated file so its formatting matches the rest of the
- * repo. Without this, every `pnpm build`/`pnpm dev` would leave the file dirty
- * until `pnpm format` is run.
- */
-function formatWithBiome(filePath: string): void {
-  const result = spawnSync(
-    "pnpm",
-    ["exec", "biome", "check", "--write", "--no-errors-on-unmatched", filePath],
-    { cwd: REPO_ROOT, stdio: "inherit" },
-  );
-  if (result.status !== 0) {
-    throw new Error(`biome check --write failed for ${filePath}`);
-  }
 }
 
 main();

--- a/tools/generate-schema-types.ts
+++ b/tools/generate-schema-types.ts
@@ -5,6 +5,7 @@
  *
  * Run from repo root: pnpm exec tsx tools/generate-schema-types.ts
  */
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -48,7 +49,24 @@ async function main(): Promise<void> {
 
   fs.mkdirSync(path.dirname(OUT_PATH), { recursive: true });
   fs.writeFileSync(OUT_PATH, result, "utf-8");
+  formatWithBiome(OUT_PATH);
   console.log("Wrote", OUT_PATH);
+}
+
+/**
+ * Run Biome on the generated file so its formatting matches the rest of the
+ * repo. Without this, every `pnpm build`/`pnpm dev` would leave the file dirty
+ * until `pnpm format` is run.
+ */
+function formatWithBiome(filePath: string): void {
+  const result = spawnSync(
+    "pnpm",
+    ["exec", "biome", "check", "--write", "--no-errors-on-unmatched", filePath],
+    { cwd: REPO_ROOT, stdio: "inherit" },
+  );
+  if (result.status !== 0) {
+    throw new Error(`biome check --write failed for ${filePath}`);
+  }
 }
 
 main();


### PR DESCRIPTION
## Summary

Every `pnpm build` and `pnpm dev` was leaving `packages/shared/src/schemas/plugin-manifest.generated.ts` and `packages/appkit/src/registry/types.generated.ts` dirty until `pnpm format` was run.

The per-package `build:package` scripts run the schema/registry generators before `tsdown`:

- `packages/shared`: `tsx ../../tools/generate-schema-types.ts && tsdown ...`
- `packages/appkit`: `tsx ../../tools/generate-registry-types.ts && tsdown ...`

Only the root-level `pnpm generate:types` script piped their output through Biome — but `pnpm build` / `pnpm dev` don't invoke it, so the files always landed in their unformatted state.

## Changes

- `tools/generate-schema-types.ts` and `tools/generate-registry-types.ts` now run `pnpm exec biome check --write` on their output file immediately after writing it, via `child_process.spawnSync`.
- Dropped the trailing `biome check --write …` from the root `generate:types` script in `package.json` since it's now redundant.

## Test plan

- [x] Reverted both generated files to their committed state, ran each generator individually — Biome reported "Fixed 1 file" once and `git diff` was empty afterwards.
- [x] Ran a full `pnpm build` — `git status` no longer reports the `.generated.ts` files as modified.
- [ ] CI green.