### PR TITLE
chore(lakebase): set package version to 0.2.0 for CI registry

### DIFF
--- a/packages/lakebase/package.json
+++ b/packages/lakebase/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@databricks/lakebase",
   "type": "module",
-  "version": "0.3.0",
+  "version": "0.2.0",
   "description": "PostgreSQL driver for Databricks Lakebase Autoscaling with automatic OAuth token refresh",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Downgrade `packages/lakebase` from `0.3.0` to `0.2.0` so the packed `@databricks/appkit` tarball declares a `@databricks/lakebase` version that resolves on the CI npm registry (JFrog). `0.3.0` was not available there, which broke `prepare-release` when the `template-artifact` job runs `npm install`.