### PR TITLE
feat(database): server runtime — drizzle pool, OBO, transactions, hooks

### DIFF
--- a/packages/appkit/src/database/index.ts
+++ b/packages/appkit/src/database/index.ts
@@ -1,1 +1,10 @@
+export type {
+  CountOptions,
+  DataPath,
+  IncludeSpec,
+  OrderSpec,
+  SelectOptions,
+  WhereSpec,
+} from "./runtime";
+export { createDrizzleDataPath, createUserScopedDataPath } from "./runtime";
 export * from "./schema-builder";

--- a/packages/appkit/src/database/runtime/data-path.ts
+++ b/packages/appkit/src/database/runtime/data-path.ts
@@ -1,0 +1,170 @@
+import type { AppKitTable } from "../schema-builder/types";
+
+/** Generic row shape returned by every read terminator. */
+export type Row = Record<string, unknown>;
+
+/** Sort direction accepted by `OrderSpec`. */
+type Direction = "asc" | "desc";
+
+/**
+ * Operator vocabulary supported by `WhereSpec`. Names match Drizzle helpers
+ * one-for-one; the runtime translates each into the matching helper (`eq`,
+ * `ne`, `gt`, …) when the query is built.
+ */
+type WhereOperator =
+  | "eq"
+  | "neq"
+  | "gt"
+  | "gte"
+  | "lt"
+  | "lte"
+  | "like"
+  | "ilike"
+  | "in"
+  | "is";
+
+/**
+ * Per-column predicate. Bare value is shorthand for equality; an array is
+ * shorthand for `IN`; an object selects one or more operators.
+ */
+type WhereValue =
+  | string
+  | number
+  | boolean
+  | null
+  | readonly (string | number | boolean | null)[]
+  | { [K in WhereOperator]?: unknown };
+
+/** Filter map: column name → predicate. */
+export type WhereSpec = Record<string, WhereValue>;
+
+/** Order map: column name → direction (default: `asc`). */
+export type OrderSpec = Record<string, Direction>;
+
+/**
+ * Per-relation include options. `select` projects related columns; `where`
+ * narrows them; `limit` and `order` paginate them. Nested includes are
+ * intentionally out of MVP scope.
+ */
+export interface IncludeOptions {
+  /** Restrict the related row's columns. Defaults to all columns. */
+  select?: ReadonlyArray<string>;
+  /** Cap the related rows fetched per parent. */
+  limit?: number;
+  /** Order the related rows. */
+  order?: OrderSpec;
+  /** Filter the related rows. */
+  where?: WhereSpec;
+}
+
+/**
+ * Eager-load shape: relation name → either `true` (all default) or an options
+ * bag. The runtime resolves relation names against the parent table's
+ * `$relations` metadata; unknown names throw at query time.
+ */
+export type IncludeSpec = Record<string, true | IncludeOptions>;
+
+/** Options accepted by `DataPath.select`. */
+export interface SelectOptions {
+  where?: WhereSpec;
+  order?: OrderSpec;
+  limit?: number;
+  offset?: number;
+  /** Project specific columns. Defaults to `*`. */
+  columns?: ReadonlyArray<string>;
+  /** Eager-load related entities. */
+  include?: IncludeSpec;
+  /** Aborts the underlying query when the signal fires. */
+  signal?: AbortSignal;
+}
+
+/** Options accepted by `DataPath.findOne`. */
+export interface FindOneOptions {
+  columns?: ReadonlyArray<string>;
+  include?: IncludeSpec;
+  signal?: AbortSignal;
+}
+
+/** Options accepted by `DataPath.count`. */
+export interface CountOptions {
+  where?: WhereSpec;
+  signal?: AbortSignal;
+}
+
+/**
+ * AppKit-shaped abstraction over the runtime data path.
+ *
+ * The entity proxy and route layer talk to this interface only. The
+ * implementation in `drizzle-runtime.ts` is the *only* AppKit file that
+ * imports `drizzle-orm` for query execution. Swapping Drizzle for Kysely,
+ * Knex, or raw SQL means rewriting one file.
+ *
+ * Identity, OBO, telemetry, hook dispatch, and validation all live above this
+ * interface — `DataPath` is plain "execute these reads/writes against this
+ * pool". Pool selection (SP vs per-user) happens in `entity-wiring.ts`.
+ */
+export interface DataPath {
+  /** Run a SELECT and return rows (with optional eager joins). */
+  select(table: AppKitTable, opts: SelectOptions): Promise<Row[]>;
+
+  /** Find one row by primary key, or `null` when no row matches. */
+  findOne(
+    table: AppKitTable,
+    pkColumn: string,
+    id: string | number,
+    opts?: FindOneOptions,
+  ): Promise<Row | null>;
+
+  /** Count rows matching `where`. */
+  count(table: AppKitTable, opts: CountOptions): Promise<number>;
+
+  /** INSERT one row and return the inserted row (with server-generated columns). */
+  insert(table: AppKitTable, data: Row, signal?: AbortSignal): Promise<Row>;
+
+  /**
+   * UPDATE one row by primary key. Returns the updated row, or `null` when
+   * no row matches. Hook dispatch and Zod validation happen above this layer.
+   */
+  update(
+    table: AppKitTable,
+    pkColumn: string,
+    id: string | number,
+    patch: Row,
+    signal?: AbortSignal,
+  ): Promise<Row | null>;
+
+  /**
+   * INSERT … ON CONFLICT (`onConflict`) DO UPDATE. Returns the resulting row.
+   * `onConflict` is a column name in the table (single-column unique constraint).
+   */
+  upsert(
+    table: AppKitTable,
+    data: Row,
+    options: { onConflict: string },
+    signal?: AbortSignal,
+  ): Promise<Row>;
+
+  /** DELETE one row by primary key. No-op when no row matches. */
+  delete(
+    table: AppKitTable,
+    pkColumn: string,
+    id: string | number,
+    signal?: AbortSignal,
+  ): Promise<void>;
+
+  /**
+   * Run `fn` inside a database transaction. The nested `DataPath` shares the
+   * same surface; rollbacks happen on throw, commits on resolution.
+   */
+  transaction<T>(fn: (tx: DataPath) => Promise<T>): Promise<T>;
+
+  /**
+   * Tagged-template SQL escape hatch. Values are bound as parameters; column
+   * and identifier interpolation is intentionally not supported here — use
+   * `getDrizzle()` from the plugin's exports for that case.
+   */
+  raw<T = Row>(
+    strings: TemplateStringsArray,
+    ...values: unknown[]
+  ): Promise<T[]>;
+}

--- a/packages/appkit/src/database/runtime/data-path.ts
+++ b/packages/appkit/src/database/runtime/data-path.ts
@@ -74,7 +74,12 @@ export interface SelectOptions {
   columns?: ReadonlyArray<string>;
   /** Eager-load related entities. */
   include?: IncludeSpec;
-  /** Aborts the underlying query when the signal fires. */
+  /**
+   * Reserved. `node-postgres` does not honor `AbortSignal` at the query level
+   * today — runaway queries are bounded server-side by Postgres
+   * `statement_timeout` (set by the plugin on every pool connection). The
+   * AppKit timeout interceptor still rejects the JS promise when fired.
+   */
   signal?: AbortSignal;
 }
 

--- a/packages/appkit/src/database/runtime/drizzle-runtime.ts
+++ b/packages/appkit/src/database/runtime/drizzle-runtime.ts
@@ -18,11 +18,10 @@ import {
 } from "drizzle-orm";
 import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
 import type { Pool } from "pg";
