### PR TITLE
ci: align breaking-change detector with release-it parser semantics

### DIFF
--- a/tools/detect-breaking-commits.ts
+++ b/tools/detect-breaking-commits.ts
@@ -27,11 +27,16 @@ const TRACKED_PATHS = [
   "packages/shared",
 ];
 
-// Conventional Commits breaking-change markers:
-//   1. `type!:` or `type(scope)!:` in the subject line
-//   2. `BREAKING CHANGE:` or `BREAKING-CHANGE:` footer line
+// Matches what `conventional-changelog-conventionalcommits` (used by
+// release-it) treats as a major-bumping breaking change. Verified against
+// the live parser; covers:
+//   - Subject `type!:` / `type(scope)!:` (case-insensitive)
+//   - Footer line `BREAKING CHANGE` or `BREAKING-CHANGE`, with optional
+//     leading whitespace, optional colon, case-insensitive
+// Excludes the plural `BREAKING CHANGES` (parser does NOT treat it as
+// breaking — `\b(?!S)` enforces this) and mid-line / list-item occurrences.
 const BREAKING_PATTERN =
-  /^(feat|fix|chore|refactor|perf|build|ci|docs|style|test|revert)(\([^)]+\))?!:|^BREAKING[ -]CHANGE:/m;
+  /^(feat|fix|chore|refactor|perf|build|ci|docs|style|test|revert)(\([^)]+\))?!:|^\s*BREAKING[ -]CHANGE\b(?!S)/im;
 
 function requireEnv(name: string): string {
   const value = process.env[name];


### PR DESCRIPTION
## Summary

The detector added in #350 used a hand-rolled regex that didn't match what `release-it` (via `conventional-changelog-conventionalcommits`) actually treats as a major-bumping change. Surfaced while testing #352 — a PR with `BREAKING CHANGES: ...` (plural) in its description was passing the gate, but so were a few other inputs that release-it would silently bump major on.

I instrumented the live parser and ran ~30 commit-message variants through `whatBump`, then tightened the regex until it agreed with the parser on every case. The new regex differs in four ways:

- **Case-insensitive.** `Feat!:`, `FEAT!:`, and `breaking change: ...` all bump major in release-it.
- **Leading whitespace allowed.** `  BREAKING CHANGE: ...` is a valid footer per the parser.
- **Colon optional.** `BREAKING CHANGE foo` (no colon) is a valid footer; the parser tokenizes on word boundary.
- **Plural still excluded.** `BREAKING CHANGES` is *not* breaking per the parser, so `\b(?!S)` keeps us from creating false positives on prose like "introduces some breaking changes:".

Verified end-to-end against PR #352's actual inputs.

## Test plan

- [ ] On the PR for this branch, confirm the workflow stays green (no breaking markers in this commit).
- [ ] Rebase #352 on this branch and confirm:
  - [ ] `BREAKING CHANGES: ...` (plural) in the description does **not** trigger the gate.
  - [ ] `BREAKING CHANGE: ...` (singular) in the description **does** trigger the gate.
  - [ ] `breaking change: ...` (lowercase singular) **does** trigger the gate.
  - [ ] `Feat!: ...` (mixed-case bang in title) **does** trigger the gate.