### PR TITLE
docs: track aitools rename to top-level command

### DIFF
--- a/docs/docs/_prerequisites.mdx
+++ b/docs/docs/_prerequisites.mdx
@@ -1,4 +1,4 @@
 ## Prerequisites
 
 - [Node.js](https://nodejs.org) v22+ environment with `npm`
-- Databricks CLI (v0.295.0 or higher): install and configure it according to the [official tutorial](https://docs.databricks.com/aws/en/dev-tools/cli/tutorial).
+- Databricks CLI (v1.0.0 or higher): install and configure it according to the [official tutorial](https://docs.databricks.com/aws/en/dev-tools/cli/tutorial).

--- a/docs/docs/development/_prerequisites_app.mdx
+++ b/docs/docs/development/_prerequisites_app.mdx
@@ -1,5 +1,5 @@
 ## Prerequisites
 
 - [Node.js](https://nodejs.org) v22+ environment with `npm`
-- Databricks CLI (v0.295.0 or higher): install and configure it according to the [official tutorial](https://docs.databricks.com/aws/en/dev-tools/cli/tutorial).
+- Databricks CLI (v1.0.0 or higher): install and configure it according to the [official tutorial](https://docs.databricks.com/aws/en/dev-tools/cli/tutorial).
 - A new Databricks app with AppKit installed. See [Bootstrap a new Databricks app](../index.md#quick-start-options) for more details.

--- a/docs/docs/development/ai-assisted-development.mdx
+++ b/docs/docs/development/ai-assisted-development.mdx
@@ -15,7 +15,7 @@ AppKit integrates with AI coding assistants through the Agent Skills.
 To install the Databricks Agent Skills for your preferred AI assistant, run:
 
 ```bash
-databricks experimental aitools install
+databricks aitools install
 ```
 
 ## Skills capabilities

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -38,7 +38,7 @@ Databricks AppKit is designed to work with AI coding assistants through Agent Sk
 Install Agent Skills and configure it for use with your preferred AI assistant:
 
 ```bash
-databricks experimental aitools install
+databricks aitools install
 ```
 
 Once configured for your development environment, you can use your AI assistant to create and deploy new Databricks applications, as well as to iteratively evolve your app's codebase.

--- a/docs/docs/plugins/lakebase.md
+++ b/docs/docs/plugins/lakebase.md
@@ -20,7 +20,7 @@ The easiest way to get started with the Lakebase plugin is to use the Databricks
 ### Prerequisites
 
 - [Node.js](https://nodejs.org) v22+ environment with `npm`
-- Databricks CLI (v0.295.0 or higher): install and configure it according to the [official tutorial](https://docs.databricks.com/aws/en/dev-tools/cli/tutorial).
+- Databricks CLI (v1.0.0 or higher): install and configure it according to the [official tutorial](https://docs.databricks.com/aws/en/dev-tools/cli/tutorial).
 - A new Databricks app with AppKit installed. See [Bootstrap a new Databricks app](../index.md#quick-start-options) for more details.
 
 ### Steps

--- a/packages/shared/src/cli/commands/setup.ts
+++ b/packages/shared/src/cli/commands/setup.ts
@@ -58,7 +58,7 @@ ${links}
 For enhanced AI assistance with Databricks CLI operations, authentication, data exploration, and app development, install the Databricks skills:
 
 \`\`\`bash
-databricks experimental aitools install
+databricks aitools install
 \`\`\`
 ${SECTION_END}`;
 }
@@ -88,7 +88,7 @@ ${links}
 For enhanced AI assistance with Databricks CLI operations, authentication, data exploration, and app development, install the Databricks skills:
 
 \`\`\`bash
-databricks experimental aitools install
+databricks aitools install
 \`\`\`
 ${SECTION_END}
 `;


### PR DESCRIPTION
## Summary

Mirrors databricks/cli#4917 which promotes the aitools skills-management surface from `databricks experimental aitools` to top-level `databricks aitools`. Updates 3 install-command references in appkit so that user-facing copy points at the new canonical path:

- `packages/shared/src/cli/commands/setup.ts` (×2) — the CLAUDE.md snippet emitted by the appkit setup flow
- `docs/docs/index.md` (×1)

## Why now

Purely cosmetic — there is no deprecation warning to avoid. The CLI keeps `databricks experimental aitools install` working as a **silent backward-compat alias**, so the old path doesn't break and doesn't print anything. This PR is just keeping new docs aligned with the canonical command path so users learning aitools for the first time meet the right name.

## Note on the `tools` subtree

`databricks experimental aitools tools …` (query / discover-schema / get-default-warehouse / statement) is **not** being promoted in #4917 — it stays under `experimental`. appkit doesn't reference any of those commands, so nothing else here needed updating.

## Test plan

- [ ] `databricks-appkit setup` emits a CLAUDE.md that points at `databricks aitools install`
- [ ] Docs site renders the new command

This pull request was AI-assisted by Isaac.