### PR TITLE
fix(appkit): harden SSE response headers in setupHeaders

### DIFF
--- a/packages/appkit/src/plugins/analytics/tests/analytics.integration.test.ts
+++ b/packages/appkit/src/plugins/analytics/tests/analytics.integration.test.ts
@@ -105,7 +105,9 @@ describe("Analytics Plugin Integration", () => {
       );
 
       expect(response.status).toBe(200);
-      expect(response.headers.get("Content-Type")).toBe("text/event-stream");
+      expect(response.headers.get("Content-Type")).toBe(
+        "text/event-stream; charset=utf-8",
+      );
 
       const sseData = await parseSSEResponse(response);
       expect(sseData.eventType).toBe("result");

--- a/packages/appkit/src/plugins/analytics/tests/analytics.test.ts
+++ b/packages/appkit/src/plugins/analytics/tests/analytics.test.ts
@@ -174,16 +174,13 @@ describe("Analytics Plugin", () => {
 
       expect(mockRes.setHeader).toHaveBeenCalledWith(
         "Content-Type",
-        "text/event-stream",
+        "text/event-stream; charset=utf-8",
       );
       expect(mockRes.setHeader).toHaveBeenCalledWith(
         "Cache-Control",
-        "no-cache",
+        "no-cache, no-transform",
       );
-      expect(mockRes.setHeader).toHaveBeenCalledWith(
-        "Connection",
-        "keep-alive",
-      );
+      expect(mockRes.setHeader).toHaveBeenCalledWith("X-Accel-Buffering", "no");
 
       expect(mockRes.write).toHaveBeenCalledWith("event: result\n");
       expect(mockRes.write).toHaveBeenCalledWith(
@@ -245,7 +242,7 @@ describe("Analytics Plugin", () => {
 
       expect(mockRes.setHeader).toHaveBeenCalledWith(
         "Content-Type",
-        "text/event-stream",
+        "text/event-stream; charset=utf-8",
       );
 
       expect(mockRes.write).toHaveBeenCalledWith("event: result\n");

--- a/packages/appkit/src/plugins/genie/tests/genie.test.ts
+++ b/packages/appkit/src/plugins/genie/tests/genie.test.ts
@@ -299,11 +299,11 @@ describe("Genie Plugin", () => {
       // Verify SSE headers
       expect(mockRes.setHeader).toHaveBeenCalledWith(
         "Content-Type",
-        "text/event-stream",
+        "text/event-stream; charset=utf-8",
       );
       expect(mockRes.setHeader).toHaveBeenCalledWith(
         "Cache-Control",
-        "no-cache",
+        "no-cache, no-transform",
       );
 
       // Verify SSE events are written

--- a/packages/appkit/src/plugins/serving/serving.ts
+++ b/packages/appkit/src/plugins/serving/serving.ts
@@ -261,9 +261,9 @@ export class ServingPlugin extends Plugin {
       return;
     }
 
-    res.setHeader("Content-Type", "text/event-stream");
-    res.setHeader("Cache-Control", "no-cache");
-    res.setHeader("Content-Encoding", "none");
+    res.setHeader("Content-Type", "text/event-stream; charset=utf-8");
+    res.setHeader("Cache-Control", "no-cache, no-transform");
+    res.setHeader("X-Accel-Buffering", "no");
     res.flushHeaders();
 
     const nodeStream = Readable.fromWeb(

--- a/packages/appkit/src/plugins/serving/tests/serving.test.ts
+++ b/packages/appkit/src/plugins/serving/tests/serving.test.ts
@@ -286,9 +286,12 @@ describe("Serving Plugin", () => {
 
       expect(res.setHeader).toHaveBeenCalledWith(
         "Content-Type",
-        "text/event-stream",
+        "text/event-stream; charset=utf-8",
       );
-      expect(res.setHeader).toHaveBeenCalledWith("Cache-Control", "no-cache");
+      expect(res.setHeader).toHaveBeenCalledWith(
+        "Cache-Control",
+        "no-cache, no-transform",
+      );
       expect(mockStream).toHaveBeenCalledWith(
         expect.anything(),
         "test-endpoint",

--- a/packages/appkit/src/stream/sse-writer.ts
+++ b/packages/appkit/src/stream/sse-writer.ts
@@ -21,20 +21,6 @@ export class SSEWriter {
     //   - Content-Encoding: none   (invalid value; can trigger 502/RST in
     //                                strict intermediaries)
     res.flushHeaders?.();
-    // Sentinel comment — a no-op SSE line that forces the response body
-    // open immediately. Two purposes:
-    //   1. Any buffering proxy must release the response headers + this
-    //      first chunk to the client right away, so fetch() resolves with
-    //      response.ok before the upstream generator yields.
-    //   2. Prevents "Failed to fetch" symptoms where the browser gives up
-    //      before the SQL query completes on cold-start warehouses.
-    if (!res.writableEnded) {
-      try {
-        res.write(": ok\n\n");
-      } catch {
-        // ignore — handled by writeEvent's writableEnded check downstream
-      }
-    }
   }
 
   // write a single event to the response

--- a/packages/appkit/src/stream/sse-writer.ts
+++ b/packages/appkit/src/stream/sse-writer.ts
@@ -11,12 +11,30 @@ import { StreamValidator } from "./validator";
 export class SSEWriter {
   // setup SSE headers
   setupHeaders(res: IAppResponse): void {
-    res.setHeader("Content-Type", "text/event-stream");
-    res.setHeader("Cache-Control", "no-cache");
-    res.setHeader("Connection", "keep-alive");
-    res.setHeader("Content-Encoding", "none");
-
+    res.setHeader("Content-Type", "text/event-stream; charset=utf-8");
+    res.setHeader("Cache-Control", "no-cache, no-transform");
+    // X-Accel-Buffering: no — disables nginx-style proxy response buffering
+    // for SSE (used by Cloudflare, AWS, GCP, and most corporate proxies).
+    res.setHeader("X-Accel-Buffering", "no");
+    // Intentionally NOT setting:
+    //   - Connection: keep-alive   (HTTP/2 forbids it; Node manages keep-alive)
+    //   - Content-Encoding: none   (invalid value; can trigger 502/RST in
+    //                                strict intermediaries)
     res.flushHeaders?.();
+    // Sentinel comment — a no-op SSE line that forces the response body
+    // open immediately. Two purposes:
+    //   1. Any buffering proxy must release the response headers + this
+    //      first chunk to the client right away, so fetch() resolves with
+    //      response.ok before the upstream generator yields.
+    //   2. Prevents "Failed to fetch" symptoms where the browser gives up
+    //      before the SQL query completes on cold-start warehouses.
+    if (!res.writableEnded) {
+      try {
+        res.write(": ok\n\n");
+      } catch {
+        // ignore — handled by writeEvent's writableEnded check downstream
+      }
+    }
   }
 
   // write a single event to the response

--- a/packages/appkit/src/stream/tests/stream.test.ts
+++ b/packages/appkit/src/stream/tests/stream.test.ts
@@ -44,7 +44,7 @@ describe("StreamManager", () => {
 
       expect(mockRes.setHeader).toHaveBeenCalledWith(
         "Content-Type",
-        "text/event-stream",
+        "text/event-stream; charset=utf-8",
       );
       expect(events).toContain(
         'data: {"type":"start","message":"Starting"}\n\n',


### PR DESCRIPTION
## What

Improves the SSE response headers set by `SSEWriter.setupHeaders()` to be more correct and proxy-friendly.

## Why

The previous header set had two issues that could cause problems in real deployments:

- **`Connection: keep-alive`** is forbidden by the HTTP/2 spec and was being stripped or rejected by HTTP/2 intermediaries anyway. Node.js manages keep-alive internally.
- **`Content-Encoding: none`** is not a valid header value and could trigger `502 Bad Gateway` or `RST_STREAM` errors in strict proxies (nginx, AWS ALB, GCP LB, Cloudflare).

There were also two missing proxy-buffering mitigations:

- **`Cache-Control: no-transform`** tells proxies not to modify the response body (important for streaming).
- **`X-Accel-Buffering: no`** is the de-facto header for disabling response buffering in nginx and nginx-backed CDNs/proxies (Cloudflare, AWS CloudFront, GCP, and most corporate reverse proxies honour it).

## Changes

| File | Change |
|------|--------|
| `packages/appkit/src/stream/sse-writer.ts` | Updated headers; `Connection` and `Content-Encoding` removed; `X-Accel-Buffering: no` added |