### PR TITLE
feat(appkit): improve Databricks auth failure UX at startup

### DIFF
--- a/docs/docs/api/appkit/Class.ConfigurationError.md
+++ b/docs/docs/api/appkit/Class.ConfigurationError.md
@@ -151,6 +151,35 @@ Create a human-readable string representation
 
 ***
 
+### databricksAuthenticationSetupFailed()
+
+```ts
+static databricksAuthenticationSetupFailed(detail: string, options?: {
+  cause?: Error;
+}): ConfigurationError;
+```
+
+Databricks CLI / token auth failed while creating the workspace client.
+
+By default the message is short; key lines use **picocolors** when the
+terminal supports it (also respects `NO_COLOR`). `console.error` won’t show
+stacks or `{ code, context, … }`. Set `APPKIT_VERBOSE_AUTH_ERRORS=1` for full
+`cause`, stack, and the raw SDK message (verbose appendix is unstyled).
+
+#### Parameters
+
+| Parameter | Type |
+| ------ | ------ |
+| `detail` | `string` |
+| `options?` | \{ `cause?`: `Error`; \} |
+| `options.cause?` | `Error` |
+
+#### Returns
+
+`ConfigurationError`
+
+***
+
 ### invalidConnection()
 
 ```ts

--- a/packages/appkit/src/context/service-context.ts
+++ b/packages/appkit/src/context/service-context.ts
@@ -1,5 +1,6 @@
 import {
   type ClientOptions,
+  ConfigError,
   type sql,
   WorkspaceClient,
 } from "@databricks/sdk-experimental";
@@ -158,25 +159,42 @@ export class ServiceContext {
     options?: { warehouseId?: boolean },
     client?: WorkspaceClient,
   ): Promise<ServiceContextState> {
-    const wsClient = client ?? new WorkspaceClient({}, getClientOptions());
+    try {
+      const wsClient = client ?? new WorkspaceClient({}, getClientOptions());
 
-    const warehouseId = options?.warehouseId
-      ? ServiceContext.getWarehouseId(wsClient)
-      : undefined;
+      const [resolvedWorkspaceId, currentUser, resolvedWarehouseId] =
+        await Promise.all([
+          ServiceContext.getWorkspaceId(wsClient),
+          wsClient.currentUser.me(),
+          options?.warehouseId
+            ? ServiceContext.getWarehouseId(wsClient)
+            : Promise.resolve(undefined as string | undefined),
+        ]);
 
-    const workspaceId = ServiceContext.getWorkspaceId(wsClient);
-    const currentUser = await wsClient.currentUser.me();
+      if (!currentUser.id) {
+        throw ConfigurationError.resourceNotFound("Service user ID");
+      }
 
-    if (!currentUser.id) {
-      throw ConfigurationError.resourceNotFound("Service user ID");
+      const warehouseId =
+        options?.warehouseId && resolvedWarehouseId !== undefined
+          ? Promise.resolve(resolvedWarehouseId)
+          : undefined;
+
+      return {
+        client: wsClient,
+        serviceUserId: currentUser.id,
+        warehouseId,
+        workspaceId: Promise.resolve(resolvedWorkspaceId),
+      };
+    } catch (e) {
+      if (e instanceof ConfigError) {
+        throw ConfigurationError.databricksAuthenticationSetupFailed(
+          e.baseMessage,
+          { cause: e },
+        );
+      }
+      throw e;
     }
-
-    return {
-      client: wsClient,
-      serviceUserId: currentUser.id,
-      warehouseId,
-      workspaceId,
-    };
   }
 
   private static async getWorkspaceId(

--- a/packages/appkit/src/errors/configuration.ts
+++ b/packages/appkit/src/errors/configuration.ts
@@ -1,4 +1,35 @@
+import pc from "picocolors";
 import { AppKitError } from "./base";
+
+function authSetupVerbose(): boolean {
+  return (
+    process.env.APPKIT_VERBOSE_AUTH_ERRORS === "1" ||
+    process.env.APPKIT_VERBOSE_AUTH_ERRORS === "true"
+  );
+}
+
+/** Pulls ` $ databricks ...` from SDK text when present. */
+function suggestedDatabricksCliCommand(detail: string): string | undefined {
+  const m = detail.match(/\$\s*(databricks[^\n]+)/);
+  return m?.[1]?.trim();
+}
+
+/** Makes `console.error` show only the message (no stack, no extra fields). */
+function pinUserFacingAuthError(err: ConfigurationError): void {
+  Object.defineProperty(err, "stack", {
+    value: "",
+    configurable: true,
+    enumerable: false,
+    writable: true,
+  });
+  Object.defineProperty(err, Symbol.for("nodejs.util.inspect.custom"), {
+    value: function (this: ConfigurationError): string {
+      return this.message;
+    },
+    enumerable: false,
+    configurable: true,
+  });
+}
 
 /**
  * Error thrown when configuration is missing or invalid.
@@ -56,5 +87,59 @@ export class ConfigurationError extends AppKitError {
       `Connection string must include ${param} parameter`,
       { context: { parameter: param } },
     );
+  }
+
+  /**
+   * Databricks CLI / token auth failed while creating the workspace client.
+   *
+   * By default the message is short; key lines use **picocolors** when the
+   * terminal supports it (also respects `NO_COLOR`). `console.error` won’t show
+   * stacks or `{ code, context, … }`. Set `APPKIT_VERBOSE_AUTH_ERRORS=1` for full
+   * `cause`, stack, and the raw SDK message (verbose appendix is unstyled).
+   */
+  static databricksAuthenticationSetupFailed(
+    detail: string,
+    options?: { cause?: Error },
+  ): ConfigurationError {
+    const verbose = authSetupVerbose();
+    const host = process.env.DATABRICKS_HOST ?? "(not set)";
+    const warehouseId = process.env.DATABRICKS_WAREHOUSE_ID;
+    const d = detail.trim();
+    const cli = suggestedDatabricksCliCommand(d);
+
+    const title = pc.bold(pc.red("Databricks authentication failed."));
+    const action = cli
+      ? `${pc.bold("Run this, then try again:")}\n  ${pc.cyan(cli)}`
+      : pc.yellow(
+          "Log in with the Databricks CLI (for example, databricks auth login for this workspace), then try again.",
+        );
+    const tokenHint = pc.dim(
+      "Or set DATABRICKS_TOKEN and DATABRICKS_HOST instead of CLI-based auth.",
+    );
+
+    const lines: string[] = [
+      title,
+      "",
+      action,
+      "",
+      tokenHint,
+      "",
+      `${pc.green("DATABRICKS_HOST")}: ${host}`,
+    ];
+    if (warehouseId) {
+      lines.push(`${pc.green("DATABRICKS_WAREHOUSE_ID")}: ${warehouseId}`);
+    }
+    if (verbose) {
+      lines.push("", d);
+    }
+
+    const err = new ConfigurationError(lines.join("\n"), {
+      cause: verbose ? options?.cause : undefined,
+    });
+
+    if (!verbose) {
+      pinUserFacingAuthError(err);
+    }
+    return err;
   }
 }


### PR DESCRIPTION
## Summary

When workspace credentials fail during `ServiceContext` initialization (for example expired Databricks CLI tokens), users previously saw a long `ConfigError` stack from the SDK. This change maps that case to a short, actionable `ConfigurationError` and keeps default console output easy to read.

## What changed

- **Service context:** Catch `ConfigError` while creating the client and throw `ConfigurationError.databricksAuthenticationSetupFailed` with the SDK `baseMessage`. Resolve workspace id, `currentUser.me()`, and optional warehouse id in **parallel** so startup fails fast and consistently.
- **User-facing message:** Short text with **picocolors** when the terminal supports color (`NO_COLOR` respected via picocolors). When the SDK text includes a line like `$ databricks auth login …`, that command is surfaced prominently.
- **Quiet vs verbose:** By default, empty stack and `util.inspect.custom` so `console.error(err)` does not print nested causes or enumerable `ConfigurationError` fields. Set **`APPKIT_VERBOSE_AUTH_ERRORS=1`** for full stacks, `cause`, and the raw SDK detail.

## How to verify

1. Misconfigure or expire CLI auth and run an app that calls `createApp` / `ServiceContext.initialize`.
2. Confirm the terminal shows the shortened message and suggested command.
3. Retry with `APPKIT_VERBOSE_AUTH_ERRORS=1` and confirm full diagnostics appear.