### PR TITLE
feat(appkit): scan upward from preferred port in development

### DIFF
--- a/packages/appkit/package.json
+++ b/packages/appkit/package.json
@@ -71,6 +71,7 @@
     "@types/semver": "7.7.1",
     "dotenv": "16.6.1",
     "express": "4.22.0",
+    "get-port": "7.2.0",
     "obug": "2.1.1",
     "pg": "8.18.0",
     "picocolors": "1.1.1",

--- a/packages/appkit/src/plugins/server/index.ts
+++ b/packages/appkit/src/plugins/server/index.ts
@@ -3,6 +3,7 @@ import type { Server as HTTPServer } from "node:http";
 import path from "node:path";
 import dotenv from "dotenv";
 import express from "express";
+import getPort, { portNumbers } from "get-port";
 import type { PluginClientConfigs, PluginPhase } from "shared";
 import { ServerError } from "../../errors";
 import { createLogger } from "../../logging/logger";
@@ -20,6 +21,9 @@ import { ViteDevServer } from "./vite-dev-server";
 dotenv.config({ path: path.resolve(process.cwd(), "./.env") });
 
 const logger = createLogger("server");
+
+/** Dev-only: try `requested` then consecutive ports (see `get-port` `portNumbers`). */
+const devListenPortSpan = 100;
 
 /**
  * Server plugin for the AppKit.
@@ -54,6 +58,8 @@ export class ServerPlugin extends Plugin {
   private server: HTTPServer | null;
   private viteDevServer?: ViteDevServer;
   private remoteTunnelController?: RemoteTunnelController;
+  /** Bound listen port after optional dev-time resolution. */
+  private resolvedListenPort?: number;
   protected declare config: ServerConfig;
   private serverExtensions: ((app: express.Application) => void)[] = [];
   private rawBodyPaths: Set<string> = new Set();
@@ -125,8 +131,10 @@ export class ServerPlugin extends Plugin {
 
     await this.setupFrontend(endpoints, pluginConfigs);
 
+    const listenPort = await this.resolveListenPort();
+
     const server = this.serverApplication.listen(
-      this.config.port ?? ServerPlugin.DEFAULT_CONFIG.port,
+      listenPort,
       this.config.host ?? ServerPlugin.DEFAULT_CONFIG.host,
       () => this.logStartupInfo(),
     );
@@ -306,10 +314,36 @@ export class ServerPlugin extends Plugin {
     return undefined;
   }
 
+  /**
+   * In development, prefers {@link ServerConfig.port} / env / default (8000), then
+   * scans upward using `get-port`'s `portNumbers()` on the listen host until one binds.
+   * In non-development, uses config / env / default only (no fallback).
+   */
+  private async resolveListenPort(): Promise<number> {
+    const requested = this.config.port ?? ServerPlugin.DEFAULT_CONFIG.port;
+
+    if (process.env.NODE_ENV !== "development") {
+      this.resolvedListenPort = requested;
+      return requested;
+    }
+
+    const host = this.config.host ?? ServerPlugin.DEFAULT_CONFIG.host;
+    const upper = Math.min(requested + devListenPortSpan - 1, 65_535);
+    const port = await getPort({
+      host,
+      port: portNumbers(requested, upper),
+    });
+    this.resolvedListenPort = port;
+    return port;
+  }
+
   private logStartupInfo() {
     const isDev = process.env.NODE_ENV === "development";
     const hasExplicitStaticPath = this.config.staticPath !== undefined;
-    const port = this.config.port ?? ServerPlugin.DEFAULT_CONFIG.port;
+    const port =
+      this.resolvedListenPort ??
+      this.config.port ??
+      ServerPlugin.DEFAULT_CONFIG.port;
     const host = this.config.host ?? ServerPlugin.DEFAULT_CONFIG.host;
 
     logger.info("Server running on http://%s:%d", host, port);

--- a/packages/appkit/src/plugins/server/index.ts
+++ b/packages/appkit/src/plugins/server/index.ts
@@ -334,6 +334,9 @@ export class ServerPlugin extends Plugin {
       port: portNumbers(requested, upper),
     });
     this.resolvedListenPort = port;
+    if (port !== requested) {
+      logger.info("Port %d was busy, picking %d", requested, port);
+    }
     return port;
   }
 

