### PR TITLE
chore(appkit): hide agents plugin from public exports

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -18,7 +18,7 @@
     "packages/appkit/src/plugins/vector-search/**",
     "packages/appkit/src/plugin/index.ts",
     "packages/appkit/src/plugin/to-plugin.ts",
-    "packages/appkit/src/plugins/agents/index.ts",
+    "packages/appkit/src/plugins/agents/**",
     "template/**",
     "tools/**",
     "docs/**",

--- a/packages/appkit/src/plugins/agents/manifest.json
+++ b/packages/appkit/src/plugins/agents/manifest.json
@@ -3,6 +3,7 @@
   "name": "agents",
   "displayName": "Agents Plugin",
   "stability": "beta",
+  "hidden": true,
   "description": "AI agents driven by markdown configs or code, with auto-tool-discovery from registered plugins",
   "resources": {
     "required": [],

--- a/packages/appkit/src/plugins/beta-exports.generated.ts
+++ b/packages/appkit/src/plugins/beta-exports.generated.ts
@@ -5,4 +5,4 @@
 // subpath ships each plugin. Editing this file by hand will drift it from the
 // manifests and the synced appkit.plugins.json.
 
-export { agents } from "./agents";
+export {};

--- a/template/appkit.plugins.json
+++ b/template/appkit.plugins.json
@@ -2,31 +2,6 @@
   "$schema": "https://databricks.github.io/appkit/schemas/template-plugins.schema.json",
   "version": "1.1",
   "plugins": {
-    "agents": {
-      "name": "agents",
-      "displayName": "Agents Plugin",
-      "description": "AI agents driven by markdown configs or code, with auto-tool-discovery from registered plugins",
-      "package": "@databricks/appkit",
-      "resources": {
-        "required": [],
-        "optional": [
-          {
-            "type": "serving_endpoint",
-            "alias": "Model Serving (agents)",
-            "resourceKey": "agents-serving-endpoint",
-            "description": "Databricks Model Serving endpoint for agents using workspace-hosted models (`DatabricksAdapter.fromModelServing`). Wire the same endpoint name AppKit reads from `DATABRICKS_AGENT_ENDPOINT` when no per-agent model is configured. Omit when agents use only external adapters.",
-            "permission": "CAN_QUERY",
-            "fields": {
-              "name": {
-                "env": "DATABRICKS_AGENT_ENDPOINT",
-                "description": "Endpoint name passed to Model Serving when agents default to `DatabricksAdapter.fromModelServing()`"
-              }
-            }
-          }
-        ]
-      },
-      "stability": "beta"
-    },
     "analytics": {
       "name": "analytics",
       "displayName": "Analytics Plugin",


### PR DESCRIPTION
## Summary

- Sets `hidden: true` in the agents plugin manifest so it is excluded from auto-generated barrel exports (`beta-exports.generated.ts`) and the template plugins registry (`appkit.plugins.json`)
- Manual exports in `beta.ts` remain intact for internal use
- Updates knip config to ignore the hidden plugin directory

## Test plan

- [x] `pnpm build` succeeds
- [x] `beta-exports.generated.ts` contains `export {}`
- [x] `template/appkit.plugins.json` has no `agents` entry
- [x] `beta.ts` manual exports unchanged
- [x] Knip passes