### PR TITLE
ci: sync Lakebase driver version to package.json before packing tarball

### DIFF
--- a/.github/workflows/prepare-release-lakebase.yml
+++ b/.github/workflows/prepare-release-lakebase.yml
@@ -60,6 +60,11 @@ jobs:
         working-directory: packages/lakebase
         run: |
           pnpm exec release-it ${{ steps.version.outputs.version }} --ci
+
+      - name: Sync version
+        if: steps.version.outputs.version != ''
+        run: pnpm exec tsx tools/sync-lakebase-version.ts "${{ steps.version.outputs.version }}"
+
       - name: Build
         if: steps.version.outputs.version != ''
         run: pnpm --filter=@databricks/lakebase build:package

--- a/packages/lakebase/package.json
+++ b/packages/lakebase/package.json
@@ -2,7 +2,7 @@
   "name": "@databricks/lakebase",
   "type": "module",
   "version": "0.2.0",
-  "description": "PostgreSQL driver for Databricks Lakebase with automatic OAuth token refresh",
+  "description": "PostgreSQL driver for Databricks Lakebase Autoscaling with automatic OAuth token refresh",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "packageManager": "pnpm@10.21.0",

--- a/tools/sync-lakebase-version.ts
+++ b/tools/sync-lakebase-version.ts
@@ -1,0 +1,26 @@
+#!/usr/bin/env tsx
+/**
+ * Syncs the version to the lakebase package.
+ * Used by the prepare-release-lakebase workflow after version bump.
+ */
+
+/**
+ * NOTE: This script is also used by the private secure release repo
+ * during the finalize step. Changes here affect the release pipeline.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = process.cwd();
+const version = process.argv[2];
+if (!version) {
+  console.error("Usage: sync-lakebase-version.ts <version>");
+  process.exit(1);
+}
+
+const pkgJsonPath = join(ROOT, "packages/lakebase/package.json");
+const pkgJson = JSON.parse(readFileSync(pkgJsonPath, "utf-8"));
+pkgJson.version = version;
+writeFileSync(pkgJsonPath, `${JSON.stringify(pkgJson, null, 2)}\n`);
+console.log(`✓ packages/lakebase/package.json → ${version}`);


### PR DESCRIPTION
## Summary

The lakebase 0.3.0 npm release [failed](https://github.com/databricks/secure-public-registry-releases-eng/actions/runs/25162074650/job/73759036143) because the tarball contained version `0.2.0` while the `VERSION` file said `0.3.0`. npm rejected the publish because `0.2.0` was already published.

The [prepare-release-lakebase run](https://github.com/databricks/appkit/actions/runs/25161388132) produced `VERSION=0.3.0` but the tarball was `databricks-lakebase-0.2.0.tgz`.

**Root cause**: `release-it` with `"npm": false` skips the version bump in `package.json`. The appkit workflow works because it calls `sync-versions.ts` after release-it — but the lakebase workflow had no equivalent step.

**Fix**:
- Add `tools/sync-lakebase-version.ts` (mirrors `sync-versions.ts` for appkit)
- Call it in `prepare-release-lakebase.yml` between changelog generation and build
- Align lakebase `package.json` description with README ("Autoscaling")

## Test plan

- [x] Ran `pnpm exec tsx tools/sync-lakebase-version.ts "0.3.0"` locally — confirmed `packages/lakebase/package.json` version updated to `0.3.0`
- [x] After merge, verify the prepare-release-lakebase workflow produces a tarball with matching version