--- a/packages/appkit/src/plugins/server/tests/server.test.ts
+++ b/packages/appkit/src/plugins/server/tests/server.test.ts
@@ -330,6 +330,36 @@ describe("ServerPlugin", () => {
       );
     });
 
+    test("logs info when dev preferred port was busy and another was picked", async () => {
+      process.env.NODE_ENV = "development";
+      mockLoggerInfo.mockClear();
+      mockGetPort.mockResolvedValueOnce(8123);
+      const plugin = new ServerPlugin({});
+
+      await plugin.start();
+
+      expect(mockLoggerInfo).toHaveBeenCalledWith(
+        "Port %d was busy, picking %d",
+        ServerPlugin.DEFAULT_CONFIG.port,
+        8123,
+      );
+    });
+
+    test("does not log busy info when dev preferred port was free", async () => {
+      process.env.NODE_ENV = "development";
+      mockLoggerInfo.mockClear();
+      mockGetPort.mockResolvedValueOnce(ServerPlugin.DEFAULT_CONFIG.port);
+      const plugin = new ServerPlugin({});
+
+      await plugin.start();
+
+      expect(mockLoggerInfo).not.toHaveBeenCalledWith(
+        "Port %d was busy, picking %d",
+        expect.any(Number),
+        expect.any(Number),
+      );
+    });
+
     test("should setup ViteDevServer in development mode", async () => {
       process.env.NODE_ENV = "development";
       const plugin = new ServerPlugin({});

--- a/packages/appkit/src/plugins/server/tests/server.test.ts
+++ b/packages/appkit/src/plugins/server/tests/server.test.ts
@@ -6,6 +6,7 @@ const {
   mockExpressApp,
   mockRemoteTunnelControllerMiddleware,
   mockRemoteTunnelControllerInstance,
+  mockGetPort,
 } = vi.hoisted(() => {
   const httpServer = {
     close: vi.fn((cb: any) => cb?.()),
@@ -36,11 +37,29 @@ const {
     isActive: vi.fn().mockReturnValue(false),
   };
 
+  const mockGetPort = vi.fn(
+    async (opts?: { port?: number | Iterable<number>; host?: string }) => {
+      if (opts?.port == null) return 8000;
+      if (typeof opts.port === "number") return opts.port;
+      for (const p of opts.port) return p;
+      return 8000;
+    },
+  );
+
   return {
     mockHttpServer: httpServer,
     mockExpressApp: expressApp,
     mockRemoteTunnelControllerMiddleware: remoteTunnelControllerMiddleware,
     mockRemoteTunnelControllerInstance: remoteTunnelControllerInstance,
+    mockGetPort,
+  };
+});
+
+vi.mock("get-port", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("get-port")>();
+  return {
+    ...actual,
+    default: mockGetPort,
   };
 });
 
@@ -240,6 +259,70 @@ describe("ServerPlugin", () => {
 
       await plugin.start();
 
+      expect(mockExpressApp.listen).toHaveBeenCalledWith(
+        3000,
+        expect.any(String),
+        expect.any(Function),
+      );
+    });
+
+    test("uses get-port portNumbers in development when default preferred", async () => {
+      process.env.NODE_ENV = "development";
+      mockGetPort.mockResolvedValueOnce(8123);
+      const plugin = new ServerPlugin({});
+
+      await plugin.start();
+
+      expect(mockGetPort).toHaveBeenCalledWith(
+        expect.objectContaining({
+          host: ServerPlugin.DEFAULT_CONFIG.host,
+        }),
+      );
+      const opts = mockGetPort.mock.calls[0][0] as {
+        port: Iterable<number>;
+      };
+      expect([...opts.port].slice(0, 2)).toEqual([
+        ServerPlugin.DEFAULT_CONFIG.port,
+        ServerPlugin.DEFAULT_CONFIG.port + 1,
+      ]);
+      expect(mockExpressApp.listen).toHaveBeenCalledWith(
+        8123,
+        expect.any(String),
+        expect.any(Function),
+      );
+    });
+
+    test("uses get-port portNumbers in development when explicit port preferred", async () => {
+      process.env.NODE_ENV = "development";
+      mockGetPort.mockResolvedValueOnce(9123);
+      const plugin = new ServerPlugin({ port: 4000 });
+
+      await plugin.start();
+
+      expect(mockGetPort).toHaveBeenCalledWith(
+        expect.objectContaining({
+          host: ServerPlugin.DEFAULT_CONFIG.host,
+        }),
+      );
+      const opts = mockGetPort.mock.calls[0][0] as {
+        port: Iterable<number>;
+      };
+      expect([...opts.port].slice(0, 2)).toEqual([4000, 4001]);
+      expect(mockExpressApp.listen).toHaveBeenCalledWith(
+        9123,
+        expect.any(String),
+        expect.any(Function),
+      );
+    });
+
+    test("does not use get-port outside development", async () => {
+      process.env.NODE_ENV = "production";
+      mockGetPort.mockClear();
+      const plugin = new ServerPlugin({ port: 3000 });
+
+      await plugin.start();
+
+      expect(mockGetPort).not.toHaveBeenCalled();
       expect(mockExpressApp.listen).toHaveBeenCalledWith(
         3000,
         expect.any(String),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -305,6 +305,9 @@ importers:
       express:
         specifier: 4.22.0
         version: 4.22.0
+      get-port:
+        specifier: 7.2.0
+        version: 7.2.0
       obug:
         specifier: 2.1.1
         version: 2.1.1
@@ -7314,6 +7317,10 @@ packages:
 
   get-own-enumerable-property-symbols@3.0.2:
     resolution: {integrity: sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==}
+
+  get-port@7.2.0:
+    resolution: {integrity: sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==}
+    engines: {node: '>=16'}
 
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
@@ -19902,6 +19909,8 @@ snapshots:
   get-nonce@1.0.1: {}
 
   get-own-enumerable-property-symbols@3.0.2: {}
+
+  get-port@7.2.0: {}
 
   get-proto@1.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

- In `NODE_ENV=development`, the server plugin now picks the first free TCP port by scanning upward from the preferred port (`server({ port })`, `DATABRICKS_APP_PORT`, or default `8000`) using `get-port`'s `portNumbers(from, to)` helper, bounded to 100 attempts.
- Avoids `EADDRINUSE` failures when running multiple AppKit dev servers locally (e.g. two playgrounds at once).
- Production / non-development behavior is unchanged: the plugin binds the configured / env / default port and lets `listen` errors surface as before.
- Startup log already prints the bound URL via the existing `Server running on http://…` line; no extra fallback log is emitted.

## Implementation

- New private `ServerPlugin.resolveListenPort()` returns:
  - In development: `await getPort({ host, port: portNumbers(requested, requested + 99) })`.
  - Otherwise: the requested port (no scan).
- `start()` awaits the resolved port before `app.listen(...)`.
- `logStartupInfo()` reads the resolved port so logs match the actual socket.
- Adds `get-port@7.2.0` to `@databricks/appkit` dependencies.

## Test plan

- [x] `pnpm --filter @databricks/appkit typecheck`
- [x] `pnpm exec vitest run packages/appkit/src/plugins/server/tests/server.test.ts packages/appkit/src/plugins/server/tests/server.integration.test.ts` (37 tests pass; new dev/prod cases cover the resolution branches via a partial `get-port` mock)
- [x] `pnpm exec biome check --write` on touched files
- [ ] Manual: start two dev playgrounds back-to-back; confirm second one binds `8001` (or next free port) and the URL line reflects it