### PR TITLE
chore(lakebase): revert package version back to 0.3.0

### DIFF
--- a/packages/lakebase/package.json
+++ b/packages/lakebase/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@databricks/lakebase",
   "type": "module",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "PostgreSQL driver for Databricks Lakebase Autoscaling with automatic OAuth token refresh",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

- Reverts commit 8e174db which downgraded `@databricks/lakebase` from `0.3.0` to `0.2.0`
- The workaround is no longer needed since `@databricks/lakebase` is now allowlisted in the JFrog proxy

Context: https://databricks.slack.com/archives/C0ANYB44MEX/p1777569627449729?thread_ts=1777564836.088849&cid=C0ANYB44MEX