+import { nonPrivateColumnNames } from "../schema-builder/private";
 import type { AppKitTable, Schema } from "../schema-builder/types";
 import type {
-  CountOptions,
   DataPath,
-  FindOneOptions,
   IncludeOptions,
   IncludeSpec,
   OrderSpec,
@@ -31,26 +30,16 @@ import type {
   WhereSpec,
 } from "./data-path";
 
-/**
- * Internal Drizzle column reference. Drizzle exposes columns as properties on
- * the table object (e.g. `userTable.email`), but their concrete type lives in
- * `drizzle-orm/pg-core` internals. We treat the column as opaque at this
- * boundary so the rest of the file stays free of Drizzle column generics.
- */
+// Drizzle column type lives in `pg-core` internals — keep opaque so the rest
+// of the file stays free of Drizzle generics.
 type DrizzleColumn = unknown;
 
-/**
- * Internal Drizzle table reference. The table object carries column refs and
- * runtime metadata. We never narrow this type; queries cast it where Drizzle
- * APIs require concrete generics.
- */
+// Drizzle table — never narrowed; queries cast where Drizzle wants generics.
 type DrizzleTable = Record<string, DrizzleColumn>;
 
 /**
- * Resolved relation between two tables.
- *
- * `manyToOne` — the parent table holds the foreign key (e.g. `user.team_id`).
- * `oneToMany` — the related table holds the foreign key (e.g. `post.author_id`).
+ * `manyToOne` — parent holds the FK (e.g. `user.team_id`).
+ * `oneToMany` — related holds the FK back (e.g. `post.author_id`).
  */
 type ResolvedRelation =
   | {
@@ -71,18 +60,12 @@ type ResolvedRelation =
     };
 
 /**
- * Build a `DataPath` backed by `drizzle-orm/node-postgres` over a pg.Pool.
+ * Build a `DataPath` backed by `drizzle-orm/node-postgres`.
  *
- * This is the **only** AppKit file that imports `drizzle-orm` for query
- * execution (decision #30). All other code consumes the AppKit-shaped
- * `DataPath` interface, so swapping Drizzle for another query builder later
- * means rewriting just this file.
- *
- * `schema` is needed to resolve eager-loading relations — Drizzle's runtime
- * relations API would also work, but it requires `relations()` declarations
- * in the schema-builder which we don't generate today. We do joins via a
- * two-query pattern (parent + IN-clause for related rows) which avoids the
- * N+1 trap without requiring extra schema metadata.
+ * Sole `drizzle-orm` import site (decision #30) — swapping query builders
+ * means rewriting only this file. `schema` resolves eager-loading relations
+ * via a two-query pattern (parent + IN(ids)), avoiding N+1 without needing
+ * Drizzle's `relations()` API.
  */
 export function createDrizzleDataPath(pool: Pool, schema: Schema): DataPath {
   const db = drizzle(pool);
@@ -90,19 +73,14 @@ export function createDrizzleDataPath(pool: Pool, schema: Schema): DataPath {
 }
 
 /**
- * Build a user-scoped `DataPath` that wraps every operation in a database
- * transaction with `SET LOCAL app.user_id` set to the user's identity.
+ * User-scoped `DataPath`: each op runs in a txn with `SET LOCAL app.user_id`.
  *
- * The transaction is the security boundary: the GUC is transaction-scoped
- * (Postgres clears it on COMMIT/ROLLBACK), so a connection returned to the
- * pool cannot leak identity to the next checkout. RLS policies that read
- * `current_setting('app.user_id')` (or AppKit's emitted `current_user_id()`
- * helper) resolve to the OBO user.
+ * The txn is the security boundary — the GUC is txn-scoped, so a connection
+ * returned to the pool can't leak identity to the next checkout. RLS policies
+ * reading `current_setting('app.user_id')` resolve to the OBO user.
  *
- * One SP pool services every user — connection count is independent of user
- * count, with no per-user OAuth refresh loops or LRU eviction. Cost is one
- * BEGIN+COMMIT round-trip per top-level operation; consumers amortize via
- * `transaction(fn)` for multi-step work.
+ * One SP pool services everyone (no per-user pools, OAuth refresh, or LRU).
+ * Cost: one BEGIN+COMMIT per op; amortize via `transaction(fn)` for multi-step.
  */
 export function createUserScopedDataPath(
   pool: Pool,
@@ -111,16 +89,14 @@ export function createUserScopedDataPath(
 ): DataPath {
   const db = drizzle(pool);
 
-  // Each method opens its own transaction and sets the GUC, delegating the
-  // actual query to a fresh DataPath bound to the txn. `transaction(fn)`
-  // shares one BEGIN/SET LOCAL/COMMIT across the user's nested operations.
+  // Each op opens its own txn + GUC. `transaction(fn)` shares one
+  // BEGIN/SET LOCAL/COMMIT across nested ops.
   async function withUserContext<T>(
     fn: (tx: DataPath) => Promise<T>,
   ): Promise<T> {
     // biome-ignore lint/suspicious/noExplicitAny: Drizzle's transaction generic is opaque at this boundary.
     return await (db as any).transaction(async (tx: NodePgDatabase) => {
-      // `set_config(name, value, true)` is the parameterized form of
-      // `SET LOCAL` — Postgres clears the value on COMMIT/ROLLBACK.
+      // `set_config(_, _, true)` = parameterized SET LOCAL; cleared on COMMIT/ROLLBACK.
       await tx.execute(
         sql`SELECT set_config('app.user_id', ${context.userId}, true)`,
       );
@@ -186,9 +162,8 @@ function makeDataPath(
       const drizzleTable = table.$drizzle as DrizzleTable;
       const projection = projectColumns(table, opts?.columns);
 
-      const builder = (
-        projection ? db.select(projection as never) : db.select()
-      )
+      const builder = db
+        .select(projection as never)
         // biome-ignore lint/suspicious/noExplicitAny: Drizzle's table generic is opaque at this boundary.
         .from(drizzleTable as any)
         .where(eq(pk as never, id));
@@ -216,11 +191,12 @@ function makeDataPath(
 
     async insert(table, data, signal) {
       const drizzleTable = table.$drizzle as DrizzleTable;
+      const returning = projectColumns(table, undefined);
       const builder = db
         // biome-ignore lint/suspicious/noExplicitAny: Drizzle's table generic is opaque at this boundary.
         .insert(drizzleTable as any)
         .values(data as never)
-        .returning();
+        .returning(returning as never);
       const rows = (await maybeAbort(builder, signal)) as Row[];
       const row = rows[0];
       if (!row) {
@@ -232,12 +208,13 @@ function makeDataPath(
     async update(table, pkColumn, id, patch, signal) {
       const drizzleTable = table.$drizzle as DrizzleTable;
       const pk = getColumn(table, pkColumn);
+      const returning = projectColumns(table, undefined);
       const builder = db
         // biome-ignore lint/suspicious/noExplicitAny: Drizzle's table generic is opaque at this boundary.
         .update(drizzleTable as any)
         .set(patch as never)
         .where(eq(pk as never, id))
-        .returning();
+        .returning(returning as never);
       const rows = (await maybeAbort(builder, signal)) as Row[];
       return rows[0] ?? null;
     },
@@ -245,6 +222,7 @@ function makeDataPath(
     async upsert(table, data, options, signal) {
       const drizzleTable = table.$drizzle as DrizzleTable;
       const conflictCol = getColumn(table, options.onConflict);
+      const returning = projectColumns(table, undefined);
       const builder = db
         // biome-ignore lint/suspicious/noExplicitAny: Drizzle's table generic is opaque at this boundary.
         .insert(drizzleTable as any)
@@ -253,7 +231,7 @@ function makeDataPath(
           target: conflictCol as never,
           set: data as never,
         })
-        .returning();
+        .returning(returning as never);
       const rows = (await maybeAbort(builder, signal)) as Row[];
       const row = rows[0];
       if (!row) {
@@ -273,11 +251,10 @@ function makeDataPath(
     },
 
     async transaction(fn) {
-      // Client-side cap for the whole `transaction(fn)` callback. The server
-      // also enforces `statement_timeout` per session, but a long-running
-      // workflow that holds the txn open between queries (e.g. waiting on an
-      // external API) wouldn't trip a per-statement cap. 30s is a default
-      // ceiling that catches stuck callers without surprising healthy ones.
+      // Client-side cap on the whole callback. `statement_timeout` only bounds
+      // individual queries — a workflow holding the txn open between queries
+      // (e.g. awaiting an external API) wouldn't trip it. 30s catches stuck
+      // callers without surprising healthy ones.
       const TRANSACTION_TIMEOUT_MS = 30_000;
       // biome-ignore lint/suspicious/noExplicitAny: tx shares the NodePgDatabase shape.
       const txnPromise = (db as any).transaction(async (tx: NodePgDatabase) => {
@@ -305,9 +282,8 @@ function makeDataPath(
     },
 
     async raw(strings, ...values) {
-      // Drizzle's `sql` tag accepts the same shape as a TaggedTemplateLiteral.
-      // We pass the strings array straight through and let Drizzle bind values
-      // as parameters, avoiding any string concatenation here.
+      // Hand off to Drizzle's `sql` tag — it parameterizes `values`, no string
+      // concat happens here.
       const query = sql(
         Object.assign([...strings], {
           raw: [...strings],
@@ -334,7 +310,8 @@ async function runSelect(
   const drizzleTable = table.$drizzle as DrizzleTable;
   const projection = projectColumns(table, opts.columns);
 
-  let builder = (projection ? db.select(projection as never) : db.select())
+  let builder = db
+    .select(projection as never)
     // biome-ignore lint/suspicious/noExplicitAny: Drizzle's table generic is opaque at this boundary.
     .from(drizzleTable as any) as any;
 
@@ -351,18 +328,16 @@ async function runSelect(
   return rows;
 }
 
-/**
- * Project a subset of columns into a Drizzle `select({ ... })` shape, or
- * return `undefined` to mean "all columns" (Drizzle's default behavior when
- * `select()` is called with no arguments returns the full row).
- */
+// Always project explicitly — bare `select()` would `SELECT *` and leak
+// `.private()` columns. Reused by `.returning()` on writes.
 function projectColumns(
   table: AppKitTable,
   columns: ReadonlyArray<string> | undefined,
-): Record<string, DrizzleColumn> | undefined {
-  if (!columns || columns.length === 0) return undefined;
+): Record<string, DrizzleColumn> {
+  const names =
+    columns && columns.length > 0 ? columns : nonPrivateColumnNames(table);
   const out: Record<string, DrizzleColumn> = {};
-  for (const name of columns) {
+  for (const name of names) {
     out[name] = getColumn(table, name);
   }
   return out;
@@ -391,13 +366,24 @@ export function buildWhere(
       continue;
     }
 
-    if (value === null || typeof value !== "object") {
+    if (value === null) {
+      // `= NULL` is never true in SQL — use IS NULL.
+      conditions.push(isNull(col as never));
+      continue;
+    }
+
+    if (typeof value !== "object") {
       conditions.push(eq(col as never, value as never));
       continue;
     }
 
-    for (const [op, opValue] of Object.entries(value)) {
-      const condition = buildOperator(col, op, opValue);
+    for (const op of Object.keys(value)) {
+      if (!Object.hasOwn(value, op)) continue;
+      const condition = buildOperator(
+        col,
+        op,
+        (value as Record<string, unknown>)[op],
+      );
       if (condition) conditions.push(condition);
     }
   }
@@ -469,10 +455,8 @@ async function applyIncludes(
   parentRows: Row[],
   spec: IncludeSpec,
 ): Promise<void> {
-  // Mutate parent rows in place — adding each relation as either an array
-  // (one-to-many) or a single value/null (many-to-one). Two queries per
-  // relation: one to fetch the parent, one to fetch the related rows with
-  // `IN (parent_ids)`. This avoids N+1 without needing Drizzle's relations API.
+  // Two queries per relation (parent + related-rows-by-IN(ids)) avoids N+1
+  // without Drizzle's relations API. Mutates parent rows in place.
   for (const [relationName, options] of Object.entries(spec)) {
     if (options === undefined) continue;
     const opts: IncludeOptions = options === true ? {} : options;
@@ -507,20 +491,24 @@ async function applyManyToOne(
   const relatedKey = getColumn(relatedTable, resolved.relatedKey);
   const projection = projectColumns(relatedTable, opts.select);
 
-  let builder = (projection ? db.select(projection as never) : db.select())
+  // Drizzle `.where()` replaces on re-call — combine here, or the IN(parent_ids)
+  // predicate gets dropped and the include leaks rows across parents.
+  const inClause = inArray(relatedKey as never, parentFkValues as never[]);
+  const userWhere = buildWhere(relatedTable, opts.where);
+  const combined = userWhere ? and(inClause, userWhere) : inClause;
+
+  let builder = db
+    .select(projection as never)
     // biome-ignore lint/suspicious/noExplicitAny: Drizzle's table generic is opaque.
     .from(relatedDrizzle as any)
-    .where(inArray(relatedKey as never, parentFkValues as never[])) as any;
-
-  const where = buildWhere(relatedTable, opts.where);
-  if (where) builder = builder.where(and(where) as never);
+    .where(combined as never) as any;
 
   const order = buildOrder(relatedTable, opts.order);
   if (order.length > 0) builder = builder.orderBy(...order);
 
   const relatedRows = (await builder) as Row[];
 
-  // Index related by their PK for O(1) lookup when assigning to parents.
+  // Index by PK for O(1) parent assignment.
   const byKey = new Map<unknown, Row>();
   for (const row of relatedRows) {
     byKey.set(row[resolved.relatedKey], row);
@@ -553,21 +541,23 @@ async function applyOneToMany(
   const relatedFk = getColumn(relatedTable, resolved.relatedFk);
   const projection = projectColumns(relatedTable, opts.select);
 
-  let builder = (projection ? db.select(projection as never) : db.select())
+  // Combine before `.where()` — see applyManyToOne.
+  const inClause = inArray(relatedFk as never, parentKeyValues as never[]);
+  const userWhere = buildWhere(relatedTable, opts.where);
+  const combined = userWhere ? and(inClause, userWhere) : inClause;
+
+  let builder = db
+    .select(projection as never)
     // biome-ignore lint/suspicious/noExplicitAny: Drizzle's table generic is opaque.
     .from(relatedDrizzle as any)
-    .where(inArray(relatedFk as never, parentKeyValues as never[])) as any;
-
-  const where = buildWhere(relatedTable, opts.where);
-  if (where) builder = builder.where(and(where) as never);
+    .where(combined as never) as any;
 
   const order = buildOrder(relatedTable, opts.order);
   if (order.length > 0) builder = builder.orderBy(...order);
 
-  // We deliberately apply `limit` AFTER fetching, per parent — Drizzle's
-  // `.limit(n)` would cap the *whole* query, not per-parent. For small N
-  // this is acceptable; for large fan-out, consumers should paginate the
-  // parent query and call again.
+  // `.limit(n)` would cap the whole query, not per-parent — apply per-parent
+  // after fetch instead. Fine for small N; large fan-out should paginate
+  // the parent query and call again.
   const relatedRows = (await builder) as Row[];
 
   const grouped = new Map<unknown, Row[]>();
@@ -589,11 +579,8 @@ async function applyOneToMany(
 }
 
 /**
- * Resolve a relation by name on `parentTable`. The lookup is intentionally
- * lenient about naming: a relation can be referenced by the related table
- * name (`{ posts: true }` on a `user` row), by the FK column name
- * (`{ author_id: true }`), or by the entity key (the schema's exported name
- * for the related table).
+ * Resolve a relation by name. Lookup is lenient: by related table name
+ * (`{ posts: true }`), FK column (`{ author_id: true }`), or entity key.
  */
 function resolveRelation(
   schema: Schema,
@@ -665,38 +652,33 @@ function entityKeyOf(schema: Schema, tableName: string): string | undefined {
  * Helpers                                                                    *
  * -------------------------------------------------------------------------- */
 
-/** Pull a Drizzle column reference off the table by name. */
+// Gate on `$columns` so untrusted input can't reach prototype keys or Drizzle internals.
 function getColumn(table: AppKitTable, columnName: string): DrizzleColumn {
+  if (typeof columnName !== "string" || columnName.length === 0) {
+    throw new Error(
+      `Invalid column reference on table "${table.name}": expected non-empty string`,
+    );
+  }
+  if (!Object.hasOwn(table.$columns, columnName)) {
+    throw new Error(`Unknown column "${columnName}" on table "${table.name}"`);
+  }
   const drizzleTable = table.$drizzle as DrizzleTable;
   const col = drizzleTable[columnName];
-  if (!col) {
+  if (col === undefined || col === null) {
     throw new Error(
-      `Column "${columnName}" not found on table "${table.name}". ` +
-        `Available columns: ${Object.keys(drizzleTable)
-          .filter(
-            (k) => !k.startsWith("_") && typeof drizzleTable[k] === "object",
-          )
-          .join(", ")}`,
+      `Column "${columnName}" missing from drizzle table "${table.name}" — schema/runtime out of sync`,
     );
   }
   return col;
 }
 
-/**
- * Hook the optional `AbortSignal` into the Drizzle builder if the underlying
- * driver supports cancellation. `node-postgres` does not honor AbortSignal at
- * the query level today; this is a placeholder for future driver support.
- *
- * Returns the awaited result of the builder either way.
- */
+// Placeholder for AbortSignal support — node-postgres won't cancel in-flight
+// queries. `statement_timeout` (set on every pool connect) bounds runaway
+// reads; AppKit's timeout interceptor still rejects the awaited promise.
 async function maybeAbort<T>(
   builder: Promise<T> | { then: PromiseLike<T>["then"] },
   _signal?: AbortSignal,
 ): Promise<T> {
-  // Intentional no-op for the signal: node-postgres does not cancel in-flight
-  // queries. Server-side `statement_timeout` (set on every pool connection by
-  // the plugin) is what actually bounds runaway reads. The AppKit timeout
-  // interceptor still rejects the awaited promise when fired.
   return await (builder as Promise<T>);
 }
 

--- a/packages/appkit/src/database/runtime/drizzle-runtime.ts
+++ b/packages/appkit/src/database/runtime/drizzle-runtime.ts
@@ -273,10 +273,35 @@ function makeDataPath(
     },
 
     async transaction(fn) {
+      // Client-side cap for the whole `transaction(fn)` callback. The server
+      // also enforces `statement_timeout` per session, but a long-running
+      // workflow that holds the txn open between queries (e.g. waiting on an
+      // external API) wouldn't trip a per-statement cap. 30s is a default
+      // ceiling that catches stuck callers without surprising healthy ones.
+      const TRANSACTION_TIMEOUT_MS = 30_000;
       // biome-ignore lint/suspicious/noExplicitAny: tx shares the NodePgDatabase shape.
-      return await (db as any).transaction(async (tx: NodePgDatabase) => {
+      const txnPromise = (db as any).transaction(async (tx: NodePgDatabase) => {
         return await fn(makeDataPath(tx, schema));
+      }) as Promise<unknown>;
+
+      let timer: NodeJS.Timeout | undefined;
+      const timeout = new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () =>
+            reject(
+              new Error(
+                `transaction(fn) exceeded ${TRANSACTION_TIMEOUT_MS}ms client-side cap`,
+              ),
+            ),
+          TRANSACTION_TIMEOUT_MS,
+        );
+        timer.unref?.();
       });
+      try {
+        return (await Promise.race([txnPromise, timeout])) as never;
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
     },
 
     async raw(strings, ...values) {

--- a/packages/appkit/src/database/runtime/drizzle-runtime.ts
+++ b/packages/appkit/src/database/runtime/drizzle-runtime.ts
@@ -1,0 +1,676 @@
+import {
+  and,
+  asc,
+  count as countFn,
+  desc,
+  eq,
+  gt,
+  gte,
+  ilike,
+  inArray,
+  isNull,
+  like,
+  lt,
+  lte,
+  ne,
+  type SQL,
+  sql,
+} from "drizzle-orm";
+import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
+import type { Pool } from "pg";
+import type { AppKitTable, Schema } from "../schema-builder/types";
+import type {
+  CountOptions,
+  DataPath,
+  FindOneOptions,
+  IncludeOptions,
+  IncludeSpec,
+  OrderSpec,
+  Row,
+  SelectOptions,
+  WhereSpec,
+} from "./data-path";
+
+/**
+ * Internal Drizzle column reference. Drizzle exposes columns as properties on
+ * the table object (e.g. `userTable.email`), but their concrete type lives in
+ * `drizzle-orm/pg-core` internals. We treat the column as opaque at this
+ * boundary so the rest of the file stays free of Drizzle column generics.
+ */
+type DrizzleColumn = unknown;
+
+/**
+ * Internal Drizzle table reference. The table object carries column refs and
+ * runtime metadata. We never narrow this type; queries cast it where Drizzle
+ * APIs require concrete generics.
+ */
+type DrizzleTable = Record<string, DrizzleColumn>;
+
+/**
+ * Resolved relation between two tables.
+ *
+ * `manyToOne` — the parent table holds the foreign key (e.g. `user.team_id`).
+ * `oneToMany` — the related table holds the foreign key (e.g. `post.author_id`).
+ */
+type ResolvedRelation =
+  | {
+      kind: "manyToOne";
+      relatedTable: AppKitTable;
+      /** Column on the *parent* table holding the FK. */
+      parentFk: string;
+      /** Column on the *related* table being referenced (usually `id`). */
+      relatedKey: string;
+    }
+  | {
+      kind: "oneToMany";
+      relatedTable: AppKitTable;
+      /** Column on the *related* table holding the FK back to the parent. */
+      relatedFk: string;
+      /** Column on the *parent* table being referenced (usually `id`). */
+      parentKey: string;
+    };
+
+/**
+ * Build a `DataPath` backed by `drizzle-orm/node-postgres` over a pg.Pool.
+ *
+ * This is the **only** AppKit file that imports `drizzle-orm` for query
+ * execution (decision #30). All other code consumes the AppKit-shaped
+ * `DataPath` interface, so swapping Drizzle for another query builder later
+ * means rewriting just this file.
+ *
+ * `schema` is needed to resolve eager-loading relations — Drizzle's runtime
+ * relations API would also work, but it requires `relations()` declarations
+ * in the schema-builder which we don't generate today. We do joins via a
+ * two-query pattern (parent + IN-clause for related rows) which avoids the
+ * N+1 trap without requiring extra schema metadata.
+ */
+export function createDrizzleDataPath(pool: Pool, schema: Schema): DataPath {
+  const db = drizzle(pool);
+  return makeDataPath(db, schema);
+}
+
+/**
+ * Build a user-scoped `DataPath` that wraps every operation in a database
+ * transaction with `SET LOCAL app.user_id` set to the user's identity.
+ *
+ * The transaction is the security boundary: the GUC is transaction-scoped
+ * (Postgres clears it on COMMIT/ROLLBACK), so a connection returned to the
+ * pool cannot leak identity to the next checkout. RLS policies that read
+ * `current_setting('app.user_id')` (or AppKit's emitted `current_user_id()`
+ * helper) resolve to the OBO user.
+ *
+ * One SP pool services every user — connection count is independent of user
+ * count, with no per-user OAuth refresh loops or LRU eviction. Cost is one
+ * BEGIN+COMMIT round-trip per top-level operation; consumers amortize via
+ * `transaction(fn)` for multi-step work.
+ */
+export function createUserScopedDataPath(
+  pool: Pool,
+  schema: Schema,
+  context: { userId: string },
+): DataPath {
+  const db = drizzle(pool);
+
+  // Each method opens its own transaction and sets the GUC, delegating the
+  // actual query to a fresh DataPath bound to the txn. `transaction(fn)`
+  // shares one BEGIN/SET LOCAL/COMMIT across the user's nested operations.
+  async function withUserContext<T>(
+    fn: (tx: DataPath) => Promise<T>,
+  ): Promise<T> {
+    // biome-ignore lint/suspicious/noExplicitAny: Drizzle's transaction generic is opaque at this boundary.
+    return await (db as any).transaction(async (tx: NodePgDatabase) => {
+      // `set_config(name, value, true)` is the parameterized form of
+      // `SET LOCAL` — Postgres clears the value on COMMIT/ROLLBACK.
+      await tx.execute(
+        sql`SELECT set_config('app.user_id', ${context.userId}, true)`,
+      );
+      return await fn(makeDataPath(tx, schema));
+    });
+  }
+
+  const path: DataPath = {
+    async select(table, opts) {
+      return await withUserContext((tx) => tx.select(table, opts));
+    },
+    async findOne(table, pkColumn, id, opts) {
+      return await withUserContext((tx) =>
+        tx.findOne(table, pkColumn, id, opts),
+      );
+    },
+    async count(table, opts) {
+      return await withUserContext((tx) => tx.count(table, opts));
+    },
+    async insert(table, data, signal) {
+      return await withUserContext((tx) => tx.insert(table, data, signal));
+    },
+    async update(table, pkColumn, id, patch, signal) {
+      return await withUserContext((tx) =>
+        tx.update(table, pkColumn, id, patch, signal),
+      );
+    },
+    async upsert(table, data, options, signal) {
+      return await withUserContext((tx) =>
+        tx.upsert(table, data, options, signal),
+      );
+    },
+    async delete(table, pkColumn, id, signal) {
+      return await withUserContext((tx) =>
+        tx.delete(table, pkColumn, id, signal),
+      );
+    },
+    async transaction(fn) {
+      return await withUserContext(fn);
+    },
+    async raw(strings, ...values) {
+      return await withUserContext((tx) => tx.raw(strings, ...values));
+    },
+  };
+  return path;
+}
+
+function makeDataPath(
+  db: NodePgDatabase | NodePgDatabase<Record<string, never>>,
+  schema: Schema,
+): DataPath {
+  const path: DataPath = {
+    async select(table, opts) {
+      const rows = await runSelect(db, table, opts);
+      if (opts.include && rows.length > 0) {
+        await applyIncludes(db, schema, table, rows, opts.include);
+      }
+      return rows;
+    },
+
+    async findOne(table, pkColumn, id, opts) {
+      const pk = getColumn(table, pkColumn);
+      const drizzleTable = table.$drizzle as DrizzleTable;
+      const projection = projectColumns(table, opts?.columns);
+
+      const builder = (
+        projection ? db.select(projection as never) : db.select()
+      )
+        // biome-ignore lint/suspicious/noExplicitAny: Drizzle's table generic is opaque at this boundary.
+        .from(drizzleTable as any)
+        .where(eq(pk as never, id));
+
+      const rows = (await maybeAbort(builder, opts?.signal)) as Row[];
+      const row = rows[0] ?? null;
+
+      if (row && opts?.include) {
+        await applyIncludes(db, schema, table, [row], opts.include);
+      }
+      return row;
+    },
+
+    async count(table, opts) {
+      const drizzleTable = table.$drizzle as DrizzleTable;
+      // biome-ignore lint/suspicious/noExplicitAny: Drizzle's table generic is opaque at this boundary.
+      const builder = db.select({ value: countFn() }).from(drizzleTable as any);
+      const where = buildWhere(table, opts.where);
+      const final = where ? builder.where(where) : builder;
+      const result = (await maybeAbort(final, opts.signal)) as Array<{
+        value: number;
+      }>;
+      return Number(result[0]?.value ?? 0);
+    },
+
+    async insert(table, data, signal) {
+      const drizzleTable = table.$drizzle as DrizzleTable;
+      const builder = db
+        // biome-ignore lint/suspicious/noExplicitAny: Drizzle's table generic is opaque at this boundary.
+        .insert(drizzleTable as any)
+        .values(data as never)
+        .returning();
+      const rows = (await maybeAbort(builder, signal)) as Row[];
+      const row = rows[0];
+      if (!row) {
+        throw new Error(`insert into ${table.name} did not return a row`);
+      }
+      return row;
+    },
+
+    async update(table, pkColumn, id, patch, signal) {
+      const drizzleTable = table.$drizzle as DrizzleTable;
+      const pk = getColumn(table, pkColumn);
+      const builder = db
+        // biome-ignore lint/suspicious/noExplicitAny: Drizzle's table generic is opaque at this boundary.
+        .update(drizzleTable as any)
+        .set(patch as never)
+        .where(eq(pk as never, id))
+        .returning();
+      const rows = (await maybeAbort(builder, signal)) as Row[];
+      return rows[0] ?? null;
+    },
+
+    async upsert(table, data, options, signal) {
+      const drizzleTable = table.$drizzle as DrizzleTable;
+      const conflictCol = getColumn(table, options.onConflict);
+      const builder = db
+        // biome-ignore lint/suspicious/noExplicitAny: Drizzle's table generic is opaque at this boundary.
+        .insert(drizzleTable as any)
+        .values(data as never)
+        .onConflictDoUpdate({
+          target: conflictCol as never,
+          set: data as never,
+        })
+        .returning();
+      const rows = (await maybeAbort(builder, signal)) as Row[];
+      const row = rows[0];
+      if (!row) {
+        throw new Error(`upsert on ${table.name} did not return a row`);
+      }
+      return row;
+    },
+
+    async delete(table, pkColumn, id, signal) {
+      const drizzleTable = table.$drizzle as DrizzleTable;
+      const pk = getColumn(table, pkColumn);
+      const builder = db
+        // biome-ignore lint/suspicious/noExplicitAny: Drizzle's table generic is opaque at this boundary.
+        .delete(drizzleTable as any)
+        .where(eq(pk as never, id));
+      await maybeAbort(builder, signal);
+    },
+
+    async transaction(fn) {
+      // biome-ignore lint/suspicious/noExplicitAny: tx shares the NodePgDatabase shape.
+      return await (db as any).transaction(async (tx: NodePgDatabase) => {
+        return await fn(makeDataPath(tx, schema));
+      });
+    },
+
+    async raw(strings, ...values) {
+      // Drizzle's `sql` tag accepts the same shape as a TaggedTemplateLiteral.
+      // We pass the strings array straight through and let Drizzle bind values
+      // as parameters, avoiding any string concatenation here.
+      const query = sql(
+        Object.assign([...strings], {
+          raw: [...strings],
+        }) as TemplateStringsArray,
+        ...values,
+      );
+      // biome-ignore lint/suspicious/noExplicitAny: execute() return shape varies by driver; rows is always present for node-postgres.
+      const result = (await db.execute(query)) as { rows: unknown[] };
+      return result.rows as never[];
+    },
+  };
+  return path;
+}
+
+/* -------------------------------------------------------------------------- *
+ * SELECT                                                                     *
+ * -------------------------------------------------------------------------- */
+
+async function runSelect(
+  db: NodePgDatabase | NodePgDatabase<Record<string, never>>,
+  table: AppKitTable,
+  opts: SelectOptions,
+): Promise<Row[]> {
+  const drizzleTable = table.$drizzle as DrizzleTable;
+  const projection = projectColumns(table, opts.columns);
+
+  let builder = (projection ? db.select(projection as never) : db.select())
+    // biome-ignore lint/suspicious/noExplicitAny: Drizzle's table generic is opaque at this boundary.
+    .from(drizzleTable as any) as any;
+
+  const where = buildWhere(table, opts.where);
+  if (where) builder = builder.where(where);
+
+  const orderClauses = buildOrder(table, opts.order);
+  if (orderClauses.length > 0) builder = builder.orderBy(...orderClauses);
+
+  if (opts.limit !== undefined) builder = builder.limit(opts.limit);
+  if (opts.offset !== undefined) builder = builder.offset(opts.offset);
+
+  const rows = (await maybeAbort(builder, opts.signal)) as Row[];
+  return rows;
+}
+
+/**
+ * Project a subset of columns into a Drizzle `select({ ... })` shape, or
+ * return `undefined` to mean "all columns" (Drizzle's default behavior when
+ * `select()` is called with no arguments returns the full row).
+ */
+function projectColumns(
+  table: AppKitTable,
+  columns: ReadonlyArray<string> | undefined,
+): Record<string, DrizzleColumn> | undefined {
+  if (!columns || columns.length === 0) return undefined;
+  const out: Record<string, DrizzleColumn> = {};
+  for (const name of columns) {
+    out[name] = getColumn(table, name);
+  }
+  return out;
+}
+
+/* -------------------------------------------------------------------------- *
+ * WHERE                                                                      *
+ * -------------------------------------------------------------------------- */
+
+function buildWhere(
+  table: AppKitTable,
+  spec: WhereSpec | undefined,
+): SQL | undefined {
+  if (!spec) return undefined;
+
+  const conditions: SQL[] = [];
+  for (const [columnName, value] of Object.entries(spec)) {
+    const col = getColumn(table, columnName);
+
+    if (Array.isArray(value)) {
+      conditions.push(inArray(col as never, value as never[]));
+      continue;
+    }
+
+    if (value === null || typeof value !== "object") {
+      conditions.push(eq(col as never, value as never));
+      continue;
+    }
+
+    for (const [op, opValue] of Object.entries(value)) {
+      const condition = buildOperator(col, op, opValue);
+      if (condition) conditions.push(condition);
+    }
+  }
+
+  if (conditions.length === 0) return undefined;
+  if (conditions.length === 1) return conditions[0];
+  return and(...conditions);
+}
+
+function buildOperator(
+  col: DrizzleColumn,
+  op: string,
+  value: unknown,
+): SQL | undefined {
+  switch (op) {
+    case "eq":
+      return eq(col as never, value as never);
+    case "neq":
+      return ne(col as never, value as never);
+    case "gt":
+      return gt(col as never, value as never);
+    case "gte":
+      return gte(col as never, value as never);
+    case "lt":
+      return lt(col as never, value as never);
+    case "lte":
+      return lte(col as never, value as never);
+    case "like":
+      return like(col as never, String(value));
+    case "ilike":
+      return ilike(col as never, String(value));
+    case "in":
+      return inArray(col as never, value as never[]);
+    case "is":
+      return value === null
+        ? isNull(col as never)
+        : eq(col as never, value as never);
+    default:
+      throw new Error(`Unsupported where operator: ${op}`);
+  }
+}
+
+/* -------------------------------------------------------------------------- *
+ * ORDER                                                                      *
+ * -------------------------------------------------------------------------- */
+
+function buildOrder(table: AppKitTable, spec: OrderSpec | undefined): SQL[] {
+  if (!spec) return [];
+  const out: SQL[] = [];
+  for (const [columnName, direction] of Object.entries(spec)) {
+    const col = getColumn(table, columnName);
+    out.push(direction === "desc" ? desc(col as never) : asc(col as never));
+  }
+  return out;
+}
+
+/* -------------------------------------------------------------------------- *
+ * INCLUDE (joins via two-query pattern)                                      *
+ * -------------------------------------------------------------------------- */
+
+async function applyIncludes(
+  db: NodePgDatabase | NodePgDatabase<Record<string, never>>,
+  schema: Schema,
+  parentTable: AppKitTable,
+  parentRows: Row[],
+  spec: IncludeSpec,
+): Promise<void> {
+  // Mutate parent rows in place — adding each relation as either an array
+  // (one-to-many) or a single value/null (many-to-one). Two queries per
+  // relation: one to fetch the parent, one to fetch the related rows with
+  // `IN (parent_ids)`. This avoids N+1 without needing Drizzle's relations API.
+  for (const [relationName, options] of Object.entries(spec)) {
+    if (options === undefined) continue;
+    const opts: IncludeOptions = options === true ? {} : options;
+    const resolved = resolveRelation(schema, parentTable, relationName);
+
+    if (resolved.kind === "manyToOne") {
+      await applyManyToOne(db, parentRows, relationName, resolved, opts);
+    } else {
+      await applyOneToMany(db, parentRows, relationName, resolved, opts);
+    }
+  }
+}
+
+async function applyManyToOne(
+  db: NodePgDatabase | NodePgDatabase<Record<string, never>>,
+  parentRows: Row[],
+  relationName: string,
+  resolved: Extract<ResolvedRelation, { kind: "manyToOne" }>,
+  opts: IncludeOptions,
+): Promise<void> {
+  const parentFkValues = uniqueDefined(
+    parentRows.map((r) => r[resolved.parentFk]),
+  );
+
+  if (parentFkValues.length === 0) {
+    for (const row of parentRows) row[relationName] = null;
+    return;
+  }
+
+  const relatedTable = resolved.relatedTable;
+  const relatedDrizzle = relatedTable.$drizzle as DrizzleTable;
+  const relatedKey = getColumn(relatedTable, resolved.relatedKey);
+  const projection = projectColumns(relatedTable, opts.select);
+
+  let builder = (projection ? db.select(projection as never) : db.select())
+    // biome-ignore lint/suspicious/noExplicitAny: Drizzle's table generic is opaque.
+    .from(relatedDrizzle as any)
+    .where(inArray(relatedKey as never, parentFkValues as never[])) as any;
+
+  const where = buildWhere(relatedTable, opts.where);
+  if (where) builder = builder.where(and(where) as never);
+
+  const order = buildOrder(relatedTable, opts.order);
+  if (order.length > 0) builder = builder.orderBy(...order);
+
+  const relatedRows = (await builder) as Row[];
+
+  // Index related by their PK for O(1) lookup when assigning to parents.
+  const byKey = new Map<unknown, Row>();
+  for (const row of relatedRows) {
+    byKey.set(row[resolved.relatedKey], row);
+  }
+
+  for (const row of parentRows) {
+    const fk = row[resolved.parentFk];
+    row[relationName] = fk == null ? null : (byKey.get(fk) ?? null);
+  }
+}
+
+async function applyOneToMany(
+  db: NodePgDatabase | NodePgDatabase<Record<string, never>>,
+  parentRows: Row[],
+  relationName: string,
+  resolved: Extract<ResolvedRelation, { kind: "oneToMany" }>,
+  opts: IncludeOptions,
+): Promise<void> {
+  const parentKeyValues = uniqueDefined(
+    parentRows.map((r) => r[resolved.parentKey]),
+  );
+
+  if (parentKeyValues.length === 0) {
+    for (const row of parentRows) row[relationName] = [];
+    return;
+  }
+
+  const relatedTable = resolved.relatedTable;
+  const relatedDrizzle = relatedTable.$drizzle as DrizzleTable;
+  const relatedFk = getColumn(relatedTable, resolved.relatedFk);
+  const projection = projectColumns(relatedTable, opts.select);
+
+  let builder = (projection ? db.select(projection as never) : db.select())
+    // biome-ignore lint/suspicious/noExplicitAny: Drizzle's table generic is opaque.
+    .from(relatedDrizzle as any)
+    .where(inArray(relatedFk as never, parentKeyValues as never[])) as any;
+
+  const where = buildWhere(relatedTable, opts.where);
+  if (where) builder = builder.where(and(where) as never);
+
+  const order = buildOrder(relatedTable, opts.order);
+  if (order.length > 0) builder = builder.orderBy(...order);
+
+  // We deliberately apply `limit` AFTER fetching, per parent — Drizzle's
+  // `.limit(n)` would cap the *whole* query, not per-parent. For small N
+  // this is acceptable; for large fan-out, consumers should paginate the
+  // parent query and call again.
+  const relatedRows = (await builder) as Row[];
+
+  const grouped = new Map<unknown, Row[]>();
+  for (const row of relatedRows) {
+    const key = row[resolved.relatedFk];
+    const list = grouped.get(key);
+    if (list) {
+      list.push(row);
+    } else {
+      grouped.set(key, [row]);
+    }
+  }
+
+  for (const row of parentRows) {
+    const key = row[resolved.parentKey];
+    const list = grouped.get(key) ?? [];
+    row[relationName] = opts.limit ? list.slice(0, opts.limit) : list;
+  }
+}
+
+/**
+ * Resolve a relation by name on `parentTable`. The lookup is intentionally
+ * lenient about naming: a relation can be referenced by the related table
+ * name (`{ posts: true }` on a `user` row), by the FK column name
+ * (`{ author_id: true }`), or by the entity key (the schema's exported name
+ * for the related table).
+ */
+function resolveRelation(
+  schema: Schema,
+  parentTable: AppKitTable,
+  relationName: string,
+): ResolvedRelation {
+  // Many-to-one: this table has a FK that matches the relation name.
+  for (const rel of parentTable.$relations) {
+    if (
+      rel.fromColumn === relationName ||
+      rel.toTable === relationName ||
+      relationName === entityKeyOf(schema, rel.toTable)
+    ) {
+      const relatedTable = findTableByName(schema, rel.toTable);
+      if (!relatedTable) {
+        throw new Error(
+          `Relation "${relationName}" on "${parentTable.name}" references unknown table "${rel.toTable}"`,
+        );
+      }
+      return {
+        kind: "manyToOne",
+        relatedTable,
+        parentFk: rel.fromColumn,
+        relatedKey: rel.toColumn,
+      };
+    }
+  }
+
+  // One-to-many: another table has a FK back to this table.
+  for (const [otherKey, otherTable] of Object.entries(schema.$tables)) {
+    if (otherTable.name === parentTable.name) continue;
+    for (const rel of otherTable.$relations) {
+      if (rel.toTable !== parentTable.name) continue;
+      if (relationName === otherKey || relationName === otherTable.name) {
+        return {
+          kind: "oneToMany",
+          relatedTable: otherTable,
+          relatedFk: rel.fromColumn,
+          parentKey: rel.toColumn,
+        };
+      }
+    }
+  }
+
+  throw new Error(
+    `Unknown relation "${relationName}" on table "${parentTable.name}". ` +
+      `Expected a foreign-key column on this table or another table referencing it.`,
+  );
+}
+
+function findTableByName(
+  schema: Schema,
+  tableName: string,
+): AppKitTable | undefined {
+  for (const t of Object.values(schema.$tables)) {
+    if (t.name === tableName) return t;
+  }
+  return undefined;
+}
+
+function entityKeyOf(schema: Schema, tableName: string): string | undefined {
+  for (const [key, t] of Object.entries(schema.$tables)) {
+    if (t.name === tableName) return key;
+  }
+  return undefined;
+}
+
+/* -------------------------------------------------------------------------- *
+ * Helpers                                                                    *
+ * -------------------------------------------------------------------------- */
+
+/** Pull a Drizzle column reference off the table by name. */
+function getColumn(table: AppKitTable, columnName: string): DrizzleColumn {
+  const drizzleTable = table.$drizzle as DrizzleTable;
+  const col = drizzleTable[columnName];
+  if (!col) {
+    throw new Error(
+      `Column "${columnName}" not found on table "${table.name}". ` +
+        `Available columns: ${Object.keys(drizzleTable)
+          .filter(
+            (k) => !k.startsWith("_") && typeof drizzleTable[k] === "object",
+          )
+          .join(", ")}`,
+    );
+  }
+  return col;
+}
+
+/**
+ * Hook the optional `AbortSignal` into the Drizzle builder if the underlying
+ * driver supports cancellation. `node-postgres` does not honor AbortSignal at
+ * the query level today; this is a placeholder for future driver support.
+ *
+ * Returns the awaited result of the builder either way.
+ */
+async function maybeAbort<T>(
+  builder: Promise<T> | { then: PromiseLike<T>["then"] },
+  _signal?: AbortSignal,
+): Promise<T> {
+  return await (builder as Promise<T>);
+}
+
+function uniqueDefined<T>(values: ReadonlyArray<T>): T[] {
+  const seen = new Set<unknown>();
+  const out: T[] = [];
+  for (const v of values) {
+    if (v == null) continue;
+    if (seen.has(v)) continue;
+    seen.add(v);
+    out.push(v);
+  }
+  return out;
+}

--- a/packages/appkit/src/database/runtime/drizzle-runtime.ts
+++ b/packages/appkit/src/database/runtime/drizzle-runtime.ts
@@ -347,7 +347,11 @@ function projectColumns(
  * WHERE                                                                      *
  * -------------------------------------------------------------------------- */
 
-function buildWhere(
+/**
+ * @internal Exported for snapshot tests that lock in operator → SQL fragment
+ * mapping. Not part of the public surface — go through `DataPath` instead.
+ */
+export function buildWhere(
   table: AppKitTable,
   spec: WhereSpec | undefined,
 ): SQL | undefined {
@@ -415,7 +419,11 @@ function buildOperator(
  * ORDER                                                                      *
  * -------------------------------------------------------------------------- */
 
-function buildOrder(table: AppKitTable, spec: OrderSpec | undefined): SQL[] {
+/** @internal Exported for snapshot tests; same caveat as `buildWhere`. */
+export function buildOrder(
+  table: AppKitTable,
+  spec: OrderSpec | undefined,
+): SQL[] {
   if (!spec) return [];
   const out: SQL[] = [];
   for (const [columnName, direction] of Object.entries(spec)) {
@@ -660,6 +668,10 @@ async function maybeAbort<T>(
   builder: Promise<T> | { then: PromiseLike<T>["then"] },
   _signal?: AbortSignal,
 ): Promise<T> {
+  // Intentional no-op for the signal: node-postgres does not cancel in-flight
+  // queries. Server-side `statement_timeout` (set on every pool connection by
+  // the plugin) is what actually bounds runaway reads. The AppKit timeout
+  // interceptor still rejects the awaited promise when fired.
   return await (builder as Promise<T>);
 }
 

--- a/packages/appkit/src/database/runtime/index.ts
+++ b/packages/appkit/src/database/runtime/index.ts
@@ -1,0 +1,12 @@
+export type {
+  CountOptions,
+  DataPath,
+  IncludeSpec,
+  OrderSpec,
+  SelectOptions,
+  WhereSpec,
+} from "./data-path";
+export {
+  createDrizzleDataPath,
+  createUserScopedDataPath,
+} from "./drizzle-runtime";

--- a/packages/appkit/src/database/runtime/tests/drizzle-runtime.test.ts
+++ b/packages/appkit/src/database/runtime/tests/drizzle-runtime.test.ts
@@ -1,0 +1,86 @@
+import { PgDialect } from "drizzle-orm/pg-core";
+import { describe, expect, test } from "vitest";
+import {
+  defineSchema,
+  id,
+  integer,
+  text,
+  timestamp,
+} from "../../schema-builder";
+import { buildOrder, buildWhere } from "../drizzle-runtime";
+
+const schema = defineSchema(({ table }) => ({
+  user: table("user", {
+    id: id(),
+    email: text().notNull(),
+    role: text(),
+    age: integer(),
+    createdAt: timestamp(),
+  }),
+}));
+
+const dialect = new PgDialect();
+
+describe("drizzle-runtime buildWhere → SQL", () => {
+  test("scalar shorthand becomes col = $1", () => {
+    const sql = buildWhere(schema.user, { email: "alice@x" });
+    expect(sql).toBeDefined();
+    if (sql) {
+      const out = dialect.sqlToQuery(sql);
+      expect(out.sql).toMatch(/"email" = \$1/);
+      expect(out.params).toEqual(["alice@x"]);
+    }
+  });
+
+  test("array value becomes col IN ($1, $2)", () => {
+    const sql = buildWhere(schema.user, { role: ["admin", "owner"] });
+    if (sql) {
+      const out = dialect.sqlToQuery(sql);
+      expect(out.sql).toMatch(/"role" in \(\$1, \$2\)/);
+      expect(out.params).toEqual(["admin", "owner"]);
+    }
+  });
+
+  test("operator object renders gte / lte / ilike / is null", () => {
+    const sql = buildWhere(schema.user, {
+      age: { gte: 18, lte: 65 },
+      email: { ilike: "%@example.com" },
+      role: { is: null },
+    });
+    expect(sql).toBeDefined();
+    if (sql) {
+      const out = dialect.sqlToQuery(sql);
+      expect(out.sql).toContain('"age" >= ');
+      expect(out.sql).toContain('"age" <= ');
+      expect(out.sql).toContain('"email" ilike ');
+      expect(out.sql).toContain('"role" is null');
+      expect(out.params).toEqual([18, 65, "%@example.com"]);
+    }
+  });
+
+  test("undefined spec returns undefined (no WHERE clause)", () => {
+    expect(buildWhere(schema.user, undefined)).toBeUndefined();
+  });
+
+  test("empty spec returns undefined (no WHERE clause)", () => {
+    expect(buildWhere(schema.user, {})).toBeUndefined();
+  });
+});
+
+describe("drizzle-runtime buildOrder → SQL", () => {
+  test("returns empty list for missing or empty spec", () => {
+    expect(buildOrder(schema.user, undefined)).toEqual([]);
+    expect(buildOrder(schema.user, {})).toEqual([]);
+  });
+
+  test("preserves the declared order of clauses", () => {
+    const out = buildOrder(schema.user, { email: "asc", createdAt: "desc" });
+    expect(out).toHaveLength(2);
+    const first = dialect.sqlToQuery(out[0]);
+    expect(first.sql).toContain('"email"');
+    expect(first.sql.toLowerCase()).toContain("asc");
+    const second = dialect.sqlToQuery(out[1]);
+    expect(second.sql).toContain('"createdAt"');
+    expect(second.sql.toLowerCase()).toContain("desc");
+  });
+});

--- a/packages/appkit/src/plugins/database/database.ts
+++ b/packages/appkit/src/plugins/database/database.ts
@@ -3,7 +3,7 @@ import type { IAppRouter } from "shared";
 import { Plugin, toPlugin } from "@/plugin";
 import { createLakebasePool } from "../../connectors/lakebase";
 import type { DataPath, Schema } from "../../database";
-import { ConfigurationError } from "../../errors";
+import { AuthenticationError, ConfigurationError } from "../../errors";
 import { createLogger } from "../../logging/logger";
 import type { PluginManifest } from "../../registry";
 import { loadSchemaByConvention } from "./convention";
@@ -140,7 +140,15 @@ class DatabasePlugin extends Plugin<IDatabaseConfig> {
     // client's own asUser fallback.
     const email = req.header("x-forwarded-email");
     if (!email && process.env.NODE_ENV === "development") {
+      logger.warn(
+        "Database asUser() called without x-forwarded-email in development mode. Falling back to service pool.",
+      );
       return baseProxy;
+    }
+    if (!email) {
+      throw new AuthenticationError(
+        "Missing x-forwarded-email header. Cannot create user-scoped database exports.",
+      );
     }
 
     const userEntities: Record<string, EntityClient> = {};

--- a/packages/appkit/src/plugins/database/database.ts
+++ b/packages/appkit/src/plugins/database/database.ts
@@ -1,4 +1,5 @@
 import type { Pool } from "pg";
+import type { IAppRouter } from "shared";
 import { Plugin, toPlugin } from "@/plugin";
 import { createLakebasePool } from "../../connectors/lakebase";
 import type { Schema } from "../../database";
@@ -11,10 +12,18 @@ import {
   POOL_DEFAULTS,
   STATEMENT_TIMEOUT_DEFAULT_MS,
 } from "./defaults";
+import type { EntityClient, ExecutorFn } from "./entity-proxy";
+import { wireEntities } from "./entity-wiring";
 import manifest from "./manifest.json";
-import type { IDatabaseConfig } from "./types";
+import { RouteGenerator } from "./route-generator";
+import type { HttpAccess, IDatabaseConfig } from "./types";
 
 const logger = createLogger("database");
+
+type DatabaseExports = {
+  [entity: string]: EntityClient | (() => Pool);
+  getPool: () => Pool;
+};
 
 class DatabasePlugin extends Plugin<IDatabaseConfig> {
   static manifest = manifest as PluginManifest<"database">;
@@ -23,6 +32,7 @@ class DatabasePlugin extends Plugin<IDatabaseConfig> {
   protected pool: Pool | null = null;
   protected schema: Schema | null = null;
   protected schemaPath: string | null = null;
+  protected entities: Record<string, EntityClient> = {};
 
   constructor(config: IDatabaseConfig = {}) {
     super(config);
@@ -30,6 +40,9 @@ class DatabasePlugin extends Plugin<IDatabaseConfig> {
   }
 
   async setup() {
+    // Service-principal pool. Same factory the standalone `lakebase` plugin
+    // uses — Lakebase OAuth refresh is built in. Dev = current user OAuth,
+    // prod = SP OAuth, both transparent.
     this.pool = createLakebasePool({
       ...POOL_DEFAULTS,
       ...this.config.connection,
@@ -44,7 +57,7 @@ class DatabasePlugin extends Plugin<IDatabaseConfig> {
       const loaded = await loadSchemaByConvention();
       if (!loaded) {
         logger.warn(
-          "Database plugin did not find config/database/schema.ts, using empty schema",
+          "Database plugin did not find config/database/schema.ts; running with no entities",
         );
         return;
       }
@@ -55,6 +68,27 @@ class DatabasePlugin extends Plugin<IDatabaseConfig> {
         "Database schema loaded from %s with %d entries",
         loaded.schemaPath,
         Object.keys(loaded.schema.$tables).length,
+      );
+
+      // Wiring builds an EntityClient per table on top of the SP pool, plus a
+      // per-user pool registry used by `EntityClient.asUser(req)` for OBO.
+      const executor: ExecutorFn = async (fn, options) => {
+        const result = await this.execute(fn, options);
+        if (!result.ok) throw new Error(result.message);
+        return result.data;
+      };
+
+      const wired = wireEntities({
+        schema: this.schema,
+        config: this.config,
+        servicePool: this.pool,
+        executor,
+      });
+
+      this.entities = wired.entities;
+      logger.info(
+        "Database entity API wired for: %s",
+        Object.keys(this.entities).join(", "),
       );
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -78,22 +112,69 @@ class DatabasePlugin extends Plugin<IDatabaseConfig> {
     }
   }
 
-  async abortActiveOperations(): Promise<void> {
-    super.abortActiveOperations();
-    if (!this.pool) return;
+  injectRoutes(router: IAppRouter): void {
+    if (!this.schema) return;
 
-    logger.info("Closing database pool");
-    const draining = this.pool.end();
-    this.pool = null;
-    try {
-      await draining;
-    } catch (err) {
-      logger.error("Error closing database pool: %O", err);
-    }
+    new RouteGenerator({
+      schema: this.schema,
+      config: this.config,
+      getSurface: (req, access) => this.getSurface(req, access),
+      route: (target, config) => this.route(target, config),
+    }).injectAll(router);
   }
 
-  exports() {
+  asUser(req: import("express").Request): this {
+    const baseProxy = super.asUser(req);
+
+    // Dev fallback: when no OBO header is present and we're in dev, return
+    // the SP-backed proxy so the dev loop stays unbroken. Mirrors the entity
+    // client's own asUser fallback.
+    const email = req.header("x-forwarded-email");
+    if (!email && process.env.NODE_ENV === "development") {
+      return baseProxy;
+    }
+
+    const userEntities: Record<string, EntityClient> = {};
+    for (const [name, client] of Object.entries(this.entities)) {
+      userEntities[name] = client.asUser(req);
+    }
+
+    const userExports = (): DatabaseExports => ({
+      ...userEntities,
+      getPool: () => this.requirePool(),
+    });
+
+    return new Proxy(baseProxy, {
+      get: (target, prop, receiver) => {
+        if (prop === "exports") return userExports;
+        if (typeof prop === "string" && prop in userEntities) {
+          return userEntities[prop];
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    }) as this;
+  }
+
+  async abortActiveOperations(): Promise<void> {
+    super.abortActiveOperations();
+
+    // Drain the SP pool first, then any per-user pools built by asUser().
+    const drains: Array<Promise<void>> = [];
+    if (this.pool) {
+      logger.info("Closing database pool");
+      const draining = this.pool.end().catch((err) => {
+        logger.error("Error closing database pool: %O", err);
+      });
+      this.pool = null;
+      drains.push(draining);
+    }
+
+    await Promise.all(drains);
+  }
+
+  exports(): DatabaseExports {
     return {
+      ...this.entities,
       getPool: () => this.requirePool(),
     };
   }
@@ -106,6 +187,16 @@ class DatabasePlugin extends Plugin<IDatabaseConfig> {
       );
     }
     return this.pool;
+  }
+
+  private getSurface(
+    req: import("express").Request,
+    access: HttpAccess,
+  ): Record<string, EntityClient> {
+    if (access === "obo") {
+      return this.asUser(req).exports() as Record<string, EntityClient>;
+    }
+    return this.exports() as Record<string, EntityClient>;
   }
 }
 

--- a/packages/appkit/src/plugins/database/database.ts
+++ b/packages/appkit/src/plugins/database/database.ts
@@ -89,7 +89,11 @@ class DatabasePlugin extends Plugin<IDatabaseConfig> {
       // per-user pool registry used by `EntityClient.asUser(req)` for OBO.
       const executor: ExecutorFn = async (fn, options) => {
         const result = await this.execute(fn, options);
-        if (!result.ok) throw new Error(result.message);
+        if (!result.ok) {
+          // Preserve the interceptor's status (already scrubbed for prod by
+          // Plugin#execute) so the route can echo the right HTTP code.
+          throw new DatabaseRouteError(result.status, result.message);
+        }
         return result.data;
       };
 
@@ -176,11 +180,9 @@ class DatabasePlugin extends Plugin<IDatabaseConfig> {
     const drains: Array<Promise<void>> = [];
     if (this.pool) {
       logger.info("Closing database pool");
-      const draining = this.pool
-        .end()
-        .catch((err) => {
-          logger.error("Error closing database pool: %O", err);
-        });
+      const draining = this.pool.end().catch((err) => {
+        logger.error("Error closing database pool: %O", err);
+      });
       this.pool = null;
       drains.push(draining);
     }
@@ -241,6 +243,21 @@ class DatabasePlugin extends Plugin<IDatabaseConfig> {
 }
 
 export const database = toPlugin(DatabasePlugin);
+
+/**
+ * Carries the interceptor-derived HTTP status from the executor up to the
+ * route handler so 4xx classifications survive the throw. The route layer
+ * checks `instanceof DatabaseRouteError` to echo `statusCode`; everything
+ * else falls back to 500 with a scrubbed message in production.
+ */
+export class DatabaseRouteError extends Error {
+  readonly statusCode: number;
+  constructor(statusCode: number, message: string) {
+    super(message);
+    this.name = "DatabaseRouteError";
+    this.statusCode = statusCode;
+  }
+}
 
 /**
  * Attach a `connect` listener that sets per-session defaults on every new

--- a/packages/appkit/src/plugins/database/database.ts
+++ b/packages/appkit/src/plugins/database/database.ts
@@ -2,7 +2,7 @@ import type { Pool } from "pg";
 import type { IAppRouter } from "shared";
 import { Plugin, toPlugin } from "@/plugin";
 import { createLakebasePool } from "../../connectors/lakebase";
-import type { Schema } from "../../database";
+import type { DataPath, Schema } from "../../database";
 import { ConfigurationError } from "../../errors";
 import { createLogger } from "../../logging/logger";
 import type { PluginManifest } from "../../registry";
@@ -13,16 +13,30 @@ import {
   STATEMENT_TIMEOUT_DEFAULT_MS,
 } from "./defaults";
 import type { EntityClient, ExecutorFn } from "./entity-proxy";
-import { wireEntities } from "./entity-wiring";
+import { type UserPoolRegistry, wireEntities } from "./entity-wiring";
 import manifest from "./manifest.json";
 import { RouteGenerator } from "./route-generator";
 import type { HttpAccess, IDatabaseConfig } from "./types";
 
 const logger = createLogger("database");
 
+type TransactionFn<T> = (tx: DataPath) => Promise<T>;
+
 type DatabaseExports = {
-  [entity: string]: EntityClient | (() => Pool);
+  [entity: string]:
+    | EntityClient
+    | (() => Pool)
+    | (<T>(fn: TransactionFn<T>) => Promise<T>)
+    | ((
+        strings: TemplateStringsArray,
+        ...values: unknown[]
+      ) => Promise<unknown[]>);
   getPool: () => Pool;
+  transaction: <T>(fn: TransactionFn<T>) => Promise<T>;
+  sql: (
+    strings: TemplateStringsArray,
+    ...values: unknown[]
+  ) => Promise<unknown[]>;
 };
 
 class DatabasePlugin extends Plugin<IDatabaseConfig> {
@@ -33,6 +47,8 @@ class DatabasePlugin extends Plugin<IDatabaseConfig> {
   protected schema: Schema | null = null;
   protected schemaPath: string | null = null;
   protected entities: Record<string, EntityClient> = {};
+  protected dataPath: DataPath | null = null;
+  protected userPools: UserPoolRegistry | null = null;
 
   constructor(config: IDatabaseConfig = {}) {
     super(config);
@@ -48,9 +64,8 @@ class DatabasePlugin extends Plugin<IDatabaseConfig> {
       ...this.config.connection,
     });
     attachSessionDefaults(this.pool, this.config.statementTimeoutMs);
-    if (process.env.APPKIT_DEBUG_POOL || process.env.DEBUG_POOL) {
+    if (process.env.DEBUG_POOL)
       startPoolStatsLog(this.pool, "service-principal");
-    }
     logger.info("Database plugin pool initialized");
 
     try {
@@ -86,29 +101,23 @@ class DatabasePlugin extends Plugin<IDatabaseConfig> {
       });
 
       this.entities = wired.entities;
+      this.dataPath = wired.dataPath;
+      this.userPools = wired.userPools;
       logger.info(
         "Database entity API wired for: %s",
         Object.keys(this.entities).join(", "),
       );
     } catch (err) {
+      // A throwing schema-load otherwise cascades through Promise.all in core
+      // and crashes every plugin's boot. Decorate the error with the
+      // convention path so the operator can find it, then re-raise unless the
+      // caller opted into tolerant boot.
       const message = err instanceof Error ? err.message : String(err);
       logger.error(
         "Database schema load failed (config/database/schema.ts): %s",
         message,
       );
-      if (!this.config.tolerateSetupFailure) {
-        const stalePool = this.pool;
-        this.pool = null;
-        if (stalePool) {
-          await stalePool.end().catch((endErr) => {
-            logger.error(
-              "Error draining stale pool after schema-load failure: %O",
-              endErr,
-            );
-          });
-        }
-        throw err;
-      }
+      if (!this.config.tolerateSetupFailure) throw err;
     }
   }
 
@@ -142,6 +151,10 @@ class DatabasePlugin extends Plugin<IDatabaseConfig> {
     const userExports = (): DatabaseExports => ({
       ...userEntities,
       getPool: () => this.requirePool(),
+      transaction: <T>(fn: TransactionFn<T>) =>
+        this.requireDataPath().transaction(fn),
+      sql: (strings, ...values) =>
+        this.requireDataPath().raw(strings, ...values),
     });
 
     return new Proxy(baseProxy, {
@@ -162,11 +175,23 @@ class DatabasePlugin extends Plugin<IDatabaseConfig> {
     const drains: Array<Promise<void>> = [];
     if (this.pool) {
       logger.info("Closing database pool");
-      const draining = this.pool.end().catch((err) => {
-        logger.error("Error closing database pool: %O", err);
-      });
+      const draining = this.pool
+        .end()
+        .catch((err) => {
+          logger.error("Error closing database pool: %O", err);
+        });
       this.pool = null;
       drains.push(draining);
+    }
+
+    if (this.userPools) {
+      const pools = this.userPools;
+      this.userPools = null;
+      drains.push(
+        pools.closeAll().catch((err) => {
+          logger.error("Error closing per-user database pools: %O", err);
+        }),
+      );
     }
 
     await Promise.all(drains);
@@ -176,7 +201,21 @@ class DatabasePlugin extends Plugin<IDatabaseConfig> {
     return {
       ...this.entities,
       getPool: () => this.requirePool(),
+      transaction: <T>(fn: TransactionFn<T>) =>
+        this.requireDataPath().transaction(fn),
+      sql: (strings, ...values) =>
+        this.requireDataPath().raw(strings, ...values),
     };
+  }
+
+  protected requireDataPath(): DataPath {
+    if (!this.dataPath) {
+      throw ConfigurationError.resourceNotFound(
+        "Database",
+        "Database runtime not initialized — declare config/database/schema.ts before calling transaction() or sql``.",
+      );
+    }
+    return this.dataPath;
   }
 
   protected requirePool(): Pool {
@@ -203,59 +242,38 @@ class DatabasePlugin extends Plugin<IDatabaseConfig> {
 export const database = toPlugin(DatabasePlugin);
 
 /**
- * Attach a `connect` listener that sets per-session defaults on
- * every new Postgres session checked out of the pool
- * @param pool
- * @param override
+ * Attach a `connect` listener that sets per-session defaults on every new
+ * Postgres session checked out of the pool: `statement_timeout` (caps runaway
+ * queries even when the client signal is dropped) and `application_name` (so
+ * the connection is attributable in `pg_stat_activity`).
  */
 function attachSessionDefaults(pool: Pool, override?: number): void {
   const ms = override ?? STATEMENT_TIMEOUT_DEFAULT_MS;
-  const applicationName = applicationNameForSession();
   pool.on("connect", (client) => {
-    let destroyed = false;
-    const destroy = (label: string, err: unknown) => {
-      if (destroyed) return;
-      destroyed = true;
-      logger.error(
-        "Failed to set %s on pool connection; destroying client to prevent unguarded use: %O",
-        label,
-        err,
-      );
-      // `release(true)` removes the client from the pool entirely. pg will
-      // build a fresh connection on next acquire and re-fire `connect`.
-      const maybeRelease = (
-        client as unknown as { release?: (destroy?: boolean) => void }
-      ).release;
-      try {
-        maybeRelease?.call(client, true);
-      } catch (releaseErr) {
-        logger.error("Failed to destroy pool client: %O", releaseErr);
-      }
-    };
     client
-      .query(`SET application_name = '${applicationName}'`)
-      .catch((err) => destroy("application_name", err));
+      .query(`SET application_name = '${APPLICATION_NAME}'`)
+      .catch((err) => {
+        logger.error(
+          "Failed to set application_name on pool connection: %O",
+          err,
+        );
+      });
     if (Number.isFinite(ms) && ms > 0) {
-      client
-        .query(`SET statement_timeout = ${Math.floor(ms)}`)
-        .catch((err) => destroy("statement_timeout", err));
+      client.query(`SET statement_timeout = ${Math.floor(ms)}`).catch((err) => {
+        logger.error(
+          "Failed to set statement_timeout on pool connection: %O",
+          err,
+        );
+      });
     }
   });
 }
 
 /**
- * Build a per-session `application_name` string.
+ * When `DEBUG_POOL=1` is set, periodically log the pool's
+ * total/idle/waiting connection counts so operators can observe saturation.
+ * The interval is unrefed so it never blocks shutdown.
  */
-function applicationNameForSession(): string {
-  const appName = process.env.DATABRICKS_APP_NAME;
-  // Sanitize: only allow common identifier characters in the discriminator.
-  const safeAppName = appName?.replace(/[^A-Za-z0-9._-]/g, "_") ?? "";
-  const composed = safeAppName
-    ? `${APPLICATION_NAME}:${safeAppName}`
-    : APPLICATION_NAME;
-  return composed.slice(0, 60);
-}
-
 function startPoolStatsLog(pool: Pool, label: string): void {
   const intervalMs = 30_000;
   const handle = setInterval(() => {

--- a/packages/appkit/src/plugins/database/database.ts
+++ b/packages/appkit/src/plugins/database/database.ts
@@ -132,6 +132,7 @@ class DatabasePlugin extends Plugin<IDatabaseConfig> {
       schema: this.schema,
       config: this.config,
       getSurface: (req, access) => this.getSurface(req, access),
+      getServicePool: () => this.requirePool(),
       route: (target, config) => this.route(target, config),
     }).injectAll(router);
   }

--- a/packages/appkit/src/plugins/database/database.ts
+++ b/packages/appkit/src/plugins/database/database.ts
@@ -3,7 +3,7 @@ import type { IAppRouter } from "shared";
 import { Plugin, toPlugin } from "@/plugin";
 import { createLakebasePool } from "../../connectors/lakebase";
 import type { DataPath, Schema } from "../../database";
-import { AuthenticationError, ConfigurationError } from "../../errors";
+import { ConfigurationError } from "../../errors";
 import { createLogger } from "../../logging/logger";
 import type { PluginManifest } from "../../registry";
 import { loadSchemaByConvention } from "./convention";
@@ -135,21 +135,16 @@ class DatabasePlugin extends Plugin<IDatabaseConfig> {
   asUser(req: import("express").Request): this {
     const baseProxy = super.asUser(req);
 
-    // Dev fallback: when no OBO header is present and we're in dev, return
-    // the SP-backed proxy so the dev loop stays unbroken. Mirrors the entity
-    // client's own asUser fallback.
-    const email = req.header("x-forwarded-email");
-    if (!email && process.env.NODE_ENV === "development") {
-      logger.warn(
-        "Database asUser() called without x-forwarded-email in development mode. Falling back to service pool.",
-      );
-      return baseProxy;
-    }
-    if (!email) {
-      throw new AuthenticationError(
-        "Missing x-forwarded-email header. Cannot create user-scoped database exports.",
-      );
-    }
+    // No registry means setup() ran without a schema. Nothing to scope.
+    if (!this.userPools) return baseProxy;
+
+    const identity = this.userPools.resolveIdentity(req);
+    // Dev fallback: identity is null when OBO headers are absent in dev.
+    // resolveIdentity already logged the warning; throws in prod.
+    if (!identity) return baseProxy;
+
+    const userPool = this.userPools.getOrCreate(identity);
+    const userDataPath = this.userPools.getOrCreateDataPath(identity);
 
     const userEntities: Record<string, EntityClient> = {};
     for (const [name, client] of Object.entries(this.entities)) {
@@ -158,11 +153,9 @@ class DatabasePlugin extends Plugin<IDatabaseConfig> {
 
     const userExports = (): DatabaseExports => ({
       ...userEntities,
-      getPool: () => this.requirePool(),
-      transaction: <T>(fn: TransactionFn<T>) =>
-        this.requireDataPath().transaction(fn),
-      sql: (strings, ...values) =>
-        this.requireDataPath().raw(strings, ...values),
+      getPool: () => userPool,
+      transaction: <T>(fn: TransactionFn<T>) => userDataPath.transaction(fn),
+      sql: (strings, ...values) => userDataPath.raw(strings, ...values),
     });
 
     return new Proxy(baseProxy, {

--- a/packages/appkit/src/plugins/database/defaults.ts
+++ b/packages/appkit/src/plugins/database/defaults.ts
@@ -1,3 +1,5 @@
+import type { PluginExecuteConfig } from "shared";
+
 /**
  * Connection pool defaults for the service-principal pool.
  * 10 connections in the pool at maximum
@@ -33,4 +35,18 @@ export const APPLICATION_NAME = "appkit:database";
 export const OBO_POOL_DEFAULTS = {
   ...POOL_DEFAULTS,
   max: 4,
+};
+
+export const readDefaults: PluginExecuteConfig = {
+  timeout: 30_000,
+  retry: { enabled: false },
+  cache: { enabled: false },
+  telemetryInterceptor: { spanName: "database.read" },
+};
+
+export const writeDefaults: PluginExecuteConfig = {
+  timeout: 30_000,
+  retry: { enabled: false },
+  cache: { enabled: false },
+  telemetryInterceptor: { spanName: "database.write" },
 };

--- a/packages/appkit/src/plugins/database/defaults.ts
+++ b/packages/appkit/src/plugins/database/defaults.ts
@@ -24,3 +24,13 @@ export const STATEMENT_TIMEOUT_DEFAULT_MS = 15_000;
  * connections back to AppKit.
  */
 export const APPLICATION_NAME = "appkit:database";
+
+/**
+ * Per-user (OBO) pool defaults. The plugin builds one pool per OBO user, so
+ * each pool stays small. Fan-out is `(1 + oboPoolMax) × max`; with the
+ * defaults that caps at `(1 + 25) × 4 + 10 = 114` connections per instance.
+ */
+export const OBO_POOL_DEFAULTS = {
+  ...POOL_DEFAULTS,
+  max: 4,
+};

--- a/packages/appkit/src/plugins/database/entity-proxy.ts
+++ b/packages/appkit/src/plugins/database/entity-proxy.ts
@@ -72,11 +72,16 @@ export type OrderInput<TRow extends Row> = {
   [K in keyof TRow]?: "asc" | "desc";
 };
 
-type RelatedRow<TIncludes, K extends keyof TIncludes> = TIncludes[K] extends {
+type RelatedRow<
+  TIncludes,
+  K extends keyof TIncludes,
+> = TIncludes[K] extends Array<{
   row: infer R;
-}
+}>
   ? Extract<R, Row>
-  : Row;
+  : TIncludes[K] extends { row: infer R }
+    ? Extract<R, Row>
+    : Row;
 
 export type IncludeInput<TIncludes> = {
   [K in keyof TIncludes]?:
@@ -89,8 +94,17 @@ export type IncludeInput<TIncludes> = {
       };
 };
 
+/**
+ * Project the runtime shape of `.include({ K: ... })`. One-to-many includes
+ * declare `Array<{ row: R }>` and resolve to `R[]`; one-to-one includes
+ * declare `{ row: R }` and resolve to `R | null`.
+ */
 export type ApplyIncludes<TIncludes, I> = {
-  [K in keyof I & keyof TIncludes]: RelatedRow<TIncludes, K>[];
+  [K in keyof I & keyof TIncludes]: TIncludes[K] extends Array<{ row: infer R }>
+    ? Extract<R, Row>[]
+    : TIncludes[K] extends { row: infer R }
+      ? Extract<R, Row> | null
+      : never;
 };
 
 /**
@@ -249,11 +263,19 @@ class EntityClientImpl<
   }
 
   limit(n: number) {
+    const requested = Math.max(0, Math.floor(n));
     if (this.state.unbounded) {
-      const explicit = Math.max(0, Math.floor(n));
-      return this.chain({ limit: explicit }, { limit: explicit });
+      return this.chain({ limit: requested }, { limit: requested });
     }
-    const limit = Math.min(MAX_LIMIT, Math.max(0, Math.floor(n)));
+    const limit = Math.min(MAX_LIMIT, requested);
+    if (requested > MAX_LIMIT) {
+      logger.warn(
+        "limit(%d) on %s clamped to MAX_LIMIT=%d. Use .unbounded() for full scans.",
+        requested,
+        this.deps.entity,
+        MAX_LIMIT,
+      );
+    }
     return this.chain({ limit }, { limit });
   }
 
@@ -305,12 +327,20 @@ class EntityClientImpl<
       }),
     };
 
+    // Cache key includes the user identity so SP and OBO results don't share
+    // a slot. In dev fallback (no x-forwarded-email), substitute the request
+    // id so two unrelated dev requests don't share a cache slot named
+    // `"unknown"` and cross-contaminate.
+    const reqId = (req as { id?: unknown }).id;
+    const identityKey =
+      req.header("x-forwarded-email") ??
+      (typeof reqId === "string" ? `unknown:${reqId}` : "unknown");
     return new EntityClientImpl<TRow, TInsert, TUpdate, TIncludes>(userDeps, {
       ...this.state,
       cacheKey: [
         this.deps.entity,
         "asUser",
-        req.header("x-forwarded-email") ?? "unknown",
+        identityKey,
         ...this.state.cacheKey.slice(1),
       ],
     });

--- a/packages/appkit/src/plugins/database/entity-proxy.ts
+++ b/packages/appkit/src/plugins/database/entity-proxy.ts
@@ -6,11 +6,24 @@ import type {
   OrderSpec,
   WhereSpec,
 } from "@/database";
+import { createLogger } from "@/logging/logger";
 import { readDefaults, writeDefaults } from "./defaults";
 import type { CacheSettings, EntityHooks, HookContext } from "./types";
 
+const logger = createLogger("database:entity");
 type Row = Record<string, unknown>;
 const MAX_LIMIT = 500;
+
+/**
+ * Public column names (private columns omitted). Used as the default read
+ * projection so columns marked `.private()` never leak via `appkit.database.<e>`
+ * or generated routes unless the caller explicitly opts in via `.select()`.
+ */
+function publicColumnNames(table: AppKitTable): string[] {
+  return Object.entries(table.$columns)
+    .filter(([, meta]) => meta.private !== true)
+    .map(([name]) => name);
+}
 
 type DatabaseAction =
   | "list"
@@ -236,10 +249,18 @@ class EntityClientImpl<
   }
 
   select<K extends keyof TRow & string>(...cols: K[]) {
-    return this.chain(
-      { columns: cols.map(String) },
-      { select: cols.join(",") },
-    );
+    const allowed = new Set(publicColumnNames(this.deps.table));
+    const requested = cols.map(String);
+    const dropped = requested.filter((c) => !allowed.has(c));
+    if (dropped.length > 0) {
+      logger.debug(
+        "Dropped private/unknown column(s) from select on %s: %s",
+        this.deps.entity,
+        dropped.join(","),
+      );
+    }
+    const filtered = requested.filter((c) => allowed.has(c));
+    return this.chain({ columns: filtered }, { select: filtered.join(",") });
   }
 
   include<I extends IncludeInput<TIncludes>>(input: I) {
@@ -287,7 +308,7 @@ class EntityClientImpl<
         where: this.state.where,
         order: this.state.order,
         ...this.resolvePagination(),
-        columns: this.state.columns,
+        columns: this.state.columns ?? publicColumnNames(this.deps.table),
         include: this.state.include,
         signal,
       });
@@ -302,7 +323,7 @@ class EntityClientImpl<
         order: this.state.order,
         limit: 1,
         offset: this.state.offset,
-        columns: this.state.columns,
+        columns: this.state.columns ?? publicColumnNames(this.deps.table),
         include: this.state.include,
         signal,
       });
@@ -317,7 +338,7 @@ class EntityClientImpl<
         this.pk(),
         id,
         {
-          columns: this.state.columns,
+          columns: this.state.columns ?? publicColumnNames(this.deps.table),
           include: this.state.include,
           signal,
         },

--- a/packages/appkit/src/plugins/database/entity-proxy.ts
+++ b/packages/appkit/src/plugins/database/entity-proxy.ts
@@ -10,15 +10,23 @@ import { createLogger } from "@/logging/logger";
 import { readDefaults, writeDefaults } from "./defaults";
 import type { CacheSettings, EntityHooks, HookContext } from "./types";
 
+// RFC 5321 §4.5.3.1.3 caps email at 320 octets.
+const MAX_EMAIL_LEN = 320;
+
+/** Trim, lowercase, length-cap. Returns `null` for missing/empty/oversize. */
+export function normalizeOboEmail(raw: string | undefined): string | null {
+  if (!raw) return null;
+  const trimmed = raw.trim().toLowerCase();
+  if (trimmed.length === 0 || trimmed.length > MAX_EMAIL_LEN) return null;
+  return trimmed;
+}
+
 const logger = createLogger("database:entity");
 type Row = Record<string, unknown>;
 const MAX_LIMIT = 500;
 
-/**
- * Public column names (private columns omitted). Used as the default read
- * projection so columns marked `.private()` never leak via `appkit.database.<e>`
- * or generated routes unless the caller explicitly opts in via `.select()`.
- */
+// Default read projection — `.private()` columns never leak via
+// `appkit.database.<e>` or generated routes unless `.select()`-ed in.
 function publicColumnNames(table: AppKitTable): string[] {
   return Object.entries(table.$columns)
     .filter(([, meta]) => meta.private !== true)
@@ -35,12 +43,9 @@ type DatabaseAction =
   | "delete";
 
 /**
- * Bound `Plugin#execute` wrapper passed in by `entity-wiring.ts`.
- *
- * `Plugin#execute` is `protected` and returns an `ExecutionResult<T>`
- * discriminated union. The wiring layer constructs an executor that calls the
- * protected method (legal in the same module), unwraps the result, and
- * rethrows on failure. Entity terminators see a flat "promise of T" contract.
+ * Bound `Plugin#execute` wrapper from `entity-wiring.ts`. Wiring unwraps the
+ * `ExecutionResult<T>` union and rethrows on failure so entity terminators
+ * see a flat `Promise<T>` contract.
  */
 export type ExecutorFn = <T>(
   fn: (signal?: AbortSignal) => Promise<T>,
@@ -108,13 +113,11 @@ export type ApplyIncludes<TIncludes, I> = {
 };
 
 /**
- * Public server-side entity facade exposed as `appkit.database.<entity>`.
+ * Public server-side entity facade — `appkit.database.<entity>`.
  *
- * Chain methods accumulate query state and return a new client (immutable);
- * terminators run the query through the bound executor (`Plugin#execute`
- * wrap) and return a promise. All filter/order operators map one-to-one to
- * `DataPath` operators — AppKit does not own SQL translation; the runtime
- * (Drizzle) does.
+ * Chain methods are immutable; terminators run via the bound executor.
+ * Filter/order operators map 1:1 to `DataPath` — SQL translation is the
+ * runtime's job, not AppKit's.
  */
 export interface EntityClient<
   TRow extends Row = Row,
@@ -132,10 +135,8 @@ export interface EntityClient<
   offset(n: number): EntityClient<TRow, TInsert, TUpdate, TIncludes>;
 
   /**
-   * Opt out of the default `MAX_LIMIT` cap for `toArray()`. Use only for
-   * background jobs that genuinely want every row — typical request handlers
-   * should page or `limit()` instead. Server-side `statement_timeout` still
-   * bounds runaway queries.
+   * Opt out of `MAX_LIMIT` for `toArray()`. Background jobs only — request
+   * handlers should page or `limit()`. `statement_timeout` still bounds runaway.
    */
   unbounded(): EntityClient<TRow, TInsert, TUpdate, TIncludes>;
 
@@ -162,10 +163,9 @@ export interface EntityClient<
   delete(id: string | number): Promise<void>;
 
   /**
-   * Per-request OBO clone. Resolves the user identity from
-   * `req.header("x-forwarded-email")` and swaps the underlying DataPath for a
-   * per-user one. In dev without the OBO header, falls through to the SP
-   * client (this) so the dev loop stays unbroken.
+   * Per-request OBO clone — resolves identity from `x-forwarded-email` and
+   * swaps in a per-user DataPath. Without the header in dev, returns the SP
+   * client so the dev loop stays unbroken.
    */
   asUser(
     req: import("express").Request,
@@ -186,21 +186,14 @@ interface EntityClientDeps {
   hookContext: () => HookContext;
   /** Bound `Plugin#execute` wrapper. Every terminator must go through this. */
   execute: ExecutorFn;
-  /**
-   * Build (or reuse) a per-user DataPath for this request. Returns `null` only
-   * for the local dev fallback when the request lacks forwarded OBO identity.
-   */
+  /** Build per-user DataPath. Returns `null` only in dev when OBO headers are absent. */
   makeUserDataPath: (req: import("express").Request) => DataPath | null;
   cache?: CacheSettings;
 }
 
 /**
- * Internal chain state.
- *
- * Pagination is tracked separately because PostgREST-style `offset(n).limit(m)`
- * needs to emit at the right moment, and `range(start, end)` competes with
- * the `offset/limit` pair. Everything else accumulates straight into the spec
- * objects.
+ * Internal chain state. Pagination is tracked separately so `offset/limit`
+ * can be resolved against `MAX_LIMIT` at terminator time.
  */
 interface EntityClientState {
   where?: WhereSpec;
@@ -226,11 +219,9 @@ export function makeEntityClient<
 }
 
 /**
- * Thin immutable wrapper around the `DataPath` runtime.
- *
- * Each chain method returns a new wrapper with the spec extended. Terminators
- * call `this.run(action, fn)` which wraps the call in `Plugin#execute` so
- * telemetry, retry, cache, and timeout flow consistently for every action.
+ * Thin immutable wrapper around `DataPath`. Terminators go through
+ * `this.run(action, fn)` → `Plugin#execute`, so telemetry, retry, cache,
+ * and timeout flow consistently per action.
  */
 class EntityClientImpl<
   TRow extends Row = Row,
@@ -244,9 +235,8 @@ class EntityClientImpl<
   ) {}
 
   where(predicate: WhereInput<TRow>) {
-    // Filter spec is shallow-merged into the existing where so successive
-    // `.where()` calls accumulate AND-style — matches the Supabase / Drizzle
-    // intuition (no clobbering on repeated calls for distinct columns).
+    // Successive .where() calls shallow-merge into AND. Matches Supabase/Drizzle
+    // intuition; no clobbering on distinct columns.
     return this.chain(
       {
         where: { ...this.state.where, ...(predicate as WhereSpec) },
@@ -311,30 +301,28 @@ class EntityClientImpl<
   }
 
   asUser(req: import("express").Request) {
-    // Dev fallback: when no user identity is forwarded and we're running
-    // locally, return self so routes don't 401 / fail the dev loop. In
-    // production, makeUserDataPath throws instead of silently falling back.
+    // Dev fallback: no OBO header → return self so routes don't 401. In prod
+    // `makeUserDataPath` throws instead of silently falling back.
     const userDataPath = this.deps.makeUserDataPath(req);
     if (!userDataPath) return this;
 
+    const email = normalizeOboEmail(req.header("x-forwarded-email"));
     const userDeps: EntityClientDeps = {
       ...this.deps,
       dataPath: userDataPath,
       hookContext: () => ({
         ...this.deps.hookContext(),
         req,
-        userId: req.header("x-forwarded-email"),
+        userId: email ?? undefined,
       }),
     };
 
-    // Cache key includes the user identity so SP and OBO results don't share
-    // a slot. In dev fallback (no x-forwarded-email), substitute the request
-    // id so two unrelated dev requests don't share a cache slot named
-    // `"unknown"` and cross-contaminate.
+    // Identity is in the cache key so SP and OBO don't share a slot. Dev
+    // fallback uses req.id so unrelated requests don't collide on a shared
+    // `"unknown"` slot.
     const reqId = (req as { id?: unknown }).id;
     const identityKey =
-      req.header("x-forwarded-email") ??
-      (typeof reqId === "string" ? `unknown:${reqId}` : "unknown");
+      email ?? (typeof reqId === "string" ? `unknown:${reqId}` : "unknown");
     return new EntityClientImpl<TRow, TInsert, TUpdate, TIncludes>(userDeps, {
       ...this.state,
       cacheKey: [
@@ -445,7 +433,14 @@ class EntityClientImpl<
         signal,
       );
       if (!row) {
-        throw new Error(`update: ${this.deps.table.name} id=${id} not found`);
+        // id may be user-supplied — strip control chars + length-cap before logging.
+        const safeId = String(id)
+          // biome-ignore lint/suspicious/noControlCharactersInRegex: deliberate
+          .replace(/[\x00-\x1f\x7f]/g, "?")
+          .slice(0, 64);
+        throw new Error(
+          `update: ${this.deps.table.name} not found (id=${safeId})`,
+        );
       }
       await this.deps.hooks?.afterUpdate?.(row, ctx);
       return row as TRow;
@@ -504,10 +499,8 @@ class EntityClientImpl<
   }
 
   /**
-   * Resolve final pagination shape for read terminators. When no limit is set
-   * the cap is `MAX_LIMIT` so server reads stay bounded; callers that really
-   * want every row opt in via `.unbounded()`. Throws when offset is set
-   * without a limit, matching the previous behavior.
+   * Default cap is `MAX_LIMIT` so reads stay bounded; opt out via `.unbounded()`.
+   * Throws when offset is set without limit.
    */
   private resolvePagination(): { limit?: number; offset?: number } {
     if (this.state.offset !== undefined && this.state.limit === undefined) {

--- a/packages/appkit/src/plugins/database/entity-proxy.ts
+++ b/packages/appkit/src/plugins/database/entity-proxy.ts
@@ -10,6 +10,7 @@ import { readDefaults, writeDefaults } from "./defaults";
 import type { CacheSettings, EntityHooks, HookContext } from "./types";
 
 type Row = Record<string, unknown>;
+const MAX_LIMIT = 500;
 
 type DatabaseAction =
   | "list"
@@ -151,8 +152,8 @@ interface EntityClientDeps {
   /** Bound `Plugin#execute` wrapper. Every terminator must go through this. */
   execute: ExecutorFn;
   /**
-   * Build (or reuse) a per-user DataPath for this request. Returns `null`
-   * when the request lacks an OBO identity — callers fall back to SP.
+   * Build (or reuse) a per-user DataPath for this request. Returns `null` only
+   * for the local dev fallback when the request lacks forwarded OBO identity.
    */
   makeUserDataPath: (req: import("express").Request) => DataPath | null;
   cache?: CacheSettings;
@@ -225,7 +226,7 @@ class EntityClientImpl<
   }
 
   limit(n: number) {
-    const limit = Math.max(0, Math.floor(n));
+    const limit = Math.min(MAX_LIMIT, Math.max(0, Math.floor(n)));
     return this.chain({ limit }, { limit });
   }
 
@@ -250,8 +251,8 @@ class EntityClientImpl<
 
   asUser(req: import("express").Request) {
     // Dev fallback: when no user identity is forwarded and we're running
-    // locally, return self so routes don't 401 / fail the dev loop. Mirrors
-    // the core Plugin#asUser contract.
+    // locally, return self so routes don't 401 / fail the dev loop. In
+    // production, makeUserDataPath throws instead of silently falling back.
     const userDataPath = this.deps.makeUserDataPath(req);
     if (!userDataPath) return this;
 
@@ -384,13 +385,20 @@ class EntityClientImpl<
 
   upsert(data: TInsert, options: { onConflict: keyof TRow }): Promise<TRow> {
     return this.run("upsert", async (signal) => {
-      const validated = this.deps.table.$insertSchema.parse(data);
+      const ctx = this.deps.hookContext();
+      const before = await this.deps.hooks?.beforeUpsert?.(
+        data as Record<string, unknown>,
+        ctx,
+      );
+      const payload = before ?? data;
+      const validated = this.deps.table.$insertSchema.parse(payload);
       const row = await this.deps.dataPath.upsert(
         this.deps.table,
         validated as Row,
         { onConflict: String(options.onConflict) },
         signal,
       );
+      await this.deps.hooks?.afterUpsert?.(row, ctx);
       return row as TRow;
     });
   }

--- a/packages/appkit/src/plugins/database/entity-proxy.ts
+++ b/packages/appkit/src/plugins/database/entity-proxy.ts
@@ -117,6 +117,14 @@ export interface EntityClient<
   limit(n: number): EntityClient<TRow, TInsert, TUpdate, TIncludes>;
   offset(n: number): EntityClient<TRow, TInsert, TUpdate, TIncludes>;
 
+  /**
+   * Opt out of the default `MAX_LIMIT` cap for `toArray()`. Use only for
+   * background jobs that genuinely want every row — typical request handlers
+   * should page or `limit()` instead. Server-side `statement_timeout` still
+   * bounds runaway queries.
+   */
+  unbounded(): EntityClient<TRow, TInsert, TUpdate, TIncludes>;
+
   select<K extends keyof TRow & string>(
     ...cols: K[]
   ): EntityClient<Pick<TRow, K> & Row, TInsert, TUpdate, TIncludes>;
@@ -187,6 +195,8 @@ interface EntityClientState {
   offset?: number;
   columns?: string[];
   include?: IncludeSpec;
+  /** Opt-out flag set by `.unbounded()` — bypasses the default `MAX_LIMIT` cap. */
+  unbounded?: boolean;
   cacheKey: (string | number | object)[];
 }
 
@@ -239,6 +249,10 @@ class EntityClientImpl<
   }
 
   limit(n: number) {
+    if (this.state.unbounded) {
+      const explicit = Math.max(0, Math.floor(n));
+      return this.chain({ limit: explicit }, { limit: explicit });
+    }
     const limit = Math.min(MAX_LIMIT, Math.max(0, Math.floor(n)));
     return this.chain({ limit }, { limit });
   }
@@ -246,6 +260,10 @@ class EntityClientImpl<
   offset(n: number) {
     const offset = Math.max(0, Math.floor(n));
     return this.chain({ offset }, { offset });
+  }
+
+  unbounded() {
+    return this.chain({ unbounded: true }, { unbounded: true });
   }
 
   select<K extends keyof TRow & string>(...cols: K[]) {
@@ -456,15 +474,19 @@ class EntityClientImpl<
   }
 
   /**
-   * Resolve final pagination shape for read terminators. Throws when offset
-   * is set without a limit, matching the previous behavior.
+   * Resolve final pagination shape for read terminators. When no limit is set
+   * the cap is `MAX_LIMIT` so server reads stay bounded; callers that really
+   * want every row opt in via `.unbounded()`. Throws when offset is set
+   * without a limit, matching the previous behavior.
    */
   private resolvePagination(): { limit?: number; offset?: number } {
     if (this.state.offset !== undefined && this.state.limit === undefined) {
       throw new Error("offset() requires limit()");
     }
+    const limit =
+      this.state.limit ?? (this.state.unbounded ? undefined : MAX_LIMIT);
     return {
-      limit: this.state.limit,
+      limit,
       offset: this.state.offset,
     };
   }

--- a/packages/appkit/src/plugins/database/entity-proxy.ts
+++ b/packages/appkit/src/plugins/database/entity-proxy.ts
@@ -1,0 +1,491 @@
+import type { PluginExecuteConfig, PluginExecutionSettings } from "shared";
+import type {
+  AppKitTable,
+  DataPath,
+  IncludeSpec,
+  OrderSpec,
+  WhereSpec,
+} from "@/database";
+import { readDefaults, writeDefaults } from "./defaults";
+import type { CacheSettings, EntityHooks, HookContext } from "./types";
+
+type Row = Record<string, unknown>;
+
+type DatabaseAction =
+  | "list"
+  | "find"
+  | "count"
+  | "create"
+  | "update"
+  | "upsert"
+  | "delete";
+
+/**
+ * Bound `Plugin#execute` wrapper passed in by `entity-wiring.ts`.
+ *
+ * `Plugin#execute` is `protected` and returns an `ExecutionResult<T>`
+ * discriminated union. The wiring layer constructs an executor that calls the
+ * protected method (legal in the same module), unwraps the result, and
+ * rethrows on failure. Entity terminators see a flat "promise of T" contract.
+ */
+export type ExecutorFn = <T>(
+  fn: (signal?: AbortSignal) => Promise<T>,
+  options: PluginExecutionSettings,
+) => Promise<T>;
+
+/**
+ * Predicate accepted by `where`. A bare value is shorthand for equality; an
+ * array is shorthand for `IN`; an object selects one or more operators.
+ */
+type WhereOperator<T> = {
+  eq?: T;
+  neq?: T;
+  gt?: T;
+  gte?: T;
+  lt?: T;
+  lte?: T;
+  like?: string;
+  ilike?: string;
+  in?: T[];
+  is?: T | null;
+};
+
+export type WhereInput<TRow extends Row> = {
+  [K in keyof TRow]?: TRow[K] | WhereOperator<TRow[K]>;
+};
+
+export type OrderInput<TRow extends Row> = {
+  [K in keyof TRow]?: "asc" | "desc";
+};
+
+type RelatedRow<TIncludes, K extends keyof TIncludes> = TIncludes[K] extends {
+  row: infer R;
+}
+  ? Extract<R, Row>
+  : Row;
+
+export type IncludeInput<TIncludes> = {
+  [K in keyof TIncludes]?:
+    | true
+    | {
+        select?: ReadonlyArray<keyof RelatedRow<TIncludes, K>>;
+        limit?: number;
+        order?: OrderInput<RelatedRow<TIncludes, K>>;
+        where?: WhereInput<RelatedRow<TIncludes, K>>;
+      };
+};
+
+export type ApplyIncludes<TIncludes, I> = {
+  [K in keyof I & keyof TIncludes]: RelatedRow<TIncludes, K>[];
+};
+
+/**
+ * Public server-side entity facade exposed as `appkit.database.<entity>`.
+ *
+ * Chain methods accumulate query state and return a new client (immutable);
+ * terminators run the query through the bound executor (`Plugin#execute`
+ * wrap) and return a promise. All filter/order operators map one-to-one to
+ * `DataPath` operators — AppKit does not own SQL translation; the runtime
+ * (Drizzle) does.
+ */
+export interface EntityClient<
+  TRow extends Row = Row,
+  TInsert = TRow,
+  TUpdate = Partial<TRow>,
+  TIncludes = Record<string, { row: Row }>,
+> {
+  where(
+    predicate: WhereInput<TRow>,
+  ): EntityClient<TRow, TInsert, TUpdate, TIncludes>;
+  order(
+    input: OrderInput<TRow>,
+  ): EntityClient<TRow, TInsert, TUpdate, TIncludes>;
+  limit(n: number): EntityClient<TRow, TInsert, TUpdate, TIncludes>;
+  offset(n: number): EntityClient<TRow, TInsert, TUpdate, TIncludes>;
+
+  select<K extends keyof TRow & string>(
+    ...cols: K[]
+  ): EntityClient<Pick<TRow, K> & Row, TInsert, TUpdate, TIncludes>;
+
+  include<I extends IncludeInput<TIncludes>>(
+    input: I,
+  ): EntityClient<
+    TRow & ApplyIncludes<TIncludes, I>,
+    TInsert,
+    TUpdate,
+    TIncludes
+  >;
+
+  toArray(): Promise<TRow[]>;
+  first(): Promise<TRow | null>;
+  find(id: string | number): Promise<TRow | null>;
+  count(): Promise<number>;
+  create(data: TInsert): Promise<TRow>;
+  update(id: string | number, patch: TUpdate): Promise<TRow>;
+  upsert(data: TInsert, options: { onConflict: keyof TRow }): Promise<TRow>;
+  delete(id: string | number): Promise<void>;
+
+  /**
+   * Per-request OBO clone. Resolves the user identity from
+   * `req.header("x-forwarded-email")` and swaps the underlying DataPath for a
+   * per-user one. In dev without the OBO header, falls through to the SP
+   * client (this) so the dev loop stays unbroken.
+   */
+  asUser(
+    req: import("express").Request,
+  ): EntityClient<TRow, TInsert, TUpdate, TIncludes>;
+}
+
+interface EntityClientDeps {
+  /** Table metadata and Zod validators produced by `defineSchema`. */
+  table: AppKitTable;
+  /** Logical entity key used for cache keys, hook context, and telemetry. */
+  entity: string;
+  /** Service-principal data path. Default for non-OBO calls. */
+  dataPath: DataPath;
+  /** Single-column primary key. Defaults to `"id"` when schema metadata absent. */
+  pkColumn?: string;
+  hooks?: EntityHooks;
+  /** Late-bound so `asUser(req)` can attach req/user info to hooks. */
+  hookContext: () => HookContext;
+  /** Bound `Plugin#execute` wrapper. Every terminator must go through this. */
+  execute: ExecutorFn;
+  /**
+   * Build (or reuse) a per-user DataPath for this request. Returns `null`
+   * when the request lacks an OBO identity — callers fall back to SP.
+   */
+  makeUserDataPath: (req: import("express").Request) => DataPath | null;
+  cache?: CacheSettings;
+}
+
+/**
+ * Internal chain state.
+ *
+ * Pagination is tracked separately because PostgREST-style `offset(n).limit(m)`
+ * needs to emit at the right moment, and `range(start, end)` competes with
+ * the `offset/limit` pair. Everything else accumulates straight into the spec
+ * objects.
+ */
+interface EntityClientState {
+  where?: WhereSpec;
+  order?: OrderSpec;
+  limit?: number;
+  offset?: number;
+  columns?: string[];
+  include?: IncludeSpec;
+  cacheKey: (string | number | object)[];
+}
+
+export function makeEntityClient<
+  TRow extends Row = Row,
+  TInsert = TRow,
+  TUpdate = Partial<TRow>,
+  TIncludes = Record<string, { row: Row }>,
+>(deps: EntityClientDeps): EntityClient<TRow, TInsert, TUpdate, TIncludes> {
+  return new EntityClientImpl<TRow, TInsert, TUpdate, TIncludes>(deps, {
+    cacheKey: [deps.entity],
+  }) as unknown as EntityClient<TRow, TInsert, TUpdate, TIncludes>;
+}
+
+/**
+ * Thin immutable wrapper around the `DataPath` runtime.
+ *
+ * Each chain method returns a new wrapper with the spec extended. Terminators
+ * call `this.run(action, fn)` which wraps the call in `Plugin#execute` so
+ * telemetry, retry, cache, and timeout flow consistently for every action.
+ */
+class EntityClientImpl<
+  TRow extends Row = Row,
+  TInsert = TRow,
+  TUpdate = Partial<TRow>,
+  TIncludes = Record<string, { row: Row }>,
+> {
+  constructor(
+    private readonly deps: EntityClientDeps,
+    private readonly state: EntityClientState,
+  ) {}
+
+  where(predicate: WhereInput<TRow>) {
+    // Filter spec is shallow-merged into the existing where so successive
+    // `.where()` calls accumulate AND-style — matches the Supabase / Drizzle
+    // intuition (no clobbering on repeated calls for distinct columns).
+    return this.chain(
+      {
+        where: { ...this.state.where, ...(predicate as WhereSpec) },
+      },
+      { where: predicate },
+    );
+  }
+
+  order(input: OrderInput<TRow>) {
+    return this.chain(
+      { order: { ...this.state.order, ...(input as OrderSpec) } },
+      { order: input },
+    );
+  }
+
+  limit(n: number) {
+    const limit = Math.max(0, Math.floor(n));
+    return this.chain({ limit }, { limit });
+  }
+
+  offset(n: number) {
+    const offset = Math.max(0, Math.floor(n));
+    return this.chain({ offset }, { offset });
+  }
+
+  select<K extends keyof TRow & string>(...cols: K[]) {
+    return this.chain(
+      { columns: cols.map(String) },
+      { select: cols.join(",") },
+    );
+  }
+
+  include<I extends IncludeInput<TIncludes>>(input: I) {
+    return this.chain(
+      { include: { ...this.state.include, ...(input as IncludeSpec) } },
+      { include: input },
+    ) as never;
+  }
+
+  asUser(req: import("express").Request) {
+    // Dev fallback: when no user identity is forwarded and we're running
+    // locally, return self so routes don't 401 / fail the dev loop. Mirrors
+    // the core Plugin#asUser contract.
+    const userDataPath = this.deps.makeUserDataPath(req);
+    if (!userDataPath) return this;
+
+    const userDeps: EntityClientDeps = {
+      ...this.deps,
+      dataPath: userDataPath,
+      hookContext: () => ({
+        ...this.deps.hookContext(),
+        req,
+        userId: req.header("x-forwarded-email"),
+      }),
+    };
+
+    return new EntityClientImpl<TRow, TInsert, TUpdate, TIncludes>(userDeps, {
+      ...this.state,
+      cacheKey: [
+        this.deps.entity,
+        "asUser",
+        req.header("x-forwarded-email") ?? "unknown",
+        ...this.state.cacheKey.slice(1),
+      ],
+    });
+  }
+
+  /* ----------------------------------------------------------------- *
+   * Read terminators                                                   *
+   * ----------------------------------------------------------------- */
+
+  toArray(): Promise<TRow[]> {
+    return this.run("list", async (signal) => {
+      const rows = await this.deps.dataPath.select(this.deps.table, {
+        where: this.state.where,
+        order: this.state.order,
+        ...this.resolvePagination(),
+        columns: this.state.columns,
+        include: this.state.include,
+        signal,
+      });
+      return rows as TRow[];
+    });
+  }
+
+  first(): Promise<TRow | null> {
+    return this.run("find", async (signal) => {
+      const rows = await this.deps.dataPath.select(this.deps.table, {
+        where: this.state.where,
+        order: this.state.order,
+        limit: 1,
+        offset: this.state.offset,
+        columns: this.state.columns,
+        include: this.state.include,
+        signal,
+      });
+      return ((rows[0] as TRow) ?? null) as TRow | null;
+    });
+  }
+
+  find(id: string | number): Promise<TRow | null> {
+    return this.run("find", async (signal) => {
+      const row = await this.deps.dataPath.findOne(
+        this.deps.table,
+        this.pk(),
+        id,
+        {
+          columns: this.state.columns,
+          include: this.state.include,
+          signal,
+        },
+      );
+      return (row as TRow) ?? null;
+    });
+  }
+
+  count(): Promise<number> {
+    return this.run("count", async (signal) => {
+      return await this.deps.dataPath.count(this.deps.table, {
+        where: this.state.where,
+        signal,
+      });
+    });
+  }
+
+  /* ----------------------------------------------------------------- *
+   * Write terminators                                                  *
+   * ----------------------------------------------------------------- */
+
+  create(data: TInsert): Promise<TRow> {
+    return this.run("create", async (signal) => {
+      const ctx = this.deps.hookContext();
+      const before = await this.deps.hooks?.beforeCreate?.(
+        data as Record<string, unknown>,
+        ctx,
+      );
+      const payload = before ?? data;
+      const validated = this.deps.table.$insertSchema.parse(payload);
+      const row = await this.deps.dataPath.insert(
+        this.deps.table,
+        validated as Row,
+        signal,
+      );
+      await this.deps.hooks?.afterCreate?.(row, ctx);
+      return row as TRow;
+    });
+  }
+
+  update(id: string | number, patch: TUpdate): Promise<TRow> {
+    return this.run("update", async (signal) => {
+      const ctx = this.deps.hookContext();
+      const before = await this.deps.hooks?.beforeUpdate?.(
+        id,
+        patch as Record<string, unknown>,
+        ctx,
+      );
+      const payload = before ?? patch;
+      const validated = this.deps.table.$updateSchema.parse(payload);
+      const row = await this.deps.dataPath.update(
+        this.deps.table,
+        this.pk(),
+        id,
+        validated as Row,
+        signal,
+      );
+      if (!row) {
+        throw new Error(`update: ${this.deps.table.name} id=${id} not found`);
+      }
+      await this.deps.hooks?.afterUpdate?.(row, ctx);
+      return row as TRow;
+    });
+  }
+
+  upsert(data: TInsert, options: { onConflict: keyof TRow }): Promise<TRow> {
+    return this.run("upsert", async (signal) => {
+      const validated = this.deps.table.$insertSchema.parse(data);
+      const row = await this.deps.dataPath.upsert(
+        this.deps.table,
+        validated as Row,
+        { onConflict: String(options.onConflict) },
+        signal,
+      );
+      return row as TRow;
+    });
+  }
+
+  delete(id: string | number): Promise<void> {
+    return this.run("delete", async (signal) => {
+      const ctx = this.deps.hookContext();
+      await this.deps.hooks?.beforeDelete?.(id, ctx);
+      await this.deps.dataPath.delete(this.deps.table, this.pk(), id, signal);
+      await this.deps.hooks?.afterDelete?.(id, ctx);
+    });
+  }
+
+  /* ----------------------------------------------------------------- *
+   * Internals                                                          *
+   * ----------------------------------------------------------------- */
+
+  private chain(
+    patch: Partial<Omit<EntityClientState, "cacheKey">>,
+    cachePart?: string | number | object,
+  ) {
+    return new EntityClientImpl<TRow, TInsert, TUpdate, TIncludes>(this.deps, {
+      ...this.state,
+      ...patch,
+      cacheKey:
+        cachePart === undefined
+          ? this.state.cacheKey
+          : [...this.state.cacheKey, cachePart],
+    });
+  }
+
+  private pk(): string {
+    return this.deps.pkColumn ?? "id";
+  }
+
+  /**
+   * Resolve final pagination shape for read terminators. Throws when offset
+   * is set without a limit, matching the previous behavior.
+   */
+  private resolvePagination(): { limit?: number; offset?: number } {
+    if (this.state.offset !== undefined && this.state.limit === undefined) {
+      throw new Error("offset() requires limit()");
+    }
+    return {
+      limit: this.state.limit,
+      offset: this.state.offset,
+    };
+  }
+
+  private run<T>(
+    action: DatabaseAction,
+    fn: (signal?: AbortSignal) => Promise<T>,
+  ) {
+    const isRead = action === "list" || action === "find" || action === "count";
+    const baseDefaults: PluginExecuteConfig = isRead
+      ? readDefaults
+      : writeDefaults;
+
+    const ttl =
+      action === "list"
+        ? this.deps.cache?.list?.ttl
+        : action === "find"
+          ? this.deps.cache?.find?.ttl
+          : action === "count"
+            ? this.deps.cache?.count?.ttl
+            : undefined;
+
+    const cache =
+      ttl && ttl > 0
+        ? {
+            ...baseDefaults.cache,
+            enabled: true,
+            ttl,
+            cacheKey: [
+              "database",
+              this.deps.entity,
+              action,
+              ...this.state.cacheKey,
+            ],
+          }
+        : baseDefaults.cache;
+
+    return this.deps.execute(fn, {
+      default: {
+        ...baseDefaults,
+        cache,
+        telemetryInterceptor: {
+          spanName: `database.${this.deps.entity}.${action}`,
+          attributes: {
+            "database.entity": this.deps.entity,
+            "database.action": action,
+            "database.channel": "drizzle-pool",
+          },
+        },
+      },
+    });
+  }
+}

--- a/packages/appkit/src/plugins/database/entity-wiring.ts
+++ b/packages/appkit/src/plugins/database/entity-wiring.ts
@@ -1,8 +1,8 @@
 import type { Pool } from "pg";
+import { createLakebasePool } from "@/connectors";
 import {
   type AppKitTable,
   createDrizzleDataPath,
-  createUserScopedDataPath,
   type DataPath,
   type Schema,
 } from "@/database";
@@ -27,29 +27,44 @@ interface WireEntitiesArgs {
 
 interface WireEntitiesResult {
   entities: Record<string, EntityClient>;
+  /** Service-principal DataPath. Backs `appkit.database.transaction` and `sql\`\``. */
+  dataPath: DataPath;
+  /** Per-user pool registry. The plugin owns its lifecycle on shutdown. */
+  userPools: UserPoolRegistry;
+}
+
+/**
+ * Per-user pool registry.
+ *
+ * `getOrCreate(email)` returns (or builds) a `pg.Pool` whose Lakebase OAuth
+ * resolves to the given user. Pools are kept in a Map; `closeAll()` drains
+ * them at shutdown. There is no LRU eviction yet — for MVP, we accept a pool
+ * per distinct user identity. A bounded LRU is tracked as a follow-up.
+ */
+export interface UserPoolRegistry {
+  getOrCreate(email: string): Pool;
+  closeAll(): Promise<void>;
 }
 
 /**
  * Wire one EntityClient per table on top of the service-principal pool, plus
- * a per-request user-scoped `DataPath` factory used by `EntityClient.asUser(req)`
- * to swap identity for OBO operations.
+ * a per-user pool factory used by `EntityClient.asUser(req)` to swap identity.
  *
  * The runtime data path is `DataPath` (Drizzle behind a thin AppKit-shaped
- * interface). Identity propagation for OBO uses `SET LOCAL app.user_id`
- * inside a transaction on the same SP pool — no per-user pool, no per-user
- * OAuth refresh, no LRU eviction.
+ * interface). The wiring layer never sees Drizzle; it only constructs
+ * `DataPath` instances and passes them down.
  */
 export function wireEntities(args: WireEntitiesArgs): WireEntitiesResult {
   const serviceDataPath = createDrizzleDataPath(args.servicePool, args.schema);
+  const userPools = makeUserPoolRegistry(args.config, args.schema);
 
   const makeUserDataPath = (
     req: import("express").Request,
   ): DataPath | null => {
     const email = req.header("x-forwarded-email");
     if (!email) return null;
-    return createUserScopedDataPath(args.servicePool, args.schema, {
-      userId: email,
-    });
+    const pool = userPools.getOrCreate(email);
+    return createDrizzleDataPath(pool, args.schema);
   };
 
   const entities: Record<string, EntityClient> = {};
@@ -72,7 +87,7 @@ export function wireEntities(args: WireEntitiesArgs): WireEntitiesResult {
     Object.keys(entities).length,
   );
 
-  return { entities };
+  return { entities, dataPath: serviceDataPath, userPools };
 }
 
 /**
@@ -86,4 +101,50 @@ function derivePkColumn(table: AppKitTable): string {
     if (meta.primaryKey) return name;
   }
   return "id";
+}
+
+/**
+ * Build the per-user pool registry. Pools are created lazily on first
+ * `getOrCreate(email)` and reused across requests for the same identity.
+ *
+ * Each pool is constructed via `createLakebasePool({ user })`, which is the
+ * same path the standalone `lakebase` plugin uses — Lakebase OAuth refresh
+ * happens automatically inside the pool. Dev = user OAuth, prod = SP-on-behalf
+ * (the platform forwards the user identity in a header, then we use Lakebase's
+ * standard token exchange).
+ */
+function makeUserPoolRegistry(
+  config: IDatabaseConfig,
+  _schema: Schema,
+): UserPoolRegistry {
+  const pools = new Map<string, Pool>();
+
+  return {
+    getOrCreate(email) {
+      const existing = pools.get(email);
+      if (existing) return existing;
+
+      const pool = createLakebasePool({
+        ...config.connection,
+        user: email,
+      });
+      pools.set(email, pool);
+      logger.debug("Created per-user pool for %s", email);
+      return pool;
+    },
+    async closeAll() {
+      const entries = Array.from(pools.entries());
+      pools.clear();
+      await Promise.all(
+        entries.map(async ([email, pool]) => {
+          try {
+            await pool.end();
+            logger.debug("Closed per-user pool for %s", email);
+          } catch (err) {
+            logger.error("Error closing per-user pool for %s: %O", email, err);
+          }
+        }),
+      );
+    },
+  };
 }

--- a/packages/appkit/src/plugins/database/entity-wiring.ts
+++ b/packages/appkit/src/plugins/database/entity-wiring.ts
@@ -10,6 +10,7 @@ import {
 } from "@/database";
 import { AuthenticationError, ConfigurationError } from "@/errors";
 import { createLogger } from "@/logging/logger";
+import { OBO_POOL_DEFAULTS, STATEMENT_TIMEOUT_DEFAULT_MS } from "./defaults";
 import {
   type EntityClient,
   type ExecutorFn,
@@ -149,7 +150,10 @@ function makeUserPoolRegistry(
       return existing;
     }
 
+    // Per-user pool: small (`OBO_POOL_DEFAULTS.max = 4`) by default. User-level
+    // overrides via `config.connection` still win.
     const pool = createLakebasePool({
+      ...OBO_POOL_DEFAULTS,
       ...config.connection,
       user: identity.email,
       workspaceClient: createUserWorkspaceClient(identity.token),
@@ -158,6 +162,10 @@ function makeUserPoolRegistry(
     // referencing current_user_id() (the helpers emitted by `appkit db rls`)
     // resolve to the OBO user. Per-user pool means the identity is invariant
     // across connections in this pool, so a session-level setting is safe.
+    // `statement_timeout` is set on the same connect event so OBO queries get
+    // the same server-side cap as SP ones.
+    const statementTimeoutMs =
+      config.statementTimeoutMs ?? STATEMENT_TIMEOUT_DEFAULT_MS;
     pool.on("connect", (client) => {
       client
         .query("SELECT set_config('app.user_id', $1, false)", [identity.email])
@@ -168,6 +176,17 @@ function makeUserPoolRegistry(
             err,
           );
         });
+      if (Number.isFinite(statementTimeoutMs) && statementTimeoutMs > 0) {
+        client
+          .query(`SET statement_timeout = ${Math.floor(statementTimeoutMs)}`)
+          .catch((err) => {
+            logger.error(
+              "Failed to set statement_timeout on user pool connection for %s: %O",
+              identity.email,
+              err,
+            );
+          });
+      }
     });
     pools.set(identity.email, pool);
     evictOldestIfNeeded(pools, draining, maxPools);
@@ -212,9 +231,9 @@ function makeUserPoolRegistry(
 function resolveUserPoolIdentity(
   req: import("express").Request,
 ): UserPoolIdentity | null {
+  const isDev = process.env.NODE_ENV === "development";
   const email = req.header("x-forwarded-email");
   const token = req.header("x-forwarded-access-token");
-  const isDev = process.env.NODE_ENV === "development";
 
   if (email && token) return { email, token };
 
@@ -245,7 +264,10 @@ function createUserWorkspaceClient(token: string): WorkspaceClient {
 }
 
 function normalizePoolMax(value: number | undefined): number {
-  if (!Number.isFinite(value) || value === undefined) return 50;
+  // Default of 25 keeps the worst-case fan-out tractable on Lakebase tiers
+  // ((1 + 25) × 4 + SP(10) ≈ 114 conns). Apps with hot OBO traffic should
+  // raise this explicitly after sizing the database tier.
+  if (!Number.isFinite(value) || value === undefined) return 25;
   return Math.max(1, Math.floor(value));
 }
 

--- a/packages/appkit/src/plugins/database/entity-wiring.ts
+++ b/packages/appkit/src/plugins/database/entity-wiring.ts
@@ -1,11 +1,14 @@
+import { WorkspaceClient } from "@databricks/sdk-experimental";
 import type { Pool } from "pg";
 import { createLakebasePool } from "@/connectors";
+import { ServiceContext } from "@/context";
 import {
   type AppKitTable,
   createDrizzleDataPath,
   type DataPath,
   type Schema,
 } from "@/database";
+import { AuthenticationError, ConfigurationError } from "@/errors";
 import { createLogger } from "@/logging/logger";
 import {
   type EntityClient,
@@ -36,14 +39,18 @@ interface WireEntitiesResult {
 /**
  * Per-user pool registry.
  *
- * `getOrCreate(email)` returns (or builds) a `pg.Pool` whose Lakebase OAuth
- * resolves to the given user. Pools are kept in a Map; `closeAll()` drains
- * them at shutdown. There is no LRU eviction yet — for MVP, we accept a pool
- * per distinct user identity. A bounded LRU is tracked as a follow-up.
+ * `getOrCreate(identity)` returns (or builds) a `pg.Pool` whose Lakebase OAuth
+ * resolves to the given user. Pools are kept in a bounded LRU keyed by email;
+ * evicted pools are drained with `pool.end()`.
  */
 export interface UserPoolRegistry {
-  getOrCreate(email: string): Pool;
+  getOrCreate(identity: UserPoolIdentity): Pool;
   closeAll(): Promise<void>;
+}
+
+interface UserPoolIdentity {
+  email: string;
+  token: string;
 }
 
 /**
@@ -61,9 +68,9 @@ export function wireEntities(args: WireEntitiesArgs): WireEntitiesResult {
   const makeUserDataPath = (
     req: import("express").Request,
   ): DataPath | null => {
-    const email = req.header("x-forwarded-email");
-    if (!email) return null;
-    const pool = userPools.getOrCreate(email);
+    const identity = resolveUserPoolIdentity(req);
+    if (!identity) return null;
+    const pool = userPools.getOrCreate(identity);
     return createDrizzleDataPath(pool, args.schema);
   };
 
@@ -107,29 +114,35 @@ function derivePkColumn(table: AppKitTable): string {
  * Build the per-user pool registry. Pools are created lazily on first
  * `getOrCreate(email)` and reused across requests for the same identity.
  *
- * Each pool is constructed via `createLakebasePool({ user })`, which is the
- * same path the standalone `lakebase` plugin uses — Lakebase OAuth refresh
- * happens automatically inside the pool. Dev = user OAuth, prod = SP-on-behalf
- * (the platform forwards the user identity in a header, then we use Lakebase's
- * standard token exchange).
+ * Each pool is constructed via `createLakebasePool({ user, workspaceClient })`,
+ * where the workspace client is authenticated with the forwarded user token.
+ * Lakebase OAuth refresh still happens inside the pool; this layer only selects
+ * the identity and bounds the number of open pools.
  */
 function makeUserPoolRegistry(
   config: IDatabaseConfig,
   _schema: Schema,
 ): UserPoolRegistry {
   const pools = new Map<string, Pool>();
+  const maxPools = normalizePoolMax(config.oboPoolMax);
 
   return {
-    getOrCreate(email) {
-      const existing = pools.get(email);
-      if (existing) return existing;
+    getOrCreate(identity) {
+      const existing = pools.get(identity.email);
+      if (existing) {
+        pools.delete(identity.email);
+        pools.set(identity.email, existing);
+        return existing;
+      }
 
       const pool = createLakebasePool({
         ...config.connection,
-        user: email,
+        user: identity.email,
+        workspaceClient: createUserWorkspaceClient(identity.token),
       });
-      pools.set(email, pool);
-      logger.debug("Created per-user pool for %s", email);
+      pools.set(identity.email, pool);
+      evictOldestIfNeeded(pools, maxPools);
+      logger.debug("Created per-user pool for %s", identity.email);
       return pool;
     },
     async closeAll() {
@@ -147,4 +160,59 @@ function makeUserPoolRegistry(
       );
     },
   };
+}
+
+function resolveUserPoolIdentity(
+  req: import("express").Request,
+): UserPoolIdentity | null {
+  const email = req.header("x-forwarded-email");
+  const token = req.header("x-forwarded-access-token");
+  const isDev = process.env.NODE_ENV === "development";
+
+  if (email && token) return { email, token };
+
+  if (isDev) {
+    logger.warn(
+      "Database OBO requested without x-forwarded-email/x-forwarded-access-token; falling back to service pool in development.",
+    );
+    return null;
+  }
+
+  if (!token) throw AuthenticationError.missingToken("user token");
+  throw new AuthenticationError(
+    "Missing x-forwarded-email header. Cannot create a user-scoped database pool.",
+  );
+}
+
+function createUserWorkspaceClient(token: string): WorkspaceClient {
+  const host = process.env.DATABRICKS_HOST;
+  if (!host) throw ConfigurationError.missingEnvVar("DATABRICKS_HOST");
+  return new WorkspaceClient(
+    {
+      host,
+      token,
+      authType: "pat",
+    },
+    ServiceContext.getClientOptions(),
+  );
+}
+
+function normalizePoolMax(value: number | undefined): number {
+  if (!Number.isFinite(value) || value === undefined) return 50;
+  return Math.max(1, Math.floor(value));
+}
+
+function evictOldestIfNeeded(pools: Map<string, Pool>, maxPools: number): void {
+  while (pools.size > maxPools) {
+    const oldest = pools.entries().next().value as
+      | [email: string, pool: Pool]
+      | undefined;
+    if (!oldest) return;
+    const [email, pool] = oldest;
+    pools.delete(email);
+    pool.end().catch((err) => {
+      logger.error("Error evicting per-user pool for %s: %O", email, err);
+    });
+    logger.debug("Evicted per-user pool for %s", email);
+  }
 }

--- a/packages/appkit/src/plugins/database/entity-wiring.ts
+++ b/packages/appkit/src/plugins/database/entity-wiring.ts
@@ -154,6 +154,21 @@ function makeUserPoolRegistry(
       user: identity.email,
       workspaceClient: createUserWorkspaceClient(identity.token),
     });
+    // Set session-local app.user_id on every connection so RLS predicates
+    // referencing current_user_id() (the helpers emitted by `appkit db rls`)
+    // resolve to the OBO user. Per-user pool means the identity is invariant
+    // across connections in this pool, so a session-level setting is safe.
+    pool.on("connect", (client) => {
+      client
+        .query("SELECT set_config('app.user_id', $1, false)", [identity.email])
+        .catch((err) => {
+          logger.error(
+            "Failed to set app.user_id on user pool connection for %s: %O",
+            identity.email,
+            err,
+          );
+        });
+    });
     pools.set(identity.email, pool);
     evictOldestIfNeeded(pools, draining, maxPools);
     logger.debug("Created per-user pool for %s", identity.email);

--- a/packages/appkit/src/plugins/database/entity-wiring.ts
+++ b/packages/appkit/src/plugins/database/entity-wiring.ts
@@ -16,16 +16,13 @@ import {
   type EntityClient,
   type ExecutorFn,
   makeEntityClient,
+  normalizeOboEmail,
 } from "./entity-proxy";
 import type { IDatabaseConfig } from "./types";
 
 /**
- * Hashed log tag for an email. Avoids logging the raw address (PII) while
- * keeping per-user log lines correlatable across requests.
- *
- * Format: `"<first-3-chars>#<sha256(email)[:8]>"`. The visible prefix gives
- * a debugger something to grep for; the hash disambiguates collisions and
- * makes it possible to correlate without leaking the rest of the address.
+ * Hashed log tag — keeps per-user lines correlatable without logging the raw
+ * email (PII). Format: `<first-3-chars>#<sha256(email)[:8]>`.
  */
 function logTagForEmail(email: string): string {
   const lower = email.toLowerCase();
@@ -54,12 +51,9 @@ interface WireEntitiesResult {
 }
 
 /**
- * Per-user pool registry.
- *
- * `getOrCreate(identity)` returns (or builds) a `pg.Pool` whose Lakebase OAuth
- * resolves to the given user. Pools are kept in a bounded LRU keyed by email;
- * evicted pools are moved to a draining set so `closeAll()` waits for any
- * in-flight queries to finish before resolving.
+ * Per-user pool registry. `getOrCreate(identity)` returns a `pg.Pool` whose
+ * Lakebase OAuth resolves to the given user. Bounded LRU keyed by email;
+ * evicted pools drain in the background so `closeAll()` awaits in-flight queries.
  */
 export interface UserPoolRegistry {
   resolveIdentity(req: import("express").Request): UserPoolIdentity | null;
@@ -74,12 +68,9 @@ interface UserPoolIdentity {
 }
 
 /**
- * Wire one EntityClient per table on top of the service-principal pool, plus
- * a per-user pool factory used by `EntityClient.asUser(req)` to swap identity.
- *
- * The runtime data path is `DataPath` (Drizzle behind a thin AppKit-shaped
- * interface). The wiring layer never sees Drizzle; it only constructs
- * `DataPath` instances and passes them down.
+ * Wire one EntityClient per table on the SP pool, plus a per-user pool factory
+ * for `EntityClient.asUser(req)`. Wiring never touches Drizzle — only
+ * `DataPath` instances flow through.
  */
 export function wireEntities(args: WireEntitiesArgs): WireEntitiesResult {
   const serviceDataPath = createDrizzleDataPath(args.servicePool, args.schema);
@@ -108,18 +99,13 @@ export function wireEntities(args: WireEntitiesArgs): WireEntitiesResult {
     });
   }
 
-  // Boot summary is logged once by the plugin in `setup()` (it has the
-  // entity names + schema metadata). Keeping a second log line here would
-  // duplicate the same fact in operator output for no debugging benefit.
-
+  // Plugin's `setup()` already logs the boot summary; don't duplicate.
   return { entities, dataPath: serviceDataPath, userPools };
 }
 
 /**
- * Resolve a table's primary-key column name. Falls back to the conventional
- * `"id"` when the schema has no column flagged as primary key. Composite PKs
- * are intentionally rejected at schema-builder time, so a single name is
- * always sufficient here.
+ * Resolve PK column name; defaults to `"id"`. Composite PKs are rejected at
+ * schema-builder time, so a single name always suffices.
  */
 function derivePkColumn(table: AppKitTable): string {
   for (const [name, meta] of Object.entries(table.$columns)) {
@@ -129,21 +115,17 @@ function derivePkColumn(table: AppKitTable): string {
 }
 
 /**
- * Build the per-user pool registry. Pools are created lazily on first
- * `getOrCreate(email)` and reused across requests for the same identity.
- *
- * Each pool is constructed via `createLakebasePool({ user, workspaceClient })`,
- * where the workspace client is authenticated with the forwarded user token.
- * Lakebase OAuth refresh still happens inside the pool; this layer only selects
- * the identity and bounds the number of open pools.
+ * Per-user pool registry. Lazy create on first `getOrCreate(email)`, reused
+ * for the same identity. Built via `createLakebasePool` with a workspace
+ * client bound to the forwarded user token; OAuth refresh happens inside
+ * the pool. This layer only selects identity and bounds open-pool count.
  */
 function makeUserPoolRegistry(
   config: IDatabaseConfig,
   schema: Schema,
 ): UserPoolRegistry {
   const pools = new Map<string, Pool>();
-  // Pools that have been evicted but may still have in-flight queries. We hold
-  // them here so `closeAll()` waits for graceful drain before returning.
+  // Evicted pools held here so `closeAll()` awaits graceful drain.
   const draining = new Set<Pool>();
   const dataPaths = new WeakMap<Pool, DataPath>();
   const maxPools = normalizePoolMax(config.oboPoolMax);
@@ -167,19 +149,16 @@ function makeUserPoolRegistry(
       return existing;
     }
 
-    // Per-user pool: small (`OBO_POOL_DEFAULTS.max = 4`) by default. User-level
-    // overrides via `config.connection` still win.
+    // Small per-user pool (default max=4); `config.connection` overrides win.
     const pool = createLakebasePool({
       ...OBO_POOL_DEFAULTS,
       ...config.connection,
       user: identity.email,
       workspaceClient: createUserWorkspaceClient(identity.token),
     });
-    // Set session-local app.user_id on every connection so RLS predicates
-    // referencing current_user_id() (the helpers emitted by `appkit db rls`)
-    // resolve to the OBO user. Per-user pool means the identity is invariant
-    // across connections in this pool, so a session-level setting is safe.
-    // `statement_timeout` is set on the same connect event so OBO queries get
+    // Session-local `app.user_id` so `current_user_id()` RLS helpers resolve
+    // to the OBO user — safe at session scope since identity is invariant in
+    // this per-user pool. `statement_timeout` set here too so OBO queries get
     // the same server-side cap as SP ones.
     const statementTimeoutMs =
       config.statementTimeoutMs ?? STATEMENT_TIMEOUT_DEFAULT_MS;
@@ -250,7 +229,7 @@ function resolveUserPoolIdentity(
   req: import("express").Request,
 ): UserPoolIdentity | null {
   const isDev = process.env.NODE_ENV === "development";
-  const email = req.header("x-forwarded-email");
+  const email = normalizeOboEmail(req.header("x-forwarded-email"));
   const token = req.header("x-forwarded-access-token");
 
   if (email && token) return { email, token };
@@ -282,9 +261,8 @@ function createUserWorkspaceClient(token: string): WorkspaceClient {
 }
 
 function normalizePoolMax(value: number | undefined): number {
-  // Default of 25 keeps the worst-case fan-out tractable on Lakebase tiers
-  // ((1 + 25) × 4 + SP(10) ≈ 114 conns). Apps with hot OBO traffic should
-  // raise this explicitly after sizing the database tier.
+  // Default 25 keeps fan-out tractable on Lakebase tiers ((1+25)×4 + SP(10)
+  // ≈ 114 conns). Hot-OBO apps should raise explicitly after sizing the tier.
   if (!Number.isFinite(value) || value === undefined) return 25;
   return Math.max(1, Math.floor(value));
 }

--- a/packages/appkit/src/plugins/database/entity-wiring.ts
+++ b/packages/appkit/src/plugins/database/entity-wiring.ts
@@ -41,10 +41,13 @@ interface WireEntitiesResult {
  *
  * `getOrCreate(identity)` returns (or builds) a `pg.Pool` whose Lakebase OAuth
  * resolves to the given user. Pools are kept in a bounded LRU keyed by email;
- * evicted pools are drained with `pool.end()`.
+ * evicted pools are moved to a draining set so `closeAll()` waits for any
+ * in-flight queries to finish before resolving.
  */
 export interface UserPoolRegistry {
+  resolveIdentity(req: import("express").Request): UserPoolIdentity | null;
   getOrCreate(identity: UserPoolIdentity): Pool;
+  getOrCreateDataPath(identity: UserPoolIdentity): DataPath;
   closeAll(): Promise<void>;
 }
 
@@ -68,10 +71,9 @@ export function wireEntities(args: WireEntitiesArgs): WireEntitiesResult {
   const makeUserDataPath = (
     req: import("express").Request,
   ): DataPath | null => {
-    const identity = resolveUserPoolIdentity(req);
+    const identity = userPools.resolveIdentity(req);
     if (!identity) return null;
-    const pool = userPools.getOrCreate(identity);
-    return createDrizzleDataPath(pool, args.schema);
+    return userPools.getOrCreateDataPath(identity);
   };
 
   const entities: Record<string, EntityClient> = {};
@@ -121,35 +123,58 @@ function derivePkColumn(table: AppKitTable): string {
  */
 function makeUserPoolRegistry(
   config: IDatabaseConfig,
-  _schema: Schema,
+  schema: Schema,
 ): UserPoolRegistry {
   const pools = new Map<string, Pool>();
+  // Pools that have been evicted but may still have in-flight queries. We hold
+  // them here so `closeAll()` waits for graceful drain before returning.
+  const draining = new Set<Pool>();
+  const dataPaths = new WeakMap<Pool, DataPath>();
   const maxPools = normalizePoolMax(config.oboPoolMax);
 
-  return {
-    getOrCreate(identity) {
-      const existing = pools.get(identity.email);
-      if (existing) {
-        pools.delete(identity.email);
-        pools.set(identity.email, existing);
-        return existing;
-      }
+  function buildDataPath(pool: Pool): DataPath {
+    let dp = dataPaths.get(pool);
+    if (!dp) {
+      dp = createDrizzleDataPath(pool, schema);
+      dataPaths.set(pool, dp);
+    }
+    return dp;
+  }
 
-      const pool = createLakebasePool({
-        ...config.connection,
-        user: identity.email,
-        workspaceClient: createUserWorkspaceClient(identity.token),
-      });
-      pools.set(identity.email, pool);
-      evictOldestIfNeeded(pools, maxPools);
-      logger.debug("Created per-user pool for %s", identity.email);
-      return pool;
+  function getOrCreate(identity: UserPoolIdentity): Pool {
+    const existing = pools.get(identity.email);
+    if (existing) {
+      pools.delete(identity.email);
+      pools.set(identity.email, existing);
+      return existing;
+    }
+
+    const pool = createLakebasePool({
+      ...config.connection,
+      user: identity.email,
+      workspaceClient: createUserWorkspaceClient(identity.token),
+    });
+    pools.set(identity.email, pool);
+    evictOldestIfNeeded(pools, draining, maxPools);
+    logger.debug("Created per-user pool for %s", identity.email);
+    return pool;
+  }
+
+  return {
+    resolveIdentity(req) {
+      return resolveUserPoolIdentity(req);
+    },
+    getOrCreate,
+    getOrCreateDataPath(identity) {
+      return buildDataPath(getOrCreate(identity));
     },
     async closeAll() {
       const entries = Array.from(pools.entries());
+      const drainingPools = Array.from(draining);
       pools.clear();
-      await Promise.all(
-        entries.map(async ([email, pool]) => {
+      draining.clear();
+      await Promise.all([
+        ...entries.map(async ([email, pool]) => {
           try {
             await pool.end();
             logger.debug("Closed per-user pool for %s", email);
@@ -157,7 +182,14 @@ function makeUserPoolRegistry(
             logger.error("Error closing per-user pool for %s: %O", email, err);
           }
         }),
-      );
+        ...drainingPools.map(async (pool) => {
+          try {
+            await pool.end();
+          } catch (err) {
+            logger.error("Error draining evicted per-user pool: %O", err);
+          }
+        }),
+      ]);
     },
   };
 }
@@ -202,7 +234,11 @@ function normalizePoolMax(value: number | undefined): number {
   return Math.max(1, Math.floor(value));
 }
 
-function evictOldestIfNeeded(pools: Map<string, Pool>, maxPools: number): void {
+function evictOldestIfNeeded(
+  pools: Map<string, Pool>,
+  draining: Set<Pool>,
+  maxPools: number,
+): void {
   while (pools.size > maxPools) {
     const oldest = pools.entries().next().value as
       | [email: string, pool: Pool]
@@ -210,9 +246,15 @@ function evictOldestIfNeeded(pools: Map<string, Pool>, maxPools: number): void {
     if (!oldest) return;
     const [email, pool] = oldest;
     pools.delete(email);
-    pool.end().catch((err) => {
-      logger.error("Error evicting per-user pool for %s: %O", email, err);
-    });
+    draining.add(pool);
+    pool
+      .end()
+      .catch((err) => {
+        logger.error("Error evicting per-user pool for %s: %O", email, err);
+      })
+      .finally(() => {
+        draining.delete(pool);
+      });
     logger.debug("Evicted per-user pool for %s", email);
   }
 }

--- a/packages/appkit/src/plugins/database/entity-wiring.ts
+++ b/packages/appkit/src/plugins/database/entity-wiring.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { WorkspaceClient } from "@databricks/sdk-experimental";
 import type { Pool } from "pg";
 import { createLakebasePool } from "@/connectors";
@@ -17,6 +18,21 @@ import {
   makeEntityClient,
 } from "./entity-proxy";
 import type { IDatabaseConfig } from "./types";
+
+/**
+ * Hashed log tag for an email. Avoids logging the raw address (PII) while
+ * keeping per-user log lines correlatable across requests.
+ *
+ * Format: `"<first-3-chars>#<sha256(email)[:8]>"`. The visible prefix gives
+ * a debugger something to grep for; the hash disambiguates collisions and
+ * makes it possible to correlate without leaking the rest of the address.
+ */
+function logTagForEmail(email: string): string {
+  const lower = email.toLowerCase();
+  const visible = lower.slice(0, Math.min(lower.length, 3));
+  const digest = createHash("sha256").update(lower).digest("hex").slice(0, 8);
+  return `${visible}#${digest}`;
+}
 
 const logger = createLogger("database:wiring");
 
@@ -92,10 +108,9 @@ export function wireEntities(args: WireEntitiesArgs): WireEntitiesResult {
     });
   }
 
-  logger.info(
-    "Database entities wired (%d tables, runtime: drizzle/pool)",
-    Object.keys(entities).length,
-  );
+  // Boot summary is logged once by the plugin in `setup()` (it has the
+  // entity names + schema metadata). Keeping a second log line here would
+  // duplicate the same fact in operator output for no debugging benefit.
 
   return { entities, dataPath: serviceDataPath, userPools };
 }
@@ -143,10 +158,12 @@ function makeUserPoolRegistry(
   }
 
   function getOrCreate(identity: UserPoolIdentity): Pool {
-    const existing = pools.get(identity.email);
+    const key = identity.email.toLowerCase();
+    const tag = logTagForEmail(identity.email);
+    const existing = pools.get(key);
     if (existing) {
-      pools.delete(identity.email);
-      pools.set(identity.email, existing);
+      pools.delete(key);
+      pools.set(key, existing);
       return existing;
     }
 
@@ -172,7 +189,7 @@ function makeUserPoolRegistry(
         .catch((err) => {
           logger.error(
             "Failed to set app.user_id on user pool connection for %s: %O",
-            identity.email,
+            tag,
             err,
           );
         });
@@ -182,15 +199,15 @@ function makeUserPoolRegistry(
           .catch((err) => {
             logger.error(
               "Failed to set statement_timeout on user pool connection for %s: %O",
-              identity.email,
+              tag,
               err,
             );
           });
       }
     });
-    pools.set(identity.email, pool);
+    pools.set(key, pool);
     evictOldestIfNeeded(pools, draining, maxPools);
-    logger.debug("Created per-user pool for %s", identity.email);
+    logger.debug("Created per-user pool for %s", tag);
     return pool;
   }
 
@@ -209,11 +226,12 @@ function makeUserPoolRegistry(
       draining.clear();
       await Promise.all([
         ...entries.map(async ([email, pool]) => {
+          const tag = logTagForEmail(email);
           try {
             await pool.end();
-            logger.debug("Closed per-user pool for %s", email);
+            logger.debug("Closed per-user pool for %s", tag);
           } catch (err) {
-            logger.error("Error closing per-user pool for %s: %O", email, err);
+            logger.error("Error closing per-user pool for %s: %O", tag, err);
           }
         }),
         ...drainingPools.map(async (pool) => {
@@ -282,16 +300,17 @@ function evictOldestIfNeeded(
       | undefined;
     if (!oldest) return;
     const [email, pool] = oldest;
+    const tag = logTagForEmail(email);
     pools.delete(email);
     draining.add(pool);
     pool
       .end()
       .catch((err) => {
-        logger.error("Error evicting per-user pool for %s: %O", email, err);
+        logger.error("Error evicting per-user pool for %s: %O", tag, err);
       })
       .finally(() => {
         draining.delete(pool);
       });
-    logger.debug("Evicted per-user pool for %s", email);
+    logger.debug("Evicted per-user pool for %s", tag);
   }
 }

--- a/packages/appkit/src/plugins/database/entity-wiring.ts
+++ b/packages/appkit/src/plugins/database/entity-wiring.ts
@@ -1,0 +1,89 @@
+import type { Pool } from "pg";
+import {
+  type AppKitTable,
+  createDrizzleDataPath,
+  createUserScopedDataPath,
+  type DataPath,
+  type Schema,
+} from "@/database";
+import { createLogger } from "@/logging/logger";
+import {
+  type EntityClient,
+  type ExecutorFn,
+  makeEntityClient,
+} from "./entity-proxy";
+import type { IDatabaseConfig } from "./types";
+
+const logger = createLogger("database:wiring");
+
+interface WireEntitiesArgs {
+  schema: Schema;
+  config: IDatabaseConfig;
+  /** Service-principal pool, already created by the plugin in `setup()`. */
+  servicePool: Pool;
+  /** Bound `Plugin#execute` wrapper threaded into every entity. */
+  executor: ExecutorFn;
+}
+
+interface WireEntitiesResult {
+  entities: Record<string, EntityClient>;
+}
+
+/**
+ * Wire one EntityClient per table on top of the service-principal pool, plus
+ * a per-request user-scoped `DataPath` factory used by `EntityClient.asUser(req)`
+ * to swap identity for OBO operations.
+ *
+ * The runtime data path is `DataPath` (Drizzle behind a thin AppKit-shaped
+ * interface). Identity propagation for OBO uses `SET LOCAL app.user_id`
+ * inside a transaction on the same SP pool — no per-user pool, no per-user
+ * OAuth refresh, no LRU eviction.
+ */
+export function wireEntities(args: WireEntitiesArgs): WireEntitiesResult {
+  const serviceDataPath = createDrizzleDataPath(args.servicePool, args.schema);
+
+  const makeUserDataPath = (
+    req: import("express").Request,
+  ): DataPath | null => {
+    const email = req.header("x-forwarded-email");
+    if (!email) return null;
+    return createUserScopedDataPath(args.servicePool, args.schema, {
+      userId: email,
+    });
+  };
+
+  const entities: Record<string, EntityClient> = {};
+  for (const [entity, table] of Object.entries(args.schema.$tables)) {
+    entities[entity] = makeEntityClient({
+      entity,
+      table,
+      dataPath: serviceDataPath,
+      pkColumn: derivePkColumn(table),
+      hooks: args.config.hooks?.[entity],
+      hookContext: () => ({ entity }),
+      execute: args.executor,
+      makeUserDataPath,
+      cache: args.config.cache,
+    });
+  }
+
+  logger.info(
+    "Database entities wired (%d tables, runtime: drizzle/pool)",
+    Object.keys(entities).length,
+  );
+
+  return { entities };
+}
+
+/**
+ * Resolve a table's primary-key column name. Falls back to the conventional
+ * `"id"` when the schema has no column flagged as primary key. Composite PKs
+ * are intentionally rejected at schema-builder time, so a single name is
+ * always sufficient here.
+ */
+function derivePkColumn(table: AppKitTable): string {
+  for (const [name, meta] of Object.entries(table.$columns)) {
+    if (meta.primaryKey) return name;
+  }
+  return "id";
+}

--- a/packages/appkit/src/plugins/database/manifest.json
+++ b/packages/appkit/src/plugins/database/manifest.json
@@ -2,7 +2,7 @@
   "$schema": "https://databricks.github.io/appkit/schemas/plugin-manifest.schema.json",
   "name": "database",
   "displayName": "Database",
-  "description": "Lakebase Postgres pool + schema declaration via defineSchema. CRUD/OBO/RLS surface ships incrementally in subsequent stack layers; this layer provides the pool, schema convention loader, and column metadata.",
+  "description": "Application database with schema-driven CRUD, type generation, OBO, and RLS",
   "hidden": false,
   "stability": "beta",
   "resources": {
@@ -61,25 +61,14 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "connection": {
-          "type": "object",
-          "additionalProperties": true,
-          "description": "Optional pg.Pool overrides forwarded to createLakebasePool. Avoid setting `password`/`user` here — Lakebase uses OAuth."
-        },
-        "statementTimeoutMs": {
-          "type": "number",
-          "description": "Server-side `statement_timeout` (ms) applied per pool connection. Defaults to 15_000."
-        },
-        "tolerateSetupFailure": {
-          "type": "boolean",
-          "description": "If true, plugin boot continues with an empty schema when config/database/schema.ts fails to load. Off by default."
-        },
-        "oboPoolMax": {
-          "type": "number",
-          "description": "Max number of distinct OBO pools held in the LRU. Worst-case fan-out is oboPoolMax × OBO_POOL_DEFAULTS.max + POOL_DEFAULTS.max connections per app instance."
-        },
         "http": { "type": "object", "additionalProperties": true },
         "hooks": { "type": "object", "additionalProperties": true },
+        "checkDrift": { "type": "boolean", "default": true },
+        "oboPoolMax": {
+          "type": "number",
+          "default": 50,
+          "description": "Maximum number of per-user OBO pools to keep open."
+        },
         "cache": {
           "type": "object",
           "properties": {
@@ -100,5 +89,5 @@
       }
     }
   },
-  "onSetupMessage": "Database plugin installed. Configure your schema in config/database/schema.ts via defineSchema(). The plugin currently exposes pool access (appkit.database.getPool()); CRUD, OBO, and RLS surfaces ship in subsequent stack layers."
+  "onSetupMessage": "Database plugin installed. Next: npx appkit db init\n  - For a new database: define entities in config/database/schema.ts (and optional demo rows in config/database/seed.sql) before running init.\n  - For an existing Lakebase: just run init; it will introspect the schema for you.\nThe init command picks the Databricks profile and Lakebase project, creates a per-user dev branch, writes .env, and runs the right setup or introspection."
 }

--- a/packages/appkit/src/plugins/database/route-generator.ts
+++ b/packages/appkit/src/plugins/database/route-generator.ts
@@ -1,0 +1,383 @@
+import type express from "express";
+import type { IAppRouter, RouteConfig } from "shared";
+import type { AppKitTable, Schema } from "@/database";
+import { createLogger } from "@/logging/logger";
+import type { EntityClient, WhereInput } from "./entity-proxy";
+import type { HttpAccess, HttpEntityOverride, IDatabaseConfig } from "./types";
+
+const logger = createLogger("database:routes");
+
+type Verb = "list" | "find" | "count" | "create" | "update" | "delete";
+type DatabaseExecutionSurface = Record<string, EntityClient>;
+
+// Zero-trust default: every generated route runs OBO unless the app author
+// explicitly opts that verb into service/public mode or disables it.
+const DEFAULT_ACCESS: Record<Verb, HttpAccess> = {
+  list: "obo",
+  find: "obo",
+  count: "obo",
+  create: "obo",
+  update: "obo",
+  delete: "obo",
+};
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 500;
+
+// These query params control the shape of the read. Everything else is treated
+// as a potential column filter, but only if it matches a declared schema column.
+const RESERVED_QUERY_KEYS = new Set(["select", "order", "limit", "offset"]);
+
+// Keep the HTTP dialect intentionally identical to PostGREST's builder methods:
+// `?age=gte.18`, `?name=ilike.%foo%`, `?id=in.(1,2,3)`.
+const ALLOWED_OPS = new Set([
+  "eq",
+  "neq",
+  "gt",
+  "gte",
+  "lt",
+  "lte",
+  "like",
+  "ilike",
+  "in",
+  "is",
+]);
+
+interface RouteGeneratorOptions {
+  schema: Schema;
+  config: IDatabaseConfig;
+  /**
+   * DatabasePlugin owns identity selection. The route generator only says which
+   * access mode was configured for the verb and receives the right entity map.
+   */
+  getSurface: (
+    req: express.Request,
+    access: HttpAccess,
+  ) => DatabaseExecutionSurface;
+  /** Bound wrapper around Plugin#route so endpoint registration stays central. */
+  route: (router: IAppRouter, config: RouteConfig) => void;
+}
+
+/**
+ * Generates the HTTP layer for every schema table.
+ *
+ * This class deliberately does not know about PostGREST clients, pg pools, or
+ * auth internals. It translates Express requests into the L3 EntityClient API;
+ * the entity client then handles validation, hooks, execute wrapping, retries,
+ * cache, telemetry, and PostGREST calls.
+ */
+export class RouteGenerator {
+  constructor(private readonly options: RouteGeneratorOptions) {}
+
+  injectAll(router: IAppRouter): void {
+    for (const [name, table] of Object.entries(this.options.schema.$tables)) {
+      this.injectEntity(router, name, table);
+    }
+  }
+
+  private injectEntity(
+    router: IAppRouter,
+    name: string,
+    table: AppKitTable,
+  ): void {
+    const access = resolveAccess(this.options.config.http?.[name]);
+    const cols = new Set(Object.keys(table.$columns));
+
+    // Six conventional routes per entity. A verb set to `false` is skipped
+    // entirely so disabled endpoints are not present in Express at all.
+    if (access.list !== false) this.bindList(router, name, cols, access.list);
+    if (access.count !== false)
+      this.bindCount(router, name, cols, access.count);
+    if (access.find !== false) this.bindFind(router, name, access.find);
+    if (access.create !== false)
+      this.bindCreate(router, name, table, access.create);
+    if (access.update !== false)
+      this.bindUpdate(router, name, table, access.update);
+    if (access.delete !== false) this.bindDelete(router, name, access.delete);
+  }
+  private bindList(
+    router: IAppRouter,
+    name: string,
+    cols: ReadonlySet<string>,
+    access: HttpAccess,
+  ): void {
+    this.bind(router, name, "list", "get", `/${name}`, async (req, res) => {
+      let q = this.entity(req, access, name);
+
+      // Filters are applied inline here on purpose. A separate parser would just
+      // duplicate PostGREST's operator vocabulary and create another abstraction
+      // to keep in sync.
+      q = applyFilters(q, req.query, cols);
+
+      // Forward `?select=*,posts(*)` and plain column lists to EntityClient's raw
+      // select overload. This is what lets browser `.include()` work end to end.
+      if (typeof req.query.select === "string") {
+        q = q.select(req.query.select);
+      }
+      if (typeof req.query.order === "string") {
+        q = applyOrder(q, req.query.order, cols);
+      }
+      q = q.limit(
+        typeof req.query.limit === "string"
+          ? clampLimit(Number(req.query.limit))
+          : DEFAULT_LIMIT,
+      );
+
+      // EntityClient defers offset+limit translation into PostGREST range().
+      if (typeof req.query.offset === "string") {
+        const offset = Number(req.query.offset);
+        if (Number.isFinite(offset) && offset >= 0) {
+          q = q.offset(offset);
+        }
+      }
+      res.json(await q.toArray());
+    });
+  }
+  private bindCount(
+    router: IAppRouter,
+    name: string,
+    cols: ReadonlySet<string>,
+    access: HttpAccess,
+  ): void {
+    this.bind(
+      router,
+      name,
+      "count",
+      "get",
+      `/${name}/count`,
+      async (req, res) => {
+        // Count supports the same column filters as list, but intentionally
+        // ignores pagination and select/order shape controls.
+        const q = applyFilters(this.entity(req, access, name), req.query, cols);
+        res.json({ count: await q.count() });
+      },
+    );
+  }
+  private bindFind(router: IAppRouter, name: string, access: HttpAccess): void {
+    this.bind(router, name, "find", "get", `/${name}/:id`, async (req, res) => {
+      let q = this.entity(req, access, name);
+
+      // Useful for embedded reads like /user/1?select=*,posts(*).
+      if (typeof req.query.select === "string") {
+        q = q.select(req.query.select);
+      }
+      const row = await q.find(coerceId(req.params.id));
+      if (!row) {
+        res.status(404).json({ error: `${name} not found` });
+        return;
+      }
+      res.json(row);
+    });
+  }
+  private bindCreate(
+    router: IAppRouter,
+    name: string,
+    table: AppKitTable,
+    access: HttpAccess,
+  ): void {
+    this.bind(router, name, "create", "post", `/${name}`, async (req, res) => {
+      // Validate at the route boundary so bad browser requests get a 400 with
+      // structured Zod errors before hooks or database work run.
+      const parsed = table.$insertSchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(400).json({ errors: parsed.error.format() });
+        return;
+      }
+
+      // PostgREST-compatible upsert: a POST carrying `Prefer:
+      // resolution=merge-duplicates` plus `?on_conflict=<column>` is treated as
+      // INSERT ... ON CONFLICT DO UPDATE. Lets the browser client share one
+      // verb (POST) for both create and upsert.
+      const prefer = String(req.header("prefer") ?? "").toLowerCase();
+      const onConflict = req.query.on_conflict;
+      if (
+        prefer.includes("resolution=merge-duplicates") &&
+        typeof onConflict === "string" &&
+        onConflict
+      ) {
+        const row = await this.entity(req, access, name).upsert(
+          parsed.data as Record<string, unknown>,
+          { onConflict },
+        );
+        res.status(200).json(row);
+        return;
+      }
+
+      const row = await this.entity(req, access, name).create(
+        parsed.data as Record<string, unknown>,
+      );
+      res.status(201).json(row);
+    });
+  }
+  private bindUpdate(
+    router: IAppRouter,
+    name: string,
+    table: AppKitTable,
+    access: HttpAccess,
+  ): void {
+    this.bind(
+      router,
+      name,
+      "update",
+      "patch",
+      `/${name}/:id`,
+      async (req, res) => {
+        // Same boundary validation as create(), but using the update schema so
+        // partial patches are accepted.
+        const parsed = table.$updateSchema.safeParse(req.body);
+        if (!parsed.success) {
+          res.status(400).json({ errors: parsed.error.format() });
+          return;
+        }
+        const row = await this.entity(req, access, name).update(
+          coerceId(req.params.id),
+          parsed.data as Partial<Record<string, unknown>>,
+        );
+        res.json(row);
+      },
+    );
+  }
+  private bindDelete(
+    router: IAppRouter,
+    name: string,
+    access: HttpAccess,
+  ): void {
+    this.bind(
+      router,
+      name,
+      "delete",
+      "delete",
+      `/${name}/:id`,
+      async (req, res) => {
+        await this.entity(req, access, name).delete(coerceId(req.params.id));
+        res.status(204).end();
+      },
+    );
+  }
+  private entity(
+    req: express.Request,
+    access: HttpAccess,
+    name: string,
+  ): EntityClient {
+    // `public` and `service` both resolve to the SP entity surface today. The
+    // distinction is still kept in config so future policy/logging can treat
+    // them differently without changing route registration.
+    const entity = this.options.getSurface(req, access)[name];
+    if (!entity) {
+      throw new Error(`Database entity "${name}" is not available`);
+    }
+    return entity;
+  }
+  private bind(
+    router: IAppRouter,
+    entity: string,
+    verb: Verb,
+    method: "get" | "post" | "patch" | "delete",
+    path: string,
+    handler: (req: express.Request, res: express.Response) => Promise<void>,
+  ): void {
+    // Central route wrapper: Plugin#route handles endpoint registration, while
+    // this wrapper keeps generated handlers from leaking raw exceptions.
+    this.options.route(router, {
+      name: `${entity}.${verb}`,
+      method,
+      path,
+      handler: async (req, res) => {
+        try {
+          await handler(req, res);
+        } catch (error) {
+          logger.error("database route %s %s failed: %O", method, path, error);
+          res.status(500).json({
+            error: error instanceof Error ? error.message : "Server error",
+          });
+        }
+      },
+    });
+  }
+}
+function resolveAccess(
+  override?: HttpEntityOverride,
+): Record<Verb, HttpAccess> {
+  // Missing config is intentionally not "public". App authors must opt into
+  // non-OBO HTTP exposure verb by verb.
+  return { ...DEFAULT_ACCESS, ...override };
+}
+
+function applyFilters(
+  q: EntityClient,
+  query: express.Request["query"],
+  cols: ReadonlySet<string>,
+): EntityClient {
+  let next = q;
+
+  // Query params follow `column=operator.value`. Params for undeclared columns
+  // are ignored rather than forwarded, which avoids accidentally exposing
+  // hidden columns as filterable HTTP surface.
+  for (const [key, raw] of Object.entries(query)) {
+    if (RESERVED_QUERY_KEYS.has(key) || !cols.has(key)) continue;
+    const value = String(Array.isArray(raw) ? raw[0] : raw);
+    const dot = value.indexOf(".");
+    if (dot < 0) {
+      // Bare `?role=admin` is shorthand for `eq.admin`.
+      next = next.where({ [key]: coerceScalar(value) } as WhereInput<
+        Record<string, unknown>
+      >);
+      continue;
+    }
+    const op = value.slice(0, dot);
+    if (!ALLOWED_OPS.has(op)) continue;
+    next = next.where({
+      [key]: { [op]: coerceFilterValue(op, value.slice(dot + 1)) },
+    } as WhereInput<Record<string, unknown>>);
+  }
+  return next;
+}
+function applyOrder(
+  q: EntityClient,
+  raw: string,
+  cols: ReadonlySet<string>,
+): EntityClient {
+  const order: Record<string, "asc" | "desc"> = {};
+
+  // PostGREST-style order list: `?order=email.desc,createdAt.asc`.
+  // Unknown columns are skipped for the same reason filters are constrained.
+  for (const clause of raw.split(",")) {
+    const [column, direction] = clause.split(".");
+    if (!cols.has(column)) continue;
+    order[column] = direction === "desc" ? "desc" : "asc";
+  }
+  return Object.keys(order).length ? q.order(order) : q;
+}
+function clampLimit(value: number): number {
+  // Hard clamp keeps accidental large browser reads from turning into expensive
+  // table scans. Callers that need more should page explicitly.
+  if (!Number.isFinite(value) || value <= 0) return DEFAULT_LIMIT;
+  return Math.min(MAX_LIMIT, Math.floor(value));
+}
+function coerceFilterValue(op: string, value: string): unknown {
+  if (op === "in") {
+    // Support both `in.(a,b)` and `in.a,b` shapes; the former matches PostGREST
+    // URLs while the latter is a little easier to type by hand.
+    const body =
+      value.startsWith("(") && value.endsWith(")") ? value.slice(1, -1) : value;
+    return body.split(",").map(coerceScalar);
+  }
+  return coerceScalar(value);
+}
+function coerceScalar(value: string): unknown {
+  // Keep coercion intentionally small and predictable. Anything more complex
+  // should be expressed by the client as a string and interpreted by Postgres.
+  if (value === "true") return true;
+  if (value === "false") return false;
+  if (value === "null") return null;
+  if (value !== "" && !Number.isNaN(Number(value))) return Number(value);
+  return value;
+}
+function coerceId(raw: string): string | number {
+  // Numeric path ids become numbers so serial primary keys behave naturally;
+  // UUIDs and other string ids pass through untouched.
+  const numberValue = Number(raw);
+  return Number.isFinite(numberValue) && String(numberValue) === raw
+    ? numberValue
+    : raw;
+}

--- a/packages/appkit/src/plugins/database/route-generator.ts
+++ b/packages/appkit/src/plugins/database/route-generator.ts
@@ -90,7 +90,14 @@ export class RouteGenerator {
     table: AppKitTable,
   ): void {
     const access = resolveAccess(this.options.config.http?.[name]);
-    const cols = new Set(Object.keys(table.$columns));
+    // Private columns are excluded from the HTTP-addressable surface entirely:
+    // not filterable, not selectable. The entity client enforces the same
+    // policy for default reads; this set protects the parsing layer.
+    const cols = new Set(
+      Object.entries(table.$columns)
+        .filter(([, meta]) => meta.private !== true)
+        .map(([colName]) => colName),
+    );
 
     // Six conventional routes per entity. A verb set to `false` is skipped
     // entirely so disabled endpoints are not present in Express at all.

--- a/packages/appkit/src/plugins/database/route-generator.ts
+++ b/packages/appkit/src/plugins/database/route-generator.ts
@@ -1,6 +1,8 @@
 import type express from "express";
 import type { IAppRouter, RouteConfig } from "shared";
+import { ZodError } from "zod";
 import type { AppKitTable, Schema } from "@/database";
+import { AppKitError } from "@/errors";
 import { createLogger } from "@/logging/logger";
 import type { EntityClient, WhereInput } from "./entity-proxy";
 import type { HttpAccess, HttpEntityOverride, IDatabaseConfig } from "./types";
@@ -26,7 +28,14 @@ const MAX_LIMIT = 500;
 
 // These query params control the shape of the read. Everything else is treated
 // as a potential column filter, but only if it matches a declared schema column.
-const RESERVED_QUERY_KEYS = new Set(["select", "order", "limit", "offset"]);
+const RESERVED_QUERY_KEYS = new Set([
+  "select",
+  "order",
+  "limit",
+  "offset",
+  "include",
+  "on_conflict",
+]);
 
 // Keep the HTTP dialect intentionally identical to PostGREST's builder methods:
 // `?age=gte.18`, `?name=ilike.%foo%`, `?id=in.(1,2,3)`.
@@ -64,7 +73,7 @@ interface RouteGeneratorOptions {
  * This class deliberately does not know about PostGREST clients, pg pools, or
  * auth internals. It translates Express requests into the L3 EntityClient API;
  * the entity client then handles validation, hooks, execute wrapping, retries,
- * cache, telemetry, and PostGREST calls.
+ * cache, telemetry, and DataPath calls.
  */
 export class RouteGenerator {
   constructor(private readonly options: RouteGeneratorOptions) {}
@@ -88,11 +97,9 @@ export class RouteGenerator {
     if (access.list !== false) this.bindList(router, name, cols, access.list);
     if (access.count !== false)
       this.bindCount(router, name, cols, access.count);
-    if (access.find !== false) this.bindFind(router, name, access.find);
-    if (access.create !== false)
-      this.bindCreate(router, name, table, access.create);
-    if (access.update !== false)
-      this.bindUpdate(router, name, table, access.update);
+    if (access.find !== false) this.bindFind(router, name, cols, access.find);
+    if (access.create !== false) this.bindCreate(router, name, access.create);
+    if (access.update !== false) this.bindUpdate(router, name, access.update);
     if (access.delete !== false) this.bindDelete(router, name, access.delete);
   }
   private bindList(
@@ -103,17 +110,9 @@ export class RouteGenerator {
   ): void {
     this.bind(router, name, "list", "get", `/${name}`, async (req, res) => {
       let q = this.entity(req, access, name);
-
-      // Filters are applied inline here on purpose. A separate parser would just
-      // duplicate PostGREST's operator vocabulary and create another abstraction
-      // to keep in sync.
       q = applyFilters(q, req.query, cols);
-
-      // Forward `?select=*,posts(*)` and plain column lists to EntityClient's raw
-      // select overload. This is what lets browser `.include()` work end to end.
-      if (typeof req.query.select === "string") {
-        q = q.select(req.query.select);
-      }
+      q = applySelect(q, req.query.select, cols);
+      q = applyInclude(q, req.query.include);
       if (typeof req.query.order === "string") {
         q = applyOrder(q, req.query.order, cols);
       }
@@ -122,8 +121,6 @@ export class RouteGenerator {
           ? clampLimit(Number(req.query.limit))
           : DEFAULT_LIMIT,
       );
-
-      // EntityClient defers offset+limit translation into PostGREST range().
       if (typeof req.query.offset === "string") {
         const offset = Number(req.query.offset);
         if (Number.isFinite(offset) && offset >= 0) {
@@ -153,14 +150,16 @@ export class RouteGenerator {
       },
     );
   }
-  private bindFind(router: IAppRouter, name: string, access: HttpAccess): void {
+  private bindFind(
+    router: IAppRouter,
+    name: string,
+    cols: ReadonlySet<string>,
+    access: HttpAccess,
+  ): void {
     this.bind(router, name, "find", "get", `/${name}/:id`, async (req, res) => {
       let q = this.entity(req, access, name);
-
-      // Useful for embedded reads like /user/1?select=*,posts(*).
-      if (typeof req.query.select === "string") {
-        q = q.select(req.query.select);
-      }
+      q = applySelect(q, req.query.select, cols);
+      q = applyInclude(q, req.query.include);
       const row = await q.find(coerceId(req.params.id));
       if (!row) {
         res.status(404).json({ error: `${name} not found` });
@@ -172,18 +171,9 @@ export class RouteGenerator {
   private bindCreate(
     router: IAppRouter,
     name: string,
-    table: AppKitTable,
     access: HttpAccess,
   ): void {
     this.bind(router, name, "create", "post", `/${name}`, async (req, res) => {
-      // Validate at the route boundary so bad browser requests get a 400 with
-      // structured Zod errors before hooks or database work run.
-      const parsed = table.$insertSchema.safeParse(req.body);
-      if (!parsed.success) {
-        res.status(400).json({ errors: parsed.error.format() });
-        return;
-      }
-
       // PostgREST-compatible upsert: a POST carrying `Prefer:
       // resolution=merge-duplicates` plus `?on_conflict=<column>` is treated as
       // INSERT ... ON CONFLICT DO UPDATE. Lets the browser client share one
@@ -196,7 +186,7 @@ export class RouteGenerator {
         onConflict
       ) {
         const row = await this.entity(req, access, name).upsert(
-          parsed.data as Record<string, unknown>,
+          req.body as Record<string, unknown>,
           { onConflict },
         );
         res.status(200).json(row);
@@ -204,7 +194,7 @@ export class RouteGenerator {
       }
 
       const row = await this.entity(req, access, name).create(
-        parsed.data as Record<string, unknown>,
+        req.body as Record<string, unknown>,
       );
       res.status(201).json(row);
     });
@@ -212,7 +202,6 @@ export class RouteGenerator {
   private bindUpdate(
     router: IAppRouter,
     name: string,
-    table: AppKitTable,
     access: HttpAccess,
   ): void {
     this.bind(
@@ -222,16 +211,9 @@ export class RouteGenerator {
       "patch",
       `/${name}/:id`,
       async (req, res) => {
-        // Same boundary validation as create(), but using the update schema so
-        // partial patches are accepted.
-        const parsed = table.$updateSchema.safeParse(req.body);
-        if (!parsed.success) {
-          res.status(400).json({ errors: parsed.error.format() });
-          return;
-        }
         const row = await this.entity(req, access, name).update(
           coerceId(req.params.id),
-          parsed.data as Partial<Record<string, unknown>>,
+          req.body as Partial<Record<string, unknown>>,
         );
         res.json(row);
       },
@@ -287,7 +269,13 @@ export class RouteGenerator {
           await handler(req, res);
         } catch (error) {
           logger.error("database route %s %s failed: %O", method, path, error);
-          res.status(500).json({
+          if (error instanceof ZodError) {
+            res.status(400).json({ errors: error.format() });
+            return;
+          }
+          const status =
+            error instanceof AppKitError ? error.statusCode : undefined;
+          res.status(status ?? 500).json({
             error: error instanceof Error ? error.message : "Server error",
           });
         }
@@ -332,6 +320,83 @@ function applyFilters(
   }
   return next;
 }
+/**
+ * Validate `?select=col1,col2` against the schema's columns and project.
+ * Unknown columns are dropped silently — same posture as `applyFilters` so
+ * undeclared columns never become HTTP-addressable.
+ */
+function applySelect(
+  q: EntityClient,
+  raw: unknown,
+  cols: ReadonlySet<string>,
+): EntityClient {
+  if (typeof raw !== "string" || raw.length === 0) return q;
+  const picked = raw
+    .split(",")
+    .map((c) => c.trim())
+    .filter((c) => cols.has(c));
+  return picked.length > 0 ? q.select(...picked) : q;
+}
+
+/**
+ * Parse `?include=posts,author` (or `?include=posts(id,title),author(name)`)
+ * and forward to `entity.include({ ... })`. The runtime resolves relation
+ * names against the schema's `$relations` metadata; unknown names throw at
+ * query time, so this parser intentionally trusts the caller.
+ */
+function applyInclude(q: EntityClient, raw: unknown): EntityClient {
+  if (typeof raw !== "string" || raw.length === 0) return q;
+  const include = parseIncludeSpec(raw);
+  return Object.keys(include).length > 0
+    ? (q.include(include) as EntityClient)
+    : q;
+}
+
+/**
+ * Tokenise an `?include=` value into `{ relation: true | { select: [...] } }`.
+ * Splits on top-level commas (paren-aware) and parses each `name(col,col)`
+ * fragment. Whitespace is trimmed everywhere; empty fragments are skipped.
+ */
+function parseIncludeSpec(
+  raw: string,
+): Record<string, true | { select: string[] }> {
+  const out: Record<string, true | { select: string[] }> = {};
+  let depth = 0;
+  let buf = "";
+  const fragments: string[] = [];
+  for (const ch of raw) {
+    if (ch === "(") depth++;
+    if (ch === ")") depth--;
+    if (ch === "," && depth === 0) {
+      fragments.push(buf);
+      buf = "";
+      continue;
+    }
+    buf += ch;
+  }
+  if (buf) fragments.push(buf);
+
+  for (const fragment of fragments) {
+    const trimmed = fragment.trim();
+    if (!trimmed) continue;
+    const open = trimmed.indexOf("(");
+    if (open < 0) {
+      out[trimmed] = true;
+      continue;
+    }
+    const close = trimmed.lastIndexOf(")");
+    const relation = trimmed.slice(0, open).trim();
+    if (!relation) continue;
+    const inner = close > open ? trimmed.slice(open + 1, close) : "";
+    const select = inner
+      .split(",")
+      .map((c) => c.trim())
+      .filter(Boolean);
+    out[relation] = select.length > 0 ? { select } : true;
+  }
+  return out;
+}
+
 function applyOrder(
   q: EntityClient,
   raw: string,
@@ -360,18 +425,50 @@ function coerceFilterValue(op: string, value: string): unknown {
     // URLs while the latter is a little easier to type by hand.
     const body =
       value.startsWith("(") && value.endsWith(")") ? value.slice(1, -1) : value;
-    return body.split(",").map(coerceScalar);
+    return splitList(body).map(coerceScalar);
   }
   return coerceScalar(value);
 }
 function coerceScalar(value: string): unknown {
   // Keep coercion intentionally small and predictable. Anything more complex
   // should be expressed by the client as a string and interpreted by Postgres.
+  if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
+    return value.slice(1, -1).replace(/\\"/g, '"');
+  }
   if (value === "true") return true;
   if (value === "false") return false;
   if (value === "null") return null;
   if (value !== "" && !Number.isNaN(Number(value))) return Number(value);
   return value;
+}
+function splitList(value: string): string[] {
+  const out: string[] = [];
+  let buf = "";
+  let inQuotes = false;
+  let escaped = false;
+
+  for (const ch of value) {
+    if (escaped) {
+      buf += ch;
+      escaped = false;
+      continue;
+    }
+    if (ch === "\\" && inQuotes) {
+      buf += ch;
+      escaped = true;
+      continue;
+    }
+    if (ch === '"') inQuotes = !inQuotes;
+    if (ch === "," && !inQuotes) {
+      out.push(buf);
+      buf = "";
+      continue;
+    }
+    buf += ch;
+  }
+
+  out.push(buf);
+  return out;
 }
 function coerceId(raw: string): string | number {
   // Numeric path ids become numbers so serial primary keys behave naturally;

--- a/packages/appkit/src/plugins/database/route-generator.ts
+++ b/packages/appkit/src/plugins/database/route-generator.ts
@@ -8,6 +8,55 @@ import { DatabaseRouteError } from "./database";
 import type { EntityClient, WhereInput } from "./entity-proxy";
 import type { HttpAccess, HttpEntityOverride, IDatabaseConfig } from "./types";
 
+type ColumnKind =
+  | "text"
+  | "number"
+  | "boolean"
+  | "date"
+  | "json"
+  | "uuid"
+  | "unknown";
+
+/**
+ * Read the Drizzle `columnType` off a table's `$drizzle` value to classify a
+ * column as text/number/boolean/etc. Used to keep `coerceFilterValue` and
+ * `coerceId` from over-eagerly coercing strings on text/uuid columns.
+ *
+ * Hand-rolled (rather than importing Drizzle's types) so this file stays out
+ * of the drizzle-orm import graph — `$drizzle` is `unknown` at the AppKit
+ * boundary, but the runtime layer already reads the same property names off
+ * it (see `database/runtime/drizzle-runtime.ts:getColumn`).
+ */
+function inferColumnKind(table: AppKitTable, name: string): ColumnKind {
+  const drizzleTable = table.$drizzle as
+    | Record<string, { columnType?: string } | undefined>
+    | undefined;
+  const ct = drizzleTable?.[name]?.columnType ?? "";
+  if (ct === "PgText" || ct === "PgVarchar") return "text";
+  if (
+    ct === "PgInteger" ||
+    ct === "PgSerial" ||
+    ct === "PgBigInt" ||
+    ct === "PgBigInt53"
+  ) {
+    return "number";
+  }
+  if (ct === "PgBoolean") return "boolean";
+  if (ct === "PgTimestamp") return "date";
+  if (ct === "PgJsonb" || ct === "PgJson") return "json";
+  if (ct === "PgUuid") return "uuid";
+  return "unknown";
+}
+
+function buildColumnKindMap(
+  table: AppKitTable,
+  cols: ReadonlySet<string>,
+): Map<string, ColumnKind> {
+  const out = new Map<string, ColumnKind>();
+  for (const name of cols) out.set(name, inferColumnKind(table, name));
+  return out;
+}
+
 const logger = createLogger("database:routes");
 
 type Verb = "list" | "find" | "count" | "create" | "update" | "delete";
@@ -64,6 +113,11 @@ interface RouteGeneratorOptions {
     req: express.Request,
     access: HttpAccess,
   ) => DatabaseExecutionSurface;
+  /**
+   * Service-principal pool used for the `_healthz` `SELECT 1` probe. Optional
+   * because some tests exercise the route generator without a real pool.
+   */
+  getServicePool?: () => import("pg").Pool;
   /** Bound wrapper around Plugin#route so endpoint registration stays central. */
   route: (router: IAppRouter, config: RouteConfig) => void;
 }
@@ -80,9 +134,46 @@ export class RouteGenerator {
   constructor(private readonly options: RouteGeneratorOptions) {}
 
   injectAll(router: IAppRouter): void {
+    this.bindHealth(router);
     for (const [name, table] of Object.entries(this.options.schema.$tables)) {
       this.injectEntity(router, name, table);
     }
+  }
+
+  /**
+   * Mount `GET /api/database/_healthz`. Runs a `SELECT 1` against the SP
+   * pool and returns `{ ok, poolStats }` so a load balancer can wait for the
+   * database side of the plugin to come up before routing traffic.
+   *
+   * The route is always public — readiness checks come from k8s/LB
+   * components that don't carry user auth headers.
+   */
+  private bindHealth(router: IAppRouter): void {
+    if (this.options.config.healthCheck === false) return;
+    const getPool = this.options.getServicePool;
+    if (!getPool) return;
+    this.options.route(router, {
+      name: "database._healthz",
+      method: "get",
+      path: "/_healthz",
+      handler: async (_req, res) => {
+        try {
+          const pool = getPool();
+          await pool.query("SELECT 1");
+          res.json({
+            ok: true,
+            poolStats: {
+              total: pool.totalCount,
+              idle: pool.idleCount,
+              waiting: pool.waitingCount,
+            },
+          });
+        } catch (error) {
+          logger.warn("database health check failed: %O", error);
+          res.status(503).json({ ok: false });
+        }
+      },
+    });
   }
 
   private injectEntity(
@@ -99,28 +190,41 @@ export class RouteGenerator {
         .filter(([, meta]) => meta.private !== true)
         .map(([colName]) => colName),
     );
+    const kinds = buildColumnKindMap(table, cols);
+    const pkColumn = derivePkColumnName(table);
+    const pkKind = pkColumn ? (kinds.get(pkColumn) ?? "unknown") : "unknown";
 
     // Six conventional routes per entity. A verb set to `false` is skipped
     // entirely so disabled endpoints are not present in Express at all.
-    if (access.list !== false) this.bindList(router, name, cols, access.list);
+    if (access.list !== false)
+      this.bindList(router, name, cols, kinds, access.list);
     if (access.count !== false)
-      this.bindCount(router, name, cols, access.count);
-    if (access.find !== false) this.bindFind(router, name, cols, access.find);
+      this.bindCount(router, name, cols, kinds, access.count);
+    if (access.find !== false)
+      this.bindFind(router, name, cols, kinds, pkKind, access.find);
     if (access.create !== false) this.bindCreate(router, name, access.create);
-    if (access.update !== false) this.bindUpdate(router, name, access.update);
-    if (access.delete !== false) this.bindDelete(router, name, access.delete);
+    if (access.update !== false)
+      this.bindUpdate(router, name, pkKind, access.update);
+    if (access.delete !== false)
+      this.bindDelete(router, name, pkKind, access.delete);
   }
   private bindList(
     router: IAppRouter,
     name: string,
     cols: ReadonlySet<string>,
+    kinds: ReadonlyMap<string, ColumnKind>,
     access: HttpAccess,
   ): void {
     this.bind(router, name, "list", "get", `/${name}`, async (req, res) => {
       let q = this.entity(req, access, name);
-      q = applyFilters(q, req.query, cols);
+      q = applyFilters(q, req.query, cols, kinds);
       q = applySelect(q, req.query.select, cols);
-      q = applyInclude(q, req.query.include);
+      q = applyInclude(
+        q,
+        req.query.include,
+        this.options.schema,
+        this.options.config,
+      );
       if (typeof req.query.order === "string") {
         q = applyOrder(q, req.query.order, cols);
       }
@@ -142,6 +246,7 @@ export class RouteGenerator {
     router: IAppRouter,
     name: string,
     cols: ReadonlySet<string>,
+    kinds: ReadonlyMap<string, ColumnKind>,
     access: HttpAccess,
   ): void {
     this.bind(
@@ -153,7 +258,12 @@ export class RouteGenerator {
       async (req, res) => {
         // Count supports the same column filters as list, but intentionally
         // ignores pagination and select/order shape controls.
-        const q = applyFilters(this.entity(req, access, name), req.query, cols);
+        const q = applyFilters(
+          this.entity(req, access, name),
+          req.query,
+          cols,
+          kinds,
+        );
         res.json({ count: await q.count() });
       },
     );
@@ -162,13 +272,20 @@ export class RouteGenerator {
     router: IAppRouter,
     name: string,
     cols: ReadonlySet<string>,
+    _kinds: ReadonlyMap<string, ColumnKind>,
+    pkKind: ColumnKind,
     access: HttpAccess,
   ): void {
     this.bind(router, name, "find", "get", `/${name}/:id`, async (req, res) => {
       let q = this.entity(req, access, name);
       q = applySelect(q, req.query.select, cols);
-      q = applyInclude(q, req.query.include);
-      const row = await q.find(coerceId(req.params.id));
+      q = applyInclude(
+        q,
+        req.query.include,
+        this.options.schema,
+        this.options.config,
+      );
+      const row = await q.find(coerceId(req.params.id, pkKind));
       if (!row) {
         res.status(404).json({ error: `${name} not found` });
         return;
@@ -210,6 +327,7 @@ export class RouteGenerator {
   private bindUpdate(
     router: IAppRouter,
     name: string,
+    pkKind: ColumnKind,
     access: HttpAccess,
   ): void {
     this.bind(
@@ -220,7 +338,7 @@ export class RouteGenerator {
       `/${name}/:id`,
       async (req, res) => {
         const row = await this.entity(req, access, name).update(
-          coerceId(req.params.id),
+          coerceId(req.params.id, pkKind),
           req.body as Partial<Record<string, unknown>>,
         );
         res.json(row);
@@ -230,6 +348,7 @@ export class RouteGenerator {
   private bindDelete(
     router: IAppRouter,
     name: string,
+    pkKind: ColumnKind,
     access: HttpAccess,
   ): void {
     this.bind(
@@ -239,7 +358,9 @@ export class RouteGenerator {
       "delete",
       `/${name}/:id`,
       async (req, res) => {
-        await this.entity(req, access, name).delete(coerceId(req.params.id));
+        await this.entity(req, access, name).delete(
+          coerceId(req.params.id, pkKind),
+        );
         res.status(204).end();
       },
     );
@@ -318,6 +439,7 @@ function applyFilters(
   q: EntityClient,
   query: express.Request["query"],
   cols: ReadonlySet<string>,
+  kinds: ReadonlyMap<string, ColumnKind>,
 ): EntityClient {
   let next = q;
 
@@ -326,20 +448,55 @@ function applyFilters(
   // hidden columns as filterable HTTP surface.
   for (const [key, raw] of Object.entries(query)) {
     if (RESERVED_QUERY_KEYS.has(key) || !cols.has(key)) continue;
-    const value = String(Array.isArray(raw) ? raw[0] : raw);
-    const dot = value.indexOf(".");
-    if (dot < 0) {
-      // Bare `?role=admin` is shorthand for `eq.admin`.
-      next = next.where({ [key]: coerceScalar(value) } as WhereInput<
-        Record<string, unknown>
-      >);
+    const kind = kinds.get(key) ?? "unknown";
+    const values = Array.isArray(raw) ? raw : [raw];
+    const decoded: unknown[] = [];
+    for (const v of values) {
+      const value = String(v);
+      const dot = value.indexOf(".");
+      if (dot < 0) {
+        decoded.push(coerceScalarTyped(value, kind));
+        continue;
+      }
+      const op = value.slice(0, dot);
+      if (!ALLOWED_OPS.has(op)) continue;
+      decoded.push({ [op]: coerceFilterValue(op, value.slice(dot + 1), kind) });
+    }
+    if (decoded.length === 0) continue;
+    if (decoded.length === 1) {
+      const only = decoded[0];
+      next = next.where({
+        [key]:
+          typeof only === "object" && only !== null && !Array.isArray(only)
+            ? (only as Record<string, unknown>)
+            : (only as unknown),
+      } as WhereInput<Record<string, unknown>>);
       continue;
     }
-    const op = value.slice(0, dot);
-    if (!ALLOWED_OPS.has(op)) continue;
-    next = next.where({
-      [key]: { [op]: coerceFilterValue(op, value.slice(dot + 1)) },
-    } as WhereInput<Record<string, unknown>>);
+    // Multiple values for the same key: prefer to AND them together by merging
+    // every decoded predicate (`?col=eq.a&col=neq.b` means both). When every
+    // entry is a bare scalar, treat it as `IN (...)` for the natural duplicate
+    // shape used by HTML forms (`col=a&col=b`).
+    const allScalars = decoded.every(
+      (d) => typeof d !== "object" || d === null || Array.isArray(d),
+    );
+    if (allScalars) {
+      next = next.where({
+        [key]: { in: decoded },
+      } as WhereInput<Record<string, unknown>>);
+      continue;
+    }
+    const merged: Record<string, unknown> = {};
+    for (const entry of decoded) {
+      if (
+        typeof entry === "object" &&
+        entry !== null &&
+        !Array.isArray(entry)
+      ) {
+        Object.assign(merged, entry);
+      }
+    }
+    next = next.where({ [key]: merged } as WhereInput<Record<string, unknown>>);
   }
   return next;
 }
@@ -367,9 +524,34 @@ function applySelect(
  * names against the schema's `$relations` metadata; unknown names throw at
  * query time, so this parser intentionally trusts the caller.
  */
-function applyInclude(q: EntityClient, raw: unknown): EntityClient {
+function applyInclude(
+  q: EntityClient,
+  raw: unknown,
+  schema: Schema,
+  config: IDatabaseConfig,
+): EntityClient {
   if (typeof raw !== "string" || raw.length === 0) return q;
   const include = parseIncludeSpec(raw);
+
+  // Strip select columns that don't exist on the related table or are
+  // private. Keeps `?include=author(password_hash)` from leaking secrets.
+  // Unknown relation names are passed through — the runtime layer is
+  // authoritative about what relations exist and rejects them at query time.
+  for (const [relation, spec] of Object.entries(include)) {
+    if (spec === true) continue;
+    const relatedTable = schema.$tables[relation];
+    if (!relatedTable) continue;
+    const allow = new Set(
+      Object.entries(relatedTable.$columns)
+        .filter(
+          ([, meta]) =>
+            meta.private !== true && config.http?.[relation]?.list !== false,
+        )
+        .map(([colName]) => colName),
+    );
+    spec.select = spec.select.filter((c) => allow.has(c));
+  }
+
   return Object.keys(include).length > 0
     ? (q.include(include) as EntityClient)
     : q;
@@ -442,27 +624,51 @@ function clampLimit(value: number): number {
   if (!Number.isFinite(value) || value <= 0) return DEFAULT_LIMIT;
   return Math.min(MAX_LIMIT, Math.floor(value));
 }
-function coerceFilterValue(op: string, value: string): unknown {
+function coerceFilterValue(
+  op: string,
+  value: string,
+  kind: ColumnKind,
+): unknown {
   if (op === "in") {
     // Support both `in.(a,b)` and `in.a,b` shapes; the former matches PostGREST
     // URLs while the latter is a little easier to type by hand.
     const body =
       value.startsWith("(") && value.endsWith(")") ? value.slice(1, -1) : value;
-    return splitList(body).map(coerceScalar);
+    return splitList(body).map((part) => coerceScalarTyped(part, kind));
   }
-  return coerceScalar(value);
+  if (op === "like" || op === "ilike") return value;
+  return coerceScalarTyped(value, kind);
 }
-function coerceScalar(value: string): unknown {
-  // Keep coercion intentionally small and predictable. Anything more complex
-  // should be expressed by the client as a string and interpreted by Postgres.
+/**
+ * Type-aware scalar coercion for filter values pulled out of the query string.
+ *
+ * Text/uuid/json columns get the raw string back so a value like `"true"`,
+ * `"null"`, or `"42"` is filtered as the literal string the user typed.
+ * Number/boolean/date columns get the same heuristic as before so
+ * `?count=eq.42` still works.
+ */
+function coerceScalarTyped(value: string, kind: ColumnKind): unknown {
   if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
     return value.slice(1, -1).replace(/\\"/g, '"');
   }
+  if (kind === "text" || kind === "uuid" || kind === "json") return value;
   if (value === "true") return true;
   if (value === "false") return false;
   if (value === "null") return null;
-  if (value !== "" && !Number.isNaN(Number(value))) return Number(value);
+  if (
+    (kind === "number" || kind === "unknown") &&
+    value !== "" &&
+    !Number.isNaN(Number(value))
+  ) {
+    return Number(value);
+  }
   return value;
+}
+function coerceScalar(value: string): unknown {
+  // Kept for callers that have no column-kind context. Behaves like the old
+  // heuristic — prefer `coerceScalarTyped(value, kind)` when the column kind
+  // is available so we don't reinterpret strings on text columns.
+  return coerceScalarTyped(value, "unknown");
 }
 function splitList(value: string): string[] {
   const out: string[] = [];
@@ -493,11 +699,19 @@ function splitList(value: string): string[] {
   out.push(buf);
   return out;
 }
-function coerceId(raw: string): string | number {
-  // Numeric path ids become numbers so serial primary keys behave naturally;
-  // UUIDs and other string ids pass through untouched.
+function coerceId(raw: string, kind: ColumnKind): string | number {
+  // Honor the declared PK type. Text/uuid PKs that happen to look numeric
+  // (`"123"`) used to be silently turned into numbers — now they pass through.
+  if (kind === "text" || kind === "uuid") return raw;
   const numberValue = Number(raw);
   return Number.isFinite(numberValue) && String(numberValue) === raw
     ? numberValue
     : raw;
+}
+
+function derivePkColumnName(table: AppKitTable): string | null {
+  for (const [name, meta] of Object.entries(table.$columns)) {
+    if (meta.primaryKey) return name;
+  }
+  return Object.keys(table.$columns).includes("id") ? "id" : null;
 }

--- a/packages/appkit/src/plugins/database/route-generator.ts
+++ b/packages/appkit/src/plugins/database/route-generator.ts
@@ -4,6 +4,7 @@ import { ZodError } from "zod";
 import type { AppKitTable, Schema } from "@/database";
 import { AppKitError } from "@/errors";
 import { createLogger } from "@/logging/logger";
+import { DatabaseRouteError } from "./database";
 import type { EntityClient, WhereInput } from "./entity-proxy";
 import type { HttpAccess, HttpEntityOverride, IDatabaseConfig } from "./types";
 
@@ -280,11 +281,26 @@ export class RouteGenerator {
             res.status(400).json({ errors: error.format() });
             return;
           }
-          const status =
-            error instanceof AppKitError ? error.statusCode : undefined;
-          res.status(status ?? 500).json({
-            error: error instanceof Error ? error.message : "Server error",
-          });
+          // AppKitError messages are author-controlled (404/409/etc) and safe.
+          // DatabaseRouteError carries the status from Plugin#execute (already
+          // scrubbed for prod). Anything else is a raw thrown Error — show its
+          // message in dev, scrub to "Server error" in prod to avoid leaking
+          // stack/internal hints.
+          if (error instanceof AppKitError) {
+            res.status(error.statusCode).json({ error: error.message });
+            return;
+          }
+          if (error instanceof DatabaseRouteError) {
+            res.status(error.statusCode).json({ error: error.message });
+            return;
+          }
+          const fallback =
+            process.env.NODE_ENV === "production"
+              ? "Server error"
+              : error instanceof Error
+                ? error.message
+                : "Server error";
+          res.status(500).json({ error: fallback });
         }
       },
     });

--- a/packages/appkit/src/plugins/database/tests/entity-proxy.test.ts
+++ b/packages/appkit/src/plugins/database/tests/entity-proxy.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, test, vi } from "vitest";
+import type { DataPath } from "@/database";
+import { defineSchema, id, text } from "../../../database";
+import { type ExecutorFn, makeEntityClient } from "../entity-proxy";
+
+const schema = defineSchema(({ table }) => ({
+  user: table("user", {
+    id: id(),
+    email: text().notNull(),
+    role: text().default("member"),
+  }),
+}));
+
+function makeExecutor() {
+  return vi.fn(async (fn: (signal?: AbortSignal) => Promise<unknown>) =>
+    fn(new AbortController().signal),
+  ) as unknown as ExecutorFn & ReturnType<typeof vi.fn>;
+}
+
+/**
+ * Build a fake `DataPath` whose every method records its call args. Each
+ * method returns the supplied fixture row (or rows). This is much smaller
+ * than the previous postgrest-builder mock because the surface is flat — no
+ * chain to fake.
+ */
+function fakeDataPath(
+  rows: Record<string, unknown>[] = [{ id: 1, email: "a@x" }],
+) {
+  const calls: Array<{ method: keyof DataPath; args: unknown[] }> = [];
+  const path: DataPath = {
+    select: vi.fn(async (...args) => {
+      calls.push({ method: "select", args });
+      return rows;
+    }),
+    findOne: vi.fn(async (...args) => {
+      calls.push({ method: "findOne", args });
+      return rows[0] ?? null;
+    }),
+    count: vi.fn(async (...args) => {
+      calls.push({ method: "count", args });
+      return rows.length;
+    }),
+    insert: vi.fn(async (...args) => {
+      calls.push({ method: "insert", args });
+      return rows[0] ?? { id: 1 };
+    }),
+    update: vi.fn(async (...args) => {
+      calls.push({ method: "update", args });
+      return rows[0] ?? { id: 1 };
+    }),
+    upsert: vi.fn(async (...args) => {
+      calls.push({ method: "upsert", args });
+      return rows[0] ?? { id: 1 };
+    }),
+    delete: vi.fn(async (...args) => {
+      calls.push({ method: "delete", args });
+    }),
+    transaction: vi.fn(async (fn) => fn(path)),
+    raw: vi.fn(async () => rows as never[]),
+  };
+  return { path, calls };
+}
+
+function makeClient(
+  execute = makeExecutor(),
+  rows = [{ id: 1, email: "a@x" }],
+) {
+  const dataPath = fakeDataPath(rows);
+  const client = makeEntityClient({
+    table: schema.user,
+    entity: "user",
+    dataPath: dataPath.path,
+    execute,
+    makeUserDataPath: () => dataPath.path,
+    hookContext: () => ({ entity: "user" }),
+  });
+  return { client, execute, dataPath };
+}
+
+describe("EntityClient", () => {
+  test("forwards filters/order/pagination/include into DataPath.select", async () => {
+    const { client, dataPath } = makeClient();
+
+    await client
+      .where({ role: "admin", id: { gte: 1 } })
+      .order({ email: "desc" })
+      .include({ posts: { select: ["id", "title"], limit: 5 } })
+      .limit(10)
+      .offset(20)
+      .toArray();
+
+    expect(dataPath.path.select).toHaveBeenCalledTimes(1);
+    const args = dataPath.calls[0].args[1] as Record<string, unknown>;
+    expect(args.where).toEqual({ role: "admin", id: { gte: 1 } });
+    expect(args.order).toEqual({ email: "desc" });
+    expect(args.limit).toBe(10);
+    expect(args.offset).toBe(20);
+    expect(args.include).toEqual({
+      posts: { select: ["id", "title"], limit: 5 },
+    });
+  });
+
+  test("every terminator runs through the bound executor", async () => {
+    const cases: Array<
+      (
+        client: ReturnType<typeof makeEntityClient<Record<string, unknown>>>,
+      ) => Promise<unknown>
+    > = [
+      (client) => client.toArray(),
+      (client) => client.first(),
+      (client) => client.find(1),
+      (client) => client.count(),
+      (client) => client.create({ email: "a@x" }),
+      (client) => client.update(1, { role: "admin" }),
+      (client) => client.upsert({ email: "b@x" }, { onConflict: "email" }),
+      (client) => client.delete(1),
+    ];
+
+    for (const run of cases) {
+      const execute = makeExecutor();
+      const { client } = makeClient(execute);
+
+      await run(client);
+
+      expect(execute).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  test("create and update hooks can rewrite payloads before validation", async () => {
+    const beforeCreate = vi.fn(async (data: Record<string, unknown>) => ({
+      ...data,
+      role: "admin",
+    }));
+    const beforeUpdate = vi.fn(
+      async (_id: unknown, data: Record<string, unknown>) => ({
+        ...data,
+        role: "owner",
+      }),
+    );
+    const dataPath = fakeDataPath([{ id: 1, email: "a@x", role: "admin" }]);
+    const client = makeEntityClient({
+      table: schema.user,
+      entity: "user",
+      dataPath: dataPath.path,
+      execute: makeExecutor(),
+      makeUserDataPath: () => dataPath.path,
+      hooks: { beforeCreate, beforeUpdate },
+      hookContext: () => ({ entity: "user" }),
+    });
+
+    await client.create({ email: "a@x" });
+    await client.update(1, { email: "b@x" });
+
+    expect(beforeCreate).toHaveBeenCalled();
+    expect(beforeUpdate).toHaveBeenCalled();
+    expect(dataPath.path.insert).toHaveBeenCalledWith(
+      schema.user,
+      expect.objectContaining({ role: "admin" }),
+      expect.anything(),
+    );
+    expect(dataPath.path.update).toHaveBeenCalledWith(
+      schema.user,
+      "id",
+      1,
+      expect.objectContaining({ role: "owner" }),
+      expect.anything(),
+    );
+  });
+
+  test("asUser builds a fresh user-mode DataPath when the OBO header is present", async () => {
+    const serviceDataPath = fakeDataPath([]);
+    const userDataPath = fakeDataPath([{ id: 1, email: "u@x" }]);
+    const makeUserDataPath = vi.fn(() => userDataPath.path);
+    const client = makeEntityClient({
+      table: schema.user,
+      entity: "user",
+      dataPath: serviceDataPath.path,
+      execute: makeExecutor(),
+      makeUserDataPath,
+      hookContext: () => ({ entity: "user" }),
+    });
+    const req = {
+      header: vi.fn((name: string) =>
+        name === "x-forwarded-email" ? "user@example.com" : undefined,
+      ),
+    } as unknown as import("express").Request;
+
+    await client.asUser(req).toArray();
+
+    expect(makeUserDataPath).toHaveBeenCalledWith(req);
+    expect(userDataPath.path.select).toHaveBeenCalled();
+    expect(serviceDataPath.path.select).not.toHaveBeenCalled();
+  });
+
+  test("asUser falls through to self when no per-user DataPath is available", async () => {
+    const serviceDataPath = fakeDataPath([{ id: 1, email: "x@x" }]);
+    const client = makeEntityClient({
+      table: schema.user,
+      entity: "user",
+      dataPath: serviceDataPath.path,
+      execute: makeExecutor(),
+      makeUserDataPath: () => null,
+      hookContext: () => ({ entity: "user" }),
+    });
+    const req = {
+      header: vi.fn(() => undefined),
+    } as unknown as import("express").Request;
+
+    await client.asUser(req).toArray();
+
+    expect(serviceDataPath.path.select).toHaveBeenCalled();
+  });
+});

--- a/packages/appkit/src/plugins/database/tests/entity-proxy.test.ts
+++ b/packages/appkit/src/plugins/database/tests/entity-proxy.test.ts
@@ -109,6 +109,24 @@ describe("EntityClient", () => {
     expect(args.limit).toBe(500);
   });
 
+  test("toArray() applies MAX_LIMIT when no limit is set", async () => {
+    const { client, dataPath } = makeClient();
+
+    await client.toArray();
+
+    const args = dataPath.calls[0].args[1] as Record<string, unknown>;
+    expect(args.limit).toBe(500);
+  });
+
+  test("unbounded() removes the default cap on toArray()", async () => {
+    const { client, dataPath } = makeClient();
+
+    await client.unbounded().toArray();
+
+    const args = dataPath.calls[0].args[1] as Record<string, unknown>;
+    expect(args.limit).toBeUndefined();
+  });
+
   test("private columns are excluded from default reads and from select()", async () => {
     const sensitive = defineSchema(({ table }) => ({
       user: table("user", {

--- a/packages/appkit/src/plugins/database/tests/entity-proxy.test.ts
+++ b/packages/appkit/src/plugins/database/tests/entity-proxy.test.ts
@@ -109,6 +109,38 @@ describe("EntityClient", () => {
     expect(args.limit).toBe(500);
   });
 
+  test("private columns are excluded from default reads and from select()", async () => {
+    const sensitive = defineSchema(({ table }) => ({
+      user: table("user", {
+        id: id(),
+        email: text().notNull(),
+        passwordHash: text().notNull().private(),
+      }),
+    }));
+    const dataPath = fakeDataPath([
+      { id: 1, email: "a@x", passwordHash: "secret" },
+    ]);
+    const client = makeEntityClient({
+      table: sensitive.user,
+      entity: "user",
+      dataPath: dataPath.path,
+      execute: makeExecutor(),
+      makeUserDataPath: () => dataPath.path,
+      hookContext: () => ({ entity: "user" }),
+    });
+
+    await client.toArray();
+    const defaultArgs = dataPath.calls[0].args[1] as Record<string, unknown>;
+    expect(defaultArgs.columns).toEqual(["id", "email"]);
+
+    dataPath.calls.length = 0;
+    await client
+      .select("id" as never, "email" as never, "passwordHash" as never)
+      .toArray();
+    const selectedArgs = dataPath.calls[0].args[1] as Record<string, unknown>;
+    expect(selectedArgs.columns).toEqual(["id", "email"]);
+  });
+
   test("every terminator runs through the bound executor", async () => {
     const cases: Array<
       (

--- a/packages/appkit/src/plugins/database/tests/entity-proxy.test.ts
+++ b/packages/appkit/src/plugins/database/tests/entity-proxy.test.ts
@@ -226,6 +226,60 @@ describe("EntityClient", () => {
     );
   });
 
+  test("afterCreate, afterUpdate, before/afterDelete are awaited and passed the row", async () => {
+    const afterCreate = vi.fn(async () => undefined);
+    const afterUpdate = vi.fn(async () => undefined);
+    const beforeDelete = vi.fn(async () => undefined);
+    const afterDelete = vi.fn(async () => undefined);
+    const dataPath = fakeDataPath([{ id: 1, email: "a@x", role: "member" }]);
+    const client = makeEntityClient({
+      table: schema.user,
+      entity: "user",
+      dataPath: dataPath.path,
+      execute: makeExecutor(),
+      makeUserDataPath: () => dataPath.path,
+      hooks: { afterCreate, afterUpdate, beforeDelete, afterDelete },
+      hookContext: () => ({ entity: "user" }),
+    });
+
+    await client.create({ email: "a@x" });
+    await client.update(1, { email: "b@x" });
+    await client.delete(1);
+
+    expect(afterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 1, email: "a@x" }),
+      { entity: "user" },
+    );
+    expect(afterUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 1 }),
+      { entity: "user" },
+    );
+    expect(beforeDelete).toHaveBeenCalledWith(1, { entity: "user" });
+    expect(afterDelete).toHaveBeenCalledWith(1, { entity: "user" });
+  });
+
+  test("upsert does NOT invoke beforeCreate/beforeUpdate (separate channel)", async () => {
+    const beforeCreate = vi.fn(async () => undefined);
+    const beforeUpdate = vi.fn(async () => undefined);
+    const beforeUpsert = vi.fn(async () => undefined);
+    const dataPath = fakeDataPath([{ id: 1, email: "a@x", role: "admin" }]);
+    const client = makeEntityClient({
+      table: schema.user,
+      entity: "user",
+      dataPath: dataPath.path,
+      execute: makeExecutor(),
+      makeUserDataPath: () => dataPath.path,
+      hooks: { beforeCreate, beforeUpdate, beforeUpsert },
+      hookContext: () => ({ entity: "user" }),
+    });
+
+    await client.upsert({ email: "a@x" }, { onConflict: "email" });
+
+    expect(beforeUpsert).toHaveBeenCalled();
+    expect(beforeCreate).not.toHaveBeenCalled();
+    expect(beforeUpdate).not.toHaveBeenCalled();
+  });
+
   test("upsert hooks can rewrite payloads before validation", async () => {
     const beforeUpsert = vi.fn(async (data: Record<string, unknown>) => ({
       ...data,

--- a/packages/appkit/src/plugins/database/tests/entity-proxy.test.ts
+++ b/packages/appkit/src/plugins/database/tests/entity-proxy.test.ts
@@ -100,6 +100,15 @@ describe("EntityClient", () => {
     });
   });
 
+  test("clamps read limits at the server-side maximum", async () => {
+    const { client, dataPath } = makeClient();
+
+    await client.limit(10_000).toArray();
+
+    const args = dataPath.calls[0].args[1] as Record<string, unknown>;
+    expect(args.limit).toBe(500);
+  });
+
   test("every terminator runs through the bound executor", async () => {
     const cases: Array<
       (
@@ -163,6 +172,38 @@ describe("EntityClient", () => {
       "id",
       1,
       expect.objectContaining({ role: "owner" }),
+      expect.anything(),
+    );
+  });
+
+  test("upsert hooks can rewrite payloads before validation", async () => {
+    const beforeUpsert = vi.fn(async (data: Record<string, unknown>) => ({
+      ...data,
+      role: "admin",
+    }));
+    const afterUpsert = vi.fn(async () => undefined);
+    const dataPath = fakeDataPath([{ id: 1, email: "a@x", role: "admin" }]);
+    const client = makeEntityClient({
+      table: schema.user,
+      entity: "user",
+      dataPath: dataPath.path,
+      execute: makeExecutor(),
+      makeUserDataPath: () => dataPath.path,
+      hooks: { beforeUpsert, afterUpsert },
+      hookContext: () => ({ entity: "user" }),
+    });
+
+    await client.upsert({ email: "a@x" }, { onConflict: "email" });
+
+    expect(beforeUpsert).toHaveBeenCalled();
+    expect(afterUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ role: "admin" }),
+      { entity: "user" },
+    );
+    expect(dataPath.path.upsert).toHaveBeenCalledWith(
+      schema.user,
+      expect.objectContaining({ role: "admin" }),
+      { onConflict: "email" },
       expect.anything(),
     );
   });

--- a/packages/appkit/src/plugins/database/tests/plugin.test.ts
+++ b/packages/appkit/src/plugins/database/tests/plugin.test.ts
@@ -28,7 +28,9 @@ vi.mock("../../../database", async () => {
       update: vi.fn(async () => ({})),
       upsert: vi.fn(async () => ({})),
       delete: vi.fn(async () => undefined),
-      transaction: vi.fn(async (fn: never) => fn as never),
+      transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) =>
+        fn({}),
+      ),
       raw: vi.fn(async () => []),
     })),
   };
@@ -93,7 +95,11 @@ describe("DatabasePlugin", () => {
       connectionTimeoutMillis: 3_000,
       maxUses: 1000,
     });
-    expect(plugin.exports()).toEqual({ getPool: expect.any(Function) });
+    expect(plugin.exports()).toMatchObject({
+      getPool: expect.any(Function),
+      transaction: expect.any(Function),
+      sql: expect.any(Function),
+    });
     expect((plugin.exports() as { getPool: () => Pool }).getPool()).toBe(pool);
   });
 
@@ -142,6 +148,34 @@ describe("DatabasePlugin", () => {
     expect(exports.user).toBeDefined();
     // The wiring goes through the SP pool; no Data API URL is required.
     expect(createLakebasePool).toHaveBeenCalled();
+  });
+
+  test("exports transaction(fn) and sql`` backed by the runtime data path", async () => {
+    const schema = defineSchema(({ table }) => ({
+      user: table("user", { id: id(), email: text().notNull() }),
+    }));
+    vi.mocked(loadSchemaByConvention).mockResolvedValue({
+      schema,
+      schemaPath: "/app/config/database/schema.ts",
+    });
+
+    const plugin = createPlugin();
+    await plugin.setup();
+
+    const exports = plugin.exports() as unknown as {
+      transaction: <T>(fn: (tx: unknown) => Promise<T>) => Promise<T>;
+      sql: (
+        strings: TemplateStringsArray,
+        ...values: unknown[]
+      ) => Promise<unknown[]>;
+    };
+    expect(typeof exports.transaction).toBe("function");
+    expect(typeof exports.sql).toBe("function");
+
+    // Round-trip through the stub DataPath wired in createDrizzleDataPath mock
+    // (top of this file). Both should resolve via the stubbed methods.
+    await expect(exports.transaction(async () => 42)).resolves.toBe(42);
+    await expect(exports.sql`select 1`).resolves.toEqual([]);
   });
 
   test("injectRoutes registers entity routes once schema is loaded", async () => {

--- a/packages/appkit/src/plugins/database/tests/plugin.test.ts
+++ b/packages/appkit/src/plugins/database/tests/plugin.test.ts
@@ -150,6 +150,69 @@ describe("DatabasePlugin", () => {
     expect(createLakebasePool).toHaveBeenCalled();
   });
 
+  test("entity asUser creates user-scoped pools and evicts by LRU limit", async () => {
+    const originalHost = process.env.DATABRICKS_HOST;
+    process.env.DATABRICKS_HOST = "https://example.cloud.databricks.com";
+    const servicePool = {
+      end: vi.fn(async () => undefined),
+    } as unknown as Pool;
+    const userOnePool = {
+      end: vi.fn(async () => undefined),
+    } as unknown as Pool;
+    const userTwoPool = {
+      end: vi.fn(async () => undefined),
+    } as unknown as Pool;
+    vi.mocked(createLakebasePool)
+      .mockReturnValueOnce(servicePool)
+      .mockReturnValueOnce(userOnePool)
+      .mockReturnValueOnce(userTwoPool);
+    const schema = defineSchema(({ table }) => ({
+      user: table("user", {
+        id: id(),
+        email: text().notNull(),
+      }),
+    }));
+    vi.mocked(loadSchemaByConvention).mockResolvedValue({
+      schema,
+      schemaPath: "/app/config/database/schema.ts",
+    });
+
+    const plugin = createPlugin({ oboPoolMax: 1 });
+    await plugin.setup();
+    const exports = plugin.exports() as unknown as {
+      user: {
+        asUser: (req: import("express").Request) => unknown;
+      };
+    };
+    const reqFor = (email: string, token: string) =>
+      ({
+        header: vi.fn((name: string) => {
+          if (name === "x-forwarded-email") return email;
+          if (name === "x-forwarded-access-token") return token;
+          return undefined;
+        }),
+      }) as unknown as import("express").Request;
+
+    exports.user.asUser(reqFor("one@example.com", "tok-1"));
+    exports.user.asUser(reqFor("two@example.com", "tok-2"));
+
+    expect(createLakebasePool).toHaveBeenCalledTimes(3);
+    expect(createLakebasePool).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        user: "one@example.com",
+        workspaceClient: expect.any(Object),
+      }),
+    );
+    expect(userOnePool.end).toHaveBeenCalled();
+    expect(userTwoPool.end).not.toHaveBeenCalled();
+    if (originalHost === undefined) {
+      delete process.env.DATABRICKS_HOST;
+    } else {
+      process.env.DATABRICKS_HOST = originalHost;
+    }
+  });
+
   test("exports transaction(fn) and sql`` backed by the runtime data path", async () => {
     const schema = defineSchema(({ table }) => ({
       user: table("user", { id: id(), email: text().notNull() }),

--- a/packages/appkit/src/plugins/database/tests/plugin.test.ts
+++ b/packages/appkit/src/plugins/database/tests/plugin.test.ts
@@ -36,6 +36,20 @@ vi.mock("../../../database", async () => {
   };
 });
 
+vi.mock("../../../context/service-context", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../context/service-context")
+  >("../../../context/service-context");
+  return {
+    ...actual,
+    ServiceContext: {
+      ...actual.ServiceContext,
+      createUserContext: vi.fn(() => ({})),
+      getClientOptions: vi.fn(() => ({})),
+    },
+  };
+});
+
 vi.mock("../../../cache", () => ({
   CacheManager: {
     getInstanceSync: vi.fn(() => ({
@@ -213,6 +227,51 @@ describe("DatabasePlugin", () => {
     }
   });
 
+  test("asUser routes getPool/transaction/sql through the user pool, not SP", async () => {
+    const originalHost = process.env.DATABRICKS_HOST;
+    process.env.DATABRICKS_HOST = "https://example.cloud.databricks.com";
+    const servicePool = {
+      end: vi.fn(async () => undefined),
+    } as unknown as Pool;
+    const userPool = {
+      end: vi.fn(async () => undefined),
+    } as unknown as Pool;
+    vi.mocked(createLakebasePool)
+      .mockReturnValueOnce(servicePool)
+      .mockReturnValueOnce(userPool);
+    const schema = defineSchema(({ table }) => ({
+      user: table("user", { id: id(), email: text().notNull() }),
+    }));
+    vi.mocked(loadSchemaByConvention).mockResolvedValue({
+      schema,
+      schemaPath: "/app/config/database/schema.ts",
+    });
+
+    const plugin = createPlugin();
+    await plugin.setup();
+
+    const req = {
+      header: vi.fn((name: string) => {
+        if (name === "x-forwarded-email") return "alice@example.com";
+        if (name === "x-forwarded-access-token") return "tok-alice";
+        if (name === "x-forwarded-user") return "alice@example.com";
+        return undefined;
+      }),
+    } as unknown as import("express").Request;
+
+    const userExports = (
+      plugin.asUser(req).exports() as unknown as { getPool: () => Pool }
+    ).getPool();
+
+    expect(userExports).toBe(userPool);
+    expect(userExports).not.toBe(servicePool);
+    if (originalHost === undefined) {
+      delete process.env.DATABRICKS_HOST;
+    } else {
+      process.env.DATABRICKS_HOST = originalHost;
+    }
+  });
+
   test("exports transaction(fn) and sql`` backed by the runtime data path", async () => {
     const schema = defineSchema(({ table }) => ({
       user: table("user", { id: id(), email: text().notNull() }),
@@ -323,11 +382,9 @@ describe("DatabasePlugin", () => {
     expect(pool.on).toHaveBeenCalledWith("connect", expect.any(Function));
     const handler = vi
       .mocked(pool.on)
-      .mock.calls.find(
-        ([event]) => event === "connect",
-      )?.[1] as unknown as (client: {
-      query: ReturnType<typeof vi.fn>;
-    }) => void;
+      .mock.calls.find(([event]) => event === "connect")?.[1] as unknown as (
+      client: { query: ReturnType<typeof vi.fn> },
+    ) => void;
     const client = { query: vi.fn(async () => ({})) };
     handler(client);
     expect(client.query).toHaveBeenCalledWith(
@@ -352,5 +409,66 @@ describe("DatabasePlugin", () => {
 
     const plugin = createPlugin({ tolerateSetupFailure: true });
     await expect(plugin.setup()).resolves.toBeUndefined();
+  });
+
+  test("closeAll drains evicted per-user pools, not just live ones", async () => {
+    const originalHost = process.env.DATABRICKS_HOST;
+    process.env.DATABRICKS_HOST = "https://example.cloud.databricks.com";
+    const servicePool = {
+      end: vi.fn(async () => undefined),
+      on: vi.fn(),
+    } as unknown as Pool;
+    let drainResolve: (() => void) | undefined;
+    const drainGate = new Promise<void>((resolve) => {
+      drainResolve = resolve;
+    });
+    const userOnePool = {
+      end: vi.fn(() => drainGate),
+      on: vi.fn(),
+    } as unknown as Pool;
+    const userTwoPool = {
+      end: vi.fn(async () => undefined),
+      on: vi.fn(),
+    } as unknown as Pool;
+    vi.mocked(createLakebasePool)
+      .mockReturnValueOnce(servicePool)
+      .mockReturnValueOnce(userOnePool)
+      .mockReturnValueOnce(userTwoPool);
+    const schema = defineSchema(({ table }) => ({
+      user: table("user", { id: id(), email: text().notNull() }),
+    }));
+    vi.mocked(loadSchemaByConvention).mockResolvedValue({
+      schema,
+      schemaPath: "/app/config/database/schema.ts",
+    });
+
+    const plugin = createPlugin({ oboPoolMax: 1 });
+    await plugin.setup();
+    const exports = plugin.exports() as unknown as {
+      user: { asUser: (req: import("express").Request) => unknown };
+    };
+    const reqFor = (email: string, token: string) =>
+      ({
+        header: vi.fn((name: string) => {
+          if (name === "x-forwarded-email") return email;
+          if (name === "x-forwarded-access-token") return token;
+          return undefined;
+        }),
+      }) as unknown as import("express").Request;
+
+    exports.user.asUser(reqFor("one@example.com", "tok-1"));
+    exports.user.asUser(reqFor("two@example.com", "tok-2"));
+
+    const drained = plugin.abortActiveOperations();
+    drainResolve?.();
+    await drained;
+
+    expect(userOnePool.end).toHaveBeenCalled();
+    expect(userTwoPool.end).toHaveBeenCalled();
+    if (originalHost === undefined) {
+      delete process.env.DATABRICKS_HOST;
+    } else {
+      process.env.DATABRICKS_HOST = originalHost;
+    }
   });
 });

--- a/packages/appkit/src/plugins/database/tests/plugin.test.ts
+++ b/packages/appkit/src/plugins/database/tests/plugin.test.ts
@@ -1,13 +1,38 @@
 import type { Pool } from "pg";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { createLakebasePool } from "../../../connectors/lakebase";
-import { defineSchema, id } from "../../../database";
+import { defineSchema, id, text } from "../../../database";
 import { loadSchemaByConvention } from "../convention";
 import { database } from "../database";
 
 vi.mock("../../../connectors/lakebase", () => ({
   createLakebasePool: vi.fn(),
+  createLakebasePostgrestClient: vi.fn(),
 }));
+
+vi.mock("../../../database", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../../database")>(
+      "../../../database",
+    );
+  return {
+    ...actual,
+    // The runtime is exercised by entity-proxy tests with a fake DataPath;
+    // here we only care that the plugin wires *something* per entity, so we
+    // stub the runtime to avoid initialising drizzle + node-postgres.
+    createDrizzleDataPath: vi.fn(() => ({
+      select: vi.fn(async () => []),
+      findOne: vi.fn(async () => null),
+      count: vi.fn(async () => 0),
+      insert: vi.fn(async () => ({})),
+      update: vi.fn(async () => ({})),
+      upsert: vi.fn(async () => ({})),
+      delete: vi.fn(async () => undefined),
+      transaction: vi.fn(async (fn: never) => fn as never),
+      raw: vi.fn(async () => []),
+    })),
+  };
+});
 
 vi.mock("../../../cache", () => ({
   CacheManager: {
@@ -92,6 +117,71 @@ describe("DatabasePlugin", () => {
       (plugin as unknown as { schema: typeof schema; schemaPath: string })
         .schemaPath,
     ).toBe("/app/config/database/schema.ts");
+  });
+
+  test("wires one entity client per schema table on the SP pool", async () => {
+    const schema = defineSchema(({ table }) => ({
+      user: table("user", {
+        id: id(),
+        email: text().notNull(),
+      }),
+    }));
+    vi.mocked(loadSchemaByConvention).mockResolvedValue({
+      schema,
+      schemaPath: "/app/config/database/schema.ts",
+    });
+
+    const plugin = createPlugin();
+    await plugin.setup();
+
+    const exports = plugin.exports() as unknown as {
+      getPool: () => Pool;
+      user: unknown;
+    };
+    expect(exports.getPool()).toBe(pool);
+    expect(exports.user).toBeDefined();
+    // The wiring goes through the SP pool; no Data API URL is required.
+    expect(createLakebasePool).toHaveBeenCalled();
+  });
+
+  test("injectRoutes registers entity routes once schema is loaded", async () => {
+    const schema = defineSchema(({ table }) => ({
+      user: table("user", {
+        id: id(),
+        email: text().notNull(),
+      }),
+    }));
+    vi.mocked(loadSchemaByConvention).mockResolvedValue({
+      schema,
+      schemaPath: "/app/config/database/schema.ts",
+    });
+
+    const plugin = createPlugin();
+    await plugin.setup();
+
+    const router = {
+      get: vi.fn(),
+      post: vi.fn(),
+      patch: vi.fn(),
+      delete: vi.fn(),
+    };
+    plugin.injectRoutes(router as never);
+
+    expect(router.get).toHaveBeenCalledWith("/user", expect.any(Function));
+    expect(router.get).toHaveBeenCalledWith(
+      "/user/count",
+      expect.any(Function),
+    );
+    expect(router.get).toHaveBeenCalledWith("/user/:id", expect.any(Function));
+    expect(router.post).toHaveBeenCalledWith("/user", expect.any(Function));
+    expect(router.patch).toHaveBeenCalledWith(
+      "/user/:id",
+      expect.any(Function),
+    );
+    expect(router.delete).toHaveBeenCalledWith(
+      "/user/:id",
+      expect.any(Function),
+    );
   });
 
   test("closes the pool during shutdown", async () => {

--- a/packages/appkit/src/plugins/database/tests/plugin.test.ts
+++ b/packages/appkit/src/plugins/database/tests/plugin.test.ts
@@ -169,12 +169,15 @@ describe("DatabasePlugin", () => {
     process.env.DATABRICKS_HOST = "https://example.cloud.databricks.com";
     const servicePool = {
       end: vi.fn(async () => undefined),
+      on: vi.fn(),
     } as unknown as Pool;
     const userOnePool = {
       end: vi.fn(async () => undefined),
+      on: vi.fn(),
     } as unknown as Pool;
     const userTwoPool = {
       end: vi.fn(async () => undefined),
+      on: vi.fn(),
     } as unknown as Pool;
     vi.mocked(createLakebasePool)
       .mockReturnValueOnce(servicePool)
@@ -232,9 +235,11 @@ describe("DatabasePlugin", () => {
     process.env.DATABRICKS_HOST = "https://example.cloud.databricks.com";
     const servicePool = {
       end: vi.fn(async () => undefined),
+      on: vi.fn(),
     } as unknown as Pool;
     const userPool = {
       end: vi.fn(async () => undefined),
+      on: vi.fn(),
     } as unknown as Pool;
     vi.mocked(createLakebasePool)
       .mockReturnValueOnce(servicePool)
@@ -409,6 +414,62 @@ describe("DatabasePlugin", () => {
 
     const plugin = createPlugin({ tolerateSetupFailure: true });
     await expect(plugin.setup()).resolves.toBeUndefined();
+  });
+
+  test("per-user pools set app.user_id on every new connection", async () => {
+    const originalHost = process.env.DATABRICKS_HOST;
+    process.env.DATABRICKS_HOST = "https://example.cloud.databricks.com";
+    const servicePool = {
+      end: vi.fn(async () => undefined),
+      on: vi.fn(),
+    } as unknown as Pool;
+    const userPool = {
+      end: vi.fn(async () => undefined),
+      on: vi.fn(),
+    } as unknown as Pool;
+    vi.mocked(createLakebasePool)
+      .mockReturnValueOnce(servicePool)
+      .mockReturnValueOnce(userPool);
+    const schema = defineSchema(({ table }) => ({
+      user: table("user", { id: id(), email: text().notNull() }),
+    }));
+    vi.mocked(loadSchemaByConvention).mockResolvedValue({
+      schema,
+      schemaPath: "/app/config/database/schema.ts",
+    });
+
+    const plugin = createPlugin();
+    await plugin.setup();
+    const exports = plugin.exports() as unknown as {
+      user: { asUser: (req: import("express").Request) => unknown };
+    };
+    const req = {
+      header: vi.fn((name: string) => {
+        if (name === "x-forwarded-email") return "alice@example.com";
+        if (name === "x-forwarded-access-token") return "tok-alice";
+        return undefined;
+      }),
+    } as unknown as import("express").Request;
+    exports.user.asUser(req);
+
+    expect(userPool.on).toHaveBeenCalledWith("connect", expect.any(Function));
+    const handler = vi
+      .mocked(userPool.on)
+      .mock.calls.find(([event]) => event === "connect")?.[1] as unknown as (
+      client: { query: ReturnType<typeof vi.fn> },
+    ) => void;
+    const client = { query: vi.fn(async () => ({})) };
+    handler(client);
+    expect(client.query).toHaveBeenCalledWith(
+      "SELECT set_config('app.user_id', $1, false)",
+      ["alice@example.com"],
+    );
+
+    if (originalHost === undefined) {
+      delete process.env.DATABRICKS_HOST;
+    } else {
+      process.env.DATABRICKS_HOST = originalHost;
+    }
   });
 
   test("closeAll drains evicted per-user pools, not just live ones", async () => {

--- a/packages/appkit/src/plugins/database/tests/plugin.test.ts
+++ b/packages/appkit/src/plugins/database/tests/plugin.test.ts
@@ -194,7 +194,9 @@ describe("DatabasePlugin", () => {
       schemaPath: "/app/config/database/schema.ts",
     });
 
-    const plugin = createPlugin({ oboPoolMax: 1 });
+    const plugin = createPlugin({
+      oboPoolMax: 1,
+    });
     await plugin.setup();
     const exports = plugin.exports() as unknown as {
       user: {
@@ -387,9 +389,11 @@ describe("DatabasePlugin", () => {
     expect(pool.on).toHaveBeenCalledWith("connect", expect.any(Function));
     const handler = vi
       .mocked(pool.on)
-      .mock.calls.find(([event]) => event === "connect")?.[1] as unknown as (
-      client: { query: ReturnType<typeof vi.fn> },
-    ) => void;
+      .mock.calls.find(
+        ([event]) => event === "connect",
+      )?.[1] as unknown as (client: {
+      query: ReturnType<typeof vi.fn>;
+    }) => void;
     const client = { query: vi.fn(async () => ({})) };
     handler(client);
     expect(client.query).toHaveBeenCalledWith(
@@ -455,9 +459,11 @@ describe("DatabasePlugin", () => {
     expect(userPool.on).toHaveBeenCalledWith("connect", expect.any(Function));
     const handler = vi
       .mocked(userPool.on)
-      .mock.calls.find(([event]) => event === "connect")?.[1] as unknown as (
-      client: { query: ReturnType<typeof vi.fn> },
-    ) => void;
+      .mock.calls.find(
+        ([event]) => event === "connect",
+      )?.[1] as unknown as (client: {
+      query: ReturnType<typeof vi.fn>;
+    }) => void;
     const client = { query: vi.fn(async () => ({})) };
     handler(client);
     expect(client.query).toHaveBeenCalledWith(
@@ -503,7 +509,9 @@ describe("DatabasePlugin", () => {
       schemaPath: "/app/config/database/schema.ts",
     });
 
-    const plugin = createPlugin({ oboPoolMax: 1 });
+    const plugin = createPlugin({
+      oboPoolMax: 1,
+    });
     await plugin.setup();
     const exports = plugin.exports() as unknown as {
       user: { asUser: (req: import("express").Request) => unknown };

--- a/packages/appkit/src/plugins/database/tests/route-generator.test.ts
+++ b/packages/appkit/src/plugins/database/tests/route-generator.test.ts
@@ -1,0 +1,172 @@
+import {
+  createMockRequest,
+  createMockResponse,
+  createMockRouter,
+} from "@tools/test-helpers";
+import { describe, expect, test, vi } from "vitest";
+import { defineSchema, id, text } from "../../../database";
+import type { EntityClient } from "../entity-proxy";
+import { RouteGenerator } from "../route-generator";
+
+const schema = defineSchema(({ table }) => ({
+  user: table("user", {
+    id: id(),
+    email: text().notNull(),
+    role: text().default("member"),
+  }),
+}));
+
+function makeEntity(rows: unknown[] = []) {
+  const entity = {
+    where: vi.fn(() => entity),
+    order: vi.fn(() => entity),
+    limit: vi.fn(() => entity),
+    offset: vi.fn(() => entity),
+    range: vi.fn(() => entity),
+    select: vi.fn(() => entity),
+    include: vi.fn(() => entity),
+    toArray: vi.fn(async () => rows),
+    first: vi.fn(async () => rows[0] ?? null),
+    find: vi.fn(async () => rows[0] ?? null),
+    count: vi.fn(async () => rows.length),
+    create: vi.fn(async (data: unknown) => data),
+    update: vi.fn(async (_id: unknown, data: unknown) => data),
+    upsert: vi.fn(async (data: unknown) => data),
+    delete: vi.fn(async () => undefined),
+    asUser: vi.fn(() => entity),
+  };
+
+  return entity as unknown as EntityClient & typeof entity;
+}
+
+describe("RouteGenerator", () => {
+  test("registers six routes per entity with obo access by default", async () => {
+    const { router, handlers } = createMockRouter();
+    const user = makeEntity([]);
+    const getSurface = vi.fn(() => ({ user }));
+    new RouteGenerator({
+      schema,
+      config: {},
+      getSurface,
+      route: (target, config) =>
+        target[config.method](config.path, config.handler),
+    }).injectAll(router);
+
+    expect(Object.keys(handlers).sort()).toEqual([
+      "DELETE:/user/:id",
+      "GET:/user",
+      "GET:/user/:id",
+      "GET:/user/count",
+      "PATCH:/user/:id",
+      "POST:/user",
+    ]);
+
+    await handlers["GET:/user"](
+      createMockRequest({ query: {} }),
+      createMockResponse(),
+    );
+
+    expect(getSurface).toHaveBeenCalledWith(expect.anything(), "obo");
+    expect(user.limit).toHaveBeenCalledWith(50);
+  });
+
+  test("applies filters, select projection, order, limit clamp, and include parsing", async () => {
+    const { router, getHandler } = createMockRouter();
+    const user = makeEntity([{ id: 1, email: "a@x", role: "admin" }]);
+    new RouteGenerator({
+      schema,
+      config: {},
+      getSurface: vi.fn(() => ({ user })),
+      route: (target, config) =>
+        target[config.method](config.path, config.handler),
+    }).injectAll(router);
+
+    const handler = getHandler("GET", "/user");
+    const res = createMockResponse();
+    await handler(
+      createMockRequest({
+        query: {
+          role: "eq.admin",
+          email: 'eq."Doe, Jane"',
+          select: "id,email,unknownCol",
+          include: "posts(id,title),author",
+          order: "email.desc",
+          limit: "10000",
+          offset: "10",
+        },
+      }),
+      res,
+    );
+
+    expect(user.where).toHaveBeenCalledWith({ role: { eq: "admin" } });
+    expect(user.where).toHaveBeenCalledWith({ email: { eq: "Doe, Jane" } });
+    expect(user.select).toHaveBeenCalledWith("id", "email");
+    expect(user.include).toHaveBeenCalledWith({
+      posts: { select: ["id", "title"] },
+      author: true,
+    });
+    expect(user.order).toHaveBeenCalledWith({ email: "desc" });
+    expect(user.limit).toHaveBeenCalledWith(500);
+    expect(user.offset).toHaveBeenCalledWith(10);
+    expect(res.json).toHaveBeenCalledWith([
+      { id: 1, email: "a@x", role: "admin" },
+    ]);
+  });
+
+  test("honors disabled verbs and service access overrides", async () => {
+    const { router, handlers } = createMockRouter();
+    const user = makeEntity([]);
+    const getSurface = vi.fn(() => ({ user }));
+    new RouteGenerator({
+      schema,
+      config: {
+        http: {
+          user: {
+            count: false,
+            delete: false,
+            create: "service",
+          },
+        },
+      },
+      getSurface,
+      route: (target, config) =>
+        target[config.method](config.path, config.handler),
+    }).injectAll(router);
+
+    expect(handlers["GET:/user/count"]).toBeUndefined();
+    expect(handlers["DELETE:/user/:id"]).toBeUndefined();
+
+    await handlers["POST:/user"](
+      createMockRequest({ body: { email: "a@x" } }),
+      createMockResponse(),
+    );
+
+    expect(getSurface).toHaveBeenCalledWith(expect.anything(), "service");
+    expect(user.create).toHaveBeenCalledWith(
+      expect.objectContaining({ email: "a@x" }),
+    );
+  });
+
+  test("returns zod-formatted validation errors from the entity layer", async () => {
+    const { router, handlers } = createMockRouter();
+    const user = makeEntity([]);
+    user.create.mockImplementation(async () => {
+      schema.user.$insertSchema.parse({});
+      return {};
+    });
+    new RouteGenerator({
+      schema,
+      config: {},
+      getSurface: vi.fn(() => ({ user })),
+      route: (target, config) =>
+        target[config.method](config.path, config.handler),
+    }).injectAll(router);
+
+    const res = createMockResponse();
+    await handlers["POST:/user"](createMockRequest({ body: {} }), res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ errors: expect.any(Object) });
+    expect(user.create).toHaveBeenCalledWith({});
+  });
+});

--- a/packages/appkit/src/plugins/database/types.ts
+++ b/packages/appkit/src/plugins/database/types.ts
@@ -35,7 +35,15 @@ export interface HookContext {
   req?: import("express").Request;
   /** The entity name. */
   entity?: string;
-  /** The user ID. */
+  /**
+   * The forwarded user identity (`x-forwarded-email`).
+   *
+   * **Do not use for authorization decisions.** This is a transport-level
+   * label populated from the same forwarded headers OBO uses; the actual
+   * authentication signal is the access token on `req`. For authz, read the
+   * verified user context off `req` — `userId` here is a convenience tag for
+   * logging, audit fields, or distinguishing cache keys.
+   */
   userId?: string;
 }
 
@@ -68,12 +76,23 @@ export interface EntityHooks {
     row: Record<string, unknown>,
     ctx: HookContext,
   ) => Promise<void>;
-  /** A hook to run before an upsert operation. */
+  /**
+   * Run before an upsert operation.
+   *
+   * Note: `upsert` is a separate channel from `create` and `update` — it
+   * does **not** invoke `beforeCreate`/`beforeUpdate` even when the resolved
+   * branch is logically an insert or update. If you need shared mutation
+   * logic, factor it into a helper and call it from both hooks (or from
+   * `beforeCreate` + `beforeUpdate` + `beforeUpsert`).
+   */
   beforeUpsert?: (
     data: Record<string, unknown>,
     ctx: HookContext,
   ) => Promise<HookMutationResult>;
-  /** A hook to run after an upsert operation. */
+  /**
+   * Run after an upsert operation. See `beforeUpsert` — this is **not** a
+   * fan-out of `afterCreate`/`afterUpdate`.
+   */
   afterUpsert?: (
     row: Record<string, unknown>,
     ctx: HookContext,
@@ -119,6 +138,11 @@ export interface IDatabaseConfig extends BasePluginConfig {
   hooks?: Record<string, EntityHooks>;
   /** Whether to check live schema drift during startup. */
   checkDrift?: boolean;
+  /**
+   * Mount `GET /api/database/_healthz` for load balancers and readiness probes.
+   * Defaults to enabled. Set to `false` to suppress the route entirely.
+   */
+  healthCheck?: false;
   /** The cache settings for the database. */
   cache?: CacheSettings;
   /**

--- a/packages/appkit/src/plugins/database/types.ts
+++ b/packages/appkit/src/plugins/database/types.ts
@@ -1,27 +1,5 @@
 import type { BasePluginConfig } from "shared";
-
-/**
- * Pool tuning exposed via `IDatabaseConfig.connection`.
- * Intentionally excludes auth fields; Lakebase resolves credentials via OAuth + env.
- */
-export interface DatabasePoolTuning {
-  /** Maximum number of clients in the pool. */
-  max?: number;
-  /** Idle timeout (ms) before closing an idle client. */
-  idleTimeoutMillis?: number;
-  /** Connection acquire timeout (ms). */
-  connectionTimeoutMillis?: number;
-  /**
-   * Recycle a client after N uses to reduce stale-token issues.
-   */
-  maxUses?: number;
-  /**
-   * Statement timeout (ms) set per new connection; top-level setting wins.
-   */
-  statement_timeout?: number;
-  /** Random jitter (ms) added to statement timeout when supported. */
-  statement_timeout_jitter_ms?: number;
-}
+import type { LakebasePoolConfig } from "@/connectors";
 
 /**
  * HTTP access control for entity operations.
@@ -34,17 +12,17 @@ export type HttpAccess = "public" | "obo" | "service" | false;
  * @public
  */
 export interface HttpEntityOverride {
-  /** Access mode for list. */
+  /** The HTTP access control for the list operation. */
   list?: HttpAccess;
-  /** Access mode for find. */
+  /** The HTTP access control for the find operation. */
   find?: HttpAccess;
-  /** Access mode for count. */
+  /** The HTTP access control for the count operation. */
   count?: HttpAccess;
-  /** Access mode for create. */
+  /** The HTTP access control for the create operation. */
   create?: HttpAccess;
-  /** Access mode for update. */
+  /** The HTTP access control for the update operation. */
   update?: HttpAccess;
-  /** Access mode for delete. */
+  /** The HTTP access control for the delete operation. */
   delete?: HttpAccess;
 }
 
@@ -53,43 +31,56 @@ export interface HttpEntityOverride {
  * @public
  */
 export interface HookContext {
-  /** Request object. */
+  /** The request object. */
   req?: import("express").Request;
-  /** Entity name. */
+  /** The entity name. */
   entity?: string;
-  /** User ID. */
+  /** The user ID. */
   userId?: string;
 }
+
+// biome-ignore lint/suspicious/noConfusingVoidType: hooks may return nothing to keep the original payload.
+type HookMutationResult = Record<string, unknown> | void;
 
 /**
  * Entity hooks.
  * @public
  */
 export interface EntityHooks {
-  /** Runs before create. */
+  /** A hook to run before a create operation. */
   beforeCreate?: (
     data: Record<string, unknown>,
     ctx: HookContext,
-  ) => Promise<Record<string, unknown> | void>;
-  /** Runs after create. */
+  ) => Promise<HookMutationResult>;
+  /** A hook to run after a create operation. */
   afterCreate?: (
     row: Record<string, unknown>,
     ctx: HookContext,
   ) => Promise<void>;
-  /** Runs before update. */
+  /** A hook to run before an update operation. */
   beforeUpdate?: (
     id: unknown,
     patch: Record<string, unknown>,
     ctx: HookContext,
-  ) => Promise<Record<string, unknown> | void>;
-  /** Runs after update. */
+  ) => Promise<HookMutationResult>;
+  /** A hook to run after an update operation. */
   afterUpdate?: (
     row: Record<string, unknown>,
     ctx: HookContext,
   ) => Promise<void>;
-  /** Runs before delete. */
+  /** A hook to run before an upsert operation. */
+  beforeUpsert?: (
+    data: Record<string, unknown>,
+    ctx: HookContext,
+  ) => Promise<HookMutationResult>;
+  /** A hook to run after an upsert operation. */
+  afterUpsert?: (
+    row: Record<string, unknown>,
+    ctx: HookContext,
+  ) => Promise<void>;
+  /** A hook to run before a delete operation. */
   beforeDelete?: (id: unknown, ctx: HookContext) => Promise<void>;
-  /** Runs after delete. */
+  /** A hook to run after a delete operation. */
   afterDelete?: (id: unknown, ctx: HookContext) => Promise<void>;
 }
 
@@ -98,7 +89,7 @@ export interface EntityHooks {
  * @public
  */
 export interface CacheActionSettings {
-  /** Cache TTL in seconds. */
+  /** The time to live for the cache in seconds. */
   ttl?: number;
 }
 
@@ -107,11 +98,11 @@ export interface CacheActionSettings {
  * @public
  */
 export interface CacheSettings {
-  /** Cache settings for list. */
+  /** The cache settings for the list operation. */
   list?: CacheActionSettings;
-  /** Cache settings for find. */
+  /** The cache settings for the find operation. */
   find?: CacheActionSettings;
-  /** Cache settings for count. */
+  /** The cache settings for the count operation. */
   count?: CacheActionSettings;
 }
 
@@ -120,29 +111,34 @@ export interface CacheSettings {
  * @public
  */
 export interface IDatabaseConfig extends BasePluginConfig {
-  /**
-   * Pool tuning forwarded to `createLakebasePool` (no auth fields).
-   */
-  connection?: DatabasePoolTuning;
-  /** Per-entity HTTP access overrides. */
+  /** The connection settings for the database. */
+  connection?: Partial<LakebasePoolConfig>;
+  /** The HTTP entity overrides for the database. */
   http?: Record<string, HttpEntityOverride>;
-  /** Per-entity lifecycle hooks. */
+  /** The entity hooks for the database. */
   hooks?: Record<string, EntityHooks>;
-  /** Per-operation cache settings. */
+  /** Whether to check live schema drift during startup. */
+  checkDrift?: boolean;
+  /** The cache settings for the database. */
   cache?: CacheSettings;
   /**
-   * Max distinct OBO pools kept alive. Defaults to 25.
-   * Worst-case fan-out is `(1 + oboPoolMax) × poolMax`.
+   * Maximum number of distinct per-user (OBO) pools the registry keeps alive
+   * at once. Each pool defaults to `OBO_POOL_DEFAULTS.max = 4` connections, so
+   * the worst-case fan-out is `(1 + oboPoolMax) × poolMax`. Defaults to 25 —
+   * tune up for hot OBO traffic, down for low-tier Lakebase plans.
    */
   oboPoolMax?: number;
   /**
-   * Postgres `statement_timeout` (ms) for pooled connections. Defaults to 15s.
-   * Set `0` to disable server-side timeout (client timeout still applies).
+   * Postgres `statement_timeout` applied to every pooled connection (ms).
+   * Defaults to 15s. Set to `0` to disable the server-side cap; the AppKit
+   * timeout interceptor still applies on the client side.
    */
   statementTimeoutMs?: number;
   /**
-   * If true, `setup()` schema/drift failures are logged and ignored.
-   * Defaults to false (fail closed).
+   * When true, schema-load and drift-check failures during `setup()` are
+   * logged but do not throw. Defaults to false (fail closed). Useful in
+   * environments where the database is provisioned out of band and the boot
+   * shouldn't crash before the schema is reachable.
    */
   tolerateSetupFailure?: boolean;
 }

--- a/packages/appkit/src/plugins/database/types.ts
+++ b/packages/appkit/src/plugins/database/types.ts
@@ -1,5 +1,14 @@
 import type { BasePluginConfig } from "shared";
-import type { LakebasePoolConfig } from "@/connectors";
+
+/** Pool tuning forwarded to `createLakebasePool` (no auth fields). */
+export interface DatabasePoolTuning {
+  max?: number;
+  idleTimeoutMillis?: number;
+  connectionTimeoutMillis?: number;
+  maxUses?: number;
+  statement_timeout?: number;
+  statement_timeout_jitter_ms?: number;
+}
 
 /**
  * HTTP access control for entity operations.
@@ -131,7 +140,7 @@ export interface CacheSettings {
  */
 export interface IDatabaseConfig extends BasePluginConfig {
   /** The connection settings for the database. */
-  connection?: Partial<LakebasePoolConfig>;
+  connection?: DatabasePoolTuning;
   /** The HTTP entity overrides for the database. */
   http?: Record<string, HttpEntityOverride>;
   /** The entity hooks for the database. */


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/databricks/appkit/pull/355/files/04798130912455ebc60b0a65b47fb1b9050a4468..caa5080585c53e9f995d75d14cb1ede51f8f4004) to review incremental changes.
- [stack/database/foundation](https://github.com/databricks/appkit/pull/354) [[Files changed](https://github.com/databricks/appkit/pull/354/files)]
  - [**stack/database/server**](https://github.com/databricks/appkit/pull/355) [[Files changed](https://github.com/databricks/appkit/pull/355/files/04798130912455ebc60b0a65b47fb1b9050a4468..caa5080585c53e9f995d75d14cb1ede51f8f4004)]
    - [stack/database/brownfield](https://github.com/databricks/appkit/pull/356) [[Files changed](https://github.com/databricks/appkit/pull/356/files/caa5080585c53e9f995d75d14cb1ede51f8f4004..0bcf90a7772199d2a07288224cd2283a87d6cb0f)]
      - [stack/database/init](https://github.com/databricks/appkit/pull/357) [[Files changed](https://github.com/databricks/appkit/pull/357/files/0bcf90a7772199d2a07288224cd2283a87d6cb0f..7f53a55a8c795bd80ff838c77391d547605c77bd)]
        - [stack/database/frontend](https://github.com/databricks/appkit/pull/358) [[Files changed](https://github.com/databricks/appkit/pull/358/files/7f53a55a8c795bd80ff838c77391d547605c77bd..3d90d27d17f40758558248d5420b201cc31da7a7)]
          - [stack/database/ui](https://github.com/databricks/appkit/pull/359) [[Files changed](https://github.com/databricks/appkit/pull/359/files/3d90d27d17f40758558248d5420b201cc31da7a7..eeaaacc1f2047fee815eeda1102d4a7b0953674c)]
            - [stack/database/advanced](https://github.com/databricks/appkit/pull/360) [[Files changed](https://github.com/databricks/appkit/pull/360/files/eeaaacc1f2047fee815eeda1102d4a7b0953674c..6c8c9a3a223b199ef43aa7894254fcb87c5cda4c)]
              - [stack/database/release](https://github.com/databricks/appkit/pull/361) [[Files changed](https://github.com/databricks/appkit/pull/361/files/6c8c9a3a223b199ef43aa7894254fcb87c5cda4c..97c45859711af358b096fab1e718b3ec45d3b6f3)]

---------
Server-side runtime for the database plugin. Moves the entity API onto a Drizzle-backed Postgres pool and adds the multi-tenant execution primitives.

### Drizzle-backed entity runtime

Switches entity operations from the Data API to a Drizzle/Postgres pool, adds typed coercion, health checks, route hardening, and PostgREST-style include/upsert semantics.

### OBO, transactions, and SQL escape hatch

Adds `appkit.database.transaction(fn)`, tagged `sql` execution, and `asUser(req)` execution scoped to the caller. Per-user OBO pools set `app.user_id` on connection for RLS-aware queries.

### Safety and shutdown

Hides private columns from default reads and routes, drains evicted user pools, caps `toArray()`, scrubs route errors, and tightens pool fan-out.

### Test plan

- Entity route tests
- Hook tests
- OBO pool scoping tests
- Transaction and SQL tests
- Full stack verification run locally before push

## PR Stack

1. Database foundation: schema builder, plugin skeleton, runtime base — #354
2. **Server runtime: Drizzle pool, OBO, transactions, hooks** (this PR)
3. Brownfield support: introspector, drift detection, db CLI — #356
4. `appkit db init` onboarding — #357
5. Typed browser db client + dev playground demo — #358
6. React entity UI + columns metadata — #359
7. RLS scaffolder + connection pool tuning — #360
8. Database plugin guide + release polish — #361