### PR TITLE
feat(appkit): no-config chat UI

### DIFF
--- a/apps/dev-playground/client/src/lib/nav.ts
+++ b/apps/dev-playground/client/src/lib/nav.ts
@@ -99,6 +99,13 @@ export const NAV_GROUPS: ReadonlyArray<NavGroup> = [
         icon: BotIcon,
       },
       {
+        to: "/agent-chat-full",
+        label: "Custom Agent (full no-config chat)",
+        description:
+          "Drop-in <ChatApp /> with zero props — defaults to /api/agents/chat with the full UX.",
+        icon: MessageCircleIcon,
+      },
+      {
         to: "/genie",
         label: "Genie",
         description:

--- a/apps/dev-playground/client/src/routeTree.gen.ts
+++ b/apps/dev-playground/client/src/routeTree.gen.ts
@@ -25,6 +25,7 @@ import { Route as DataVisualizationRouteRouteImport } from './routes/data-visual
 import { Route as ChartInferenceRouteRouteImport } from './routes/chart-inference.route'
 import { Route as ArrowAnalyticsRouteRouteImport } from './routes/arrow-analytics.route'
 import { Route as AnalyticsRouteRouteImport } from './routes/analytics.route'
+import { Route as AgentChatFullRouteRouteImport } from './routes/agent-chat-full.route'
 import { Route as AgentRouteRouteImport } from './routes/agent.route'
 import { Route as IndexRouteImport } from './routes/index'
 
@@ -108,6 +109,11 @@ const AnalyticsRouteRoute = AnalyticsRouteRouteImport.update({
   path: '/analytics',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AgentChatFullRouteRoute = AgentChatFullRouteRouteImport.update({
+  id: '/agent-chat-full',
+  path: '/agent-chat-full',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AgentRouteRoute = AgentRouteRouteImport.update({
   id: '/agent',
   path: '/agent',
@@ -122,6 +128,7 @@ const IndexRoute = IndexRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/agent': typeof AgentRouteRoute
+  '/agent-chat-full': typeof AgentChatFullRouteRoute
   '/analytics': typeof AnalyticsRouteRoute
   '/arrow-analytics': typeof ArrowAnalyticsRouteRoute
   '/chart-inference': typeof ChartInferenceRouteRoute
@@ -142,6 +149,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/agent': typeof AgentRouteRoute
+  '/agent-chat-full': typeof AgentChatFullRouteRoute
   '/analytics': typeof AnalyticsRouteRoute
   '/arrow-analytics': typeof ArrowAnalyticsRouteRoute
   '/chart-inference': typeof ChartInferenceRouteRoute
@@ -163,6 +171,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/agent': typeof AgentRouteRoute
+  '/agent-chat-full': typeof AgentChatFullRouteRoute
   '/analytics': typeof AnalyticsRouteRoute
   '/arrow-analytics': typeof ArrowAnalyticsRouteRoute
   '/chart-inference': typeof ChartInferenceRouteRoute
@@ -185,6 +194,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/agent'
+    | '/agent-chat-full'
     | '/analytics'
     | '/arrow-analytics'
     | '/chart-inference'
@@ -205,6 +215,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/agent'
+    | '/agent-chat-full'
     | '/analytics'
     | '/arrow-analytics'
     | '/chart-inference'
@@ -225,6 +236,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/agent'
+    | '/agent-chat-full'
     | '/analytics'
     | '/arrow-analytics'
     | '/chart-inference'
@@ -246,6 +258,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AgentRouteRoute: typeof AgentRouteRoute
+  AgentChatFullRouteRoute: typeof AgentChatFullRouteRoute
   AnalyticsRouteRoute: typeof AnalyticsRouteRoute
   ArrowAnalyticsRouteRoute: typeof ArrowAnalyticsRouteRoute
   ChartInferenceRouteRoute: typeof ChartInferenceRouteRoute
@@ -378,6 +391,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AnalyticsRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/agent-chat-full': {
+      id: '/agent-chat-full'
+      path: '/agent-chat-full'
+      fullPath: '/agent-chat-full'
+      preLoaderRoute: typeof AgentChatFullRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/agent': {
       id: '/agent'
       path: '/agent'
@@ -398,6 +418,7 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AgentRouteRoute: AgentRouteRoute,
+  AgentChatFullRouteRoute: AgentChatFullRouteRoute,
   AnalyticsRouteRoute: AnalyticsRouteRoute,
   ArrowAnalyticsRouteRoute: ArrowAnalyticsRouteRoute,
   ChartInferenceRouteRoute: ChartInferenceRouteRoute,

--- a/apps/dev-playground/client/src/routes/agent-chat-full.route.tsx
+++ b/apps/dev-playground/client/src/routes/agent-chat-full.route.tsx
@@ -1,0 +1,18 @@
+import { ChatApp } from "@databricks/appkit-ui/react/chat";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/agent-chat-full")({
+  component: AgentChatFullRoute,
+});
+
+/**
+ * No-config showcase of `<ChatApp />`. For the build-your-own variant
+ * that wires `useChat` by hand, see `agent.route.tsx`.
+ */
+function AgentChatFullRoute() {
+  return (
+    <div className="h-svh bg-background">
+      <ChatApp api="/api/agents/chat" />
+    </div>
+  );
+}

--- a/apps/dev-playground/client/src/routes/agent.route.tsx
+++ b/apps/dev-playground/client/src/routes/agent.route.tsx
@@ -1,46 +1,13 @@
 import { getPluginClientConfig } from "@databricks/appkit-ui/js";
 import { Button } from "@databricks/appkit-ui/react";
+import { ChatInput, Conversation } from "@databricks/appkit-ui/react/chat";
 import { createFileRoute } from "@tanstack/react-router";
-import { useCallback, useEffect, useRef, useState } from "react";
+import type { UIMessage, UIMessageChunk } from "ai";
+import { useCallback, useRef, useState } from "react";
 
 export const Route = createFileRoute("/agent")({
   component: AgentRoute,
 });
-
-interface SSEEvent {
-  type: string;
-  delta?: string;
-  item_id?: string;
-  item?: {
-    type?: string;
-    id?: string;
-    call_id?: string;
-    name?: string;
-    arguments?: string;
-    output?: string;
-    status?: string;
-  };
-  content?: string;
-  data?: Record<string, unknown>;
-  error?: string;
-  sequence_number?: number;
-  output_index?: number;
-  approval_id?: string;
-  stream_id?: string;
-  tool_name?: string;
-  args?: unknown;
-  annotations?: {
-    readOnly?: boolean;
-    destructive?: boolean;
-    idempotent?: boolean;
-  };
-}
-
-interface ChatMessage {
-  id: number;
-  role: "user" | "assistant";
-  content: string;
-}
 
 interface PendingApproval {
   approvalId: string;
@@ -136,43 +103,26 @@ function useAutocomplete(enabled: boolean) {
   };
 }
 
+// Joins all text parts; a message can have multiple if the agent
+// reopens text after a tool call.
+function messageBodyText(message: UIMessage): string {
+  let body = "";
+  for (const part of message.parts) {
+    if (part.type === "text") body += part.text;
+  }
+  return body;
+}
+
 function AgentRoute() {
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
-  const [events, setEvents] = useState<AgentEvent[]>([]);
-  const [input, setInput] = useState("");
-  const [isLoading, setIsLoading] = useState(false);
-  const [threadId, setThreadId] = useState<string | null>(null);
   const [pendingApprovals, setPendingApprovals] = useState<PendingApproval[]>(
     [],
   );
-
-  const decideApproval = useCallback(
-    async (approvalId: string, decision: "approve" | "deny") => {
-      const approval = pendingApprovals.find(
-        (a) => a.approvalId === approvalId,
-      );
-      if (!approval) return;
-      try {
-        await fetch("/api/agents/approve", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            streamId: approval.streamId,
-            approvalId,
-            decision,
-          }),
-        });
-      } finally {
-        setPendingApprovals((prev) =>
-          prev.filter((a) => a.approvalId !== approvalId),
-        );
-      }
-    },
-    [pendingApprovals],
-  );
-  const messagesEndRef = useRef<HTMLDivElement>(null);
+  // Raw chunk log for the debug panel; ids keep React keys stable.
+  const [streamLog, setStreamLog] = useState<
+    Array<{ id: number; chunk: UIMessageChunk }>
+  >([]);
+  const nextChunkIdRef = useRef(0);
   const inputRef = useRef<HTMLTextAreaElement>(null);
-  const msgIdCounter = useRef(0);
 
   const agentConfig = getPluginClientConfig<{
     agents?: string[];
@@ -187,381 +137,394 @@ function AgentRoute() {
     clear: clearSuggestion,
   } = useAutocomplete(hasAutocomplete);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll on new messages
-  useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages]);
-
-  const sendMessage = useCallback(async () => {
-    if (!input.trim() || isLoading) return;
-
-    clearSuggestion();
-    const userMessage = input.trim();
-    setInput("");
-    setMessages((prev) => [
-      ...prev,
-      { id: ++msgIdCounter.current, role: "user", content: userMessage },
-    ]);
-    setEvents([]);
-    setIsLoading(true);
-
-    try {
-      const response = await fetch("/api/agents/chat", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          message: userMessage,
-          ...(threadId && { threadId }),
-        }),
-      });
-
-      if (!response.ok) {
-        const error = await response.json();
-        setMessages((prev) => [
-          ...prev,
-          {
-            id: ++msgIdCounter.current,
-            role: "assistant",
-            content: `Error: ${error.error}`,
-          },
-        ]);
-        return;
+  const decideApproval = useCallback(
+    async (
+      approvalId: string,
+      streamId: string,
+      decision: "approve" | "deny",
+    ) => {
+      try {
+        await fetch("/api/agents/approve", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ streamId, approvalId, decision }),
+        });
+      } finally {
+        setPendingApprovals((prev) =>
+          prev.filter((a) => a.approvalId !== approvalId),
+        );
       }
-
-      const reader = response.body?.getReader();
-      if (!reader) return;
-
-      const decoder = new TextDecoder();
-      let assistantContent = "";
-      let buffer = "";
-
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split("\n");
-        buffer = lines.pop() ?? "";
-
-        for (const line of lines) {
-          if (!line.startsWith("data: ")) continue;
-          const data = line.slice(6).trim();
-          if (!data || data === "[DONE]") continue;
-
-          try {
-            const event: SSEEvent = JSON.parse(data);
-            if (!event.type) continue;
-            setEvents((prev) => [...prev, event]);
-
-            if (
-              event.type === "appkit.approval_pending" &&
-              event.approval_id &&
-              event.stream_id &&
-              event.tool_name
-            ) {
-              setPendingApprovals((prev) => [
-                ...prev,
-                {
-                  approvalId: event.approval_id as string,
-                  streamId: event.stream_id as string,
-                  toolName: event.tool_name as string,
-                  args: event.args,
-                },
-              ]);
-            }
-            if (event.type === "appkit.metadata" && event.data?.threadId) {
-              setThreadId(event.data.threadId as string);
-            }
-
-            if (event.type === "response.output_text.delta" && event.delta) {
-              assistantContent += event.delta;
-              setMessages((prev) => {
-                const updated = [...prev];
-                const last = updated[updated.length - 1];
-                if (last?.role === "assistant") {
-                  updated[updated.length - 1] = {
-                    ...last,
-                    content: assistantContent,
-                  };
-                } else {
-                  updated.push({
-                    id: ++msgIdCounter.current,
-                    role: "assistant",
-                    content: assistantContent,
-                  });
-                }
-                return updated;
-              });
-            }
-          } catch {
-            // skip malformed events
-          }
-        }
-      }
-    } catch (err) {
-      setMessages((prev) => [
-        ...prev,
-        {
-          id: ++msgIdCounter.current,
-          role: "assistant",
-          content: `Error: ${err instanceof Error ? err.message : "Unknown error"}`,
-        },
-      ]);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [input, isLoading, threadId, clearSuggestion]);
-
-  const handleInputChange = (value: string) => {
-    setInput(value);
-    requestSuggestion(value);
-  };
-
-  const acceptSuggestion = () => {
-    if (!suggestion) return;
-    const newValue = input + suggestion;
-    setInput(newValue);
-    clearSuggestion();
-    inputRef.current?.focus();
-  };
+    },
+    [],
+  );
 
   return (
     <div className="min-h-screen bg-background">
       <div className="max-w-7xl mx-auto px-6 py-12">
-        <div className="mb-8 flex items-end justify-between">
-          <div>
-            <h1 className="text-3xl font-bold mb-2">Agent Chat</h1>
-            <p className="text-base text-muted-foreground">
-              AI agent with auto-discovered tools from all AppKit plugins.
-              {threadId && (
-                <span className="ml-2 text-xs font-mono opacity-60">
-                  Thread: {threadId.slice(0, 8)}...
-                </span>
-              )}
-            </p>
-          </div>
-          {hasAutocomplete && (
-            <span className="text-xs text-muted-foreground bg-muted px-2 py-1 rounded">
-              Autocomplete enabled
-            </span>
-          )}
-        </div>
+        <Conversation
+          api="/api/agents/chat"
+          onData={(part) => {
+            if (part.type === "data-approval-pending") {
+              const payload = part.data as PendingApproval;
+              setPendingApprovals((prev) =>
+                prev.some((p) => p.approvalId === payload.approvalId)
+                  ? prev
+                  : [...prev, payload],
+              );
+            }
+          }}
+          onStreamPart={(chunk) =>
+            setStreamLog((prev) => [
+              ...prev,
+              { id: nextChunkIdRef.current++, chunk },
+            ])
+          }
+        >
+          {({
+            id: chatId,
+            messages,
+            status,
+            error,
+            sendMessage,
+            stop,
+            containerRef,
+          }) => {
+            const isLoading = status === "submitted" || status === "streaming";
+            // Show "Thinking..." until the assistant has produced visible
+            // text — the assistant message stub appears immediately on `start`.
+            const lastMessage = messages[messages.length - 1];
+            const lastAssistantHasText =
+              lastMessage?.role === "assistant" &&
+              messageBodyText(lastMessage).length > 0;
+            const showThinking =
+              isLoading &&
+              pendingApprovals.length === 0 &&
+              !lastAssistantHasText;
 
-        <div className="flex gap-6 h-[700px]">
-          <div className="flex-1 flex flex-col border rounded-lg bg-card min-w-0">
-            <div className="flex-1 overflow-y-auto p-4 space-y-4">
-              {messages.length === 0 && (
-                <div className="text-center text-muted-foreground py-20">
-                  <p className="text-lg">
-                    Send a message to start a conversation
-                  </p>
-                  <p className="text-sm mt-2">
-                    The agent can use analytics, files, genie, and lakebase
-                    tools.
-                    {hasAutocomplete && " Start typing for inline suggestions."}
-                  </p>
-                </div>
-              )}
-
-              {messages.map((msg) => (
-                <div
-                  key={msg.id}
-                  className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}
-                >
-                  <div
-                    className={`max-w-[85%] rounded-lg px-4 py-2 ${
-                      msg.role === "user"
-                        ? "bg-primary text-primary-foreground"
-                        : "bg-muted"
-                    }`}
-                  >
-                    <p className="whitespace-pre-wrap text-sm">{msg.content}</p>
-                  </div>
-                </div>
-              ))}
-
-              {pendingApprovals.map((approval) => (
-                <div key={approval.approvalId} className="flex justify-start">
-                  <div className="max-w-[80%] rounded-lg border border-orange-500/60 bg-orange-500/10 px-4 py-3">
-                    <div className="mb-2 flex items-center gap-2">
-                      <span className="rounded bg-orange-600 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-white">
-                        Destructive tool — approval required
+            return (
+              <>
+                <div className="mb-8 flex items-end justify-between">
+                  <div>
+                    <h1 className="text-3xl font-bold mb-2">Agent Chat</h1>
+                    <p className="text-base text-muted-foreground">
+                      AI agent with auto-discovered tools from all plugins.
+                      <span className="ml-2 text-xs font-mono opacity-60">
+                        Chat: {chatId.slice(0, 8)}...
                       </span>
-                    </div>
-                    <div className="text-sm">
-                      <strong>{approval.toolName}</strong>
-                      <pre className="mt-1 max-h-52 overflow-auto whitespace-pre-wrap break-words rounded bg-background p-2 text-xs">
-                        {JSON.stringify(approval.args, null, 2)}
-                      </pre>
-                    </div>
-                    <div className="mt-3 flex justify-end gap-2">
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        onClick={() =>
-                          decideApproval(approval.approvalId, "deny")
-                        }
-                      >
-                        Deny
-                      </Button>
-                      <Button
-                        type="button"
-                        size="sm"
-                        onClick={() =>
-                          decideApproval(approval.approvalId, "approve")
-                        }
-                      >
-                        Approve
-                      </Button>
-                    </div>
+                    </p>
                   </div>
-                </div>
-              ))}
-
-              {isLoading &&
-                pendingApprovals.length === 0 &&
-                messages[messages.length - 1]?.role === "user" && (
-                  <div className="flex justify-start">
-                    <div className="bg-muted rounded-lg px-4 py-2">
-                      <p className="text-sm text-muted-foreground animate-pulse">
-                        Thinking...
-                      </p>
-                    </div>
-                  </div>
-                )}
-
-              <div ref={messagesEndRef} />
-            </div>
-
-            <div className="border-t p-4">
-              {hasAutocomplete && (suggestion || isAutocompleting) && (
-                <div className="flex items-center gap-2 mb-2 text-xs text-muted-foreground">
-                  {isAutocompleting && (
-                    <span className="animate-pulse">Thinking...</span>
-                  )}
-                  {suggestion && (
-                    <span>
-                      Press{" "}
-                      <kbd className="px-1.5 py-0.5 rounded bg-muted border text-[10px] font-mono">
-                        Tab
-                      </kbd>{" "}
-                      to accept suggestion
+                  {hasAutocomplete && (
+                    <span className="text-xs text-muted-foreground bg-muted px-2 py-1 rounded">
+                      Autocomplete enabled
                     </span>
                   )}
                 </div>
-              )}
-              <form
-                onSubmit={(e) => {
-                  e.preventDefault();
-                  sendMessage();
-                }}
-                className="flex gap-2"
-              >
-                <div className="flex-1 relative">
-                  <div
-                    aria-hidden
-                    className="absolute inset-0 px-3 py-2 text-sm pointer-events-none whitespace-pre-wrap break-words overflow-hidden"
-                  >
-                    <span className="invisible">{input}</span>
-                    <span className="text-muted-foreground/40">
-                      {suggestion}
-                    </span>
-                  </div>
-                  <textarea
-                    ref={inputRef}
-                    value={input}
-                    onChange={(e) => handleInputChange(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Tab" && suggestion) {
-                        e.preventDefault();
-                        acceptSuggestion();
-                      }
-                      if (e.key === "Escape" && suggestion) {
-                        clearSuggestion();
-                      }
-                      if (e.key === "Enter" && !e.shiftKey && !suggestion) {
-                        e.preventDefault();
-                        sendMessage();
-                      }
-                    }}
-                    placeholder="Ask a question..."
-                    disabled={isLoading}
-                    rows={1}
-                    className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50 resize-none"
-                  />
-                </div>
-                <Button
-                  type="submit"
-                  disabled={isLoading || !input.trim()}
-                  className="self-end"
-                >
-                  Send
-                </Button>
-              </form>
-            </div>
-          </div>
 
-          <div className="w-80 shrink-0 flex flex-col border rounded-lg bg-card">
-            <div className="px-3 py-2 border-b">
-              <h3 className="text-sm font-semibold text-muted-foreground">
-                Event Stream
-              </h3>
-            </div>
-            <div className="flex-1 overflow-y-auto p-3 space-y-1">
-              {events.length === 0 && (
-                <p className="text-xs text-muted-foreground/50 text-center py-8">
-                  Events will appear here
-                </p>
-              )}
-              {events.map((event, i) => {
-                let detail: string;
-                switch (event.type) {
-                  case "response.output_text.delta":
-                    detail = event.delta?.slice(0, 60) ?? "";
-                    break;
-                  case "response.output_item.added":
-                  case "response.output_item.done":
-                    detail =
-                      event.item?.type === "function_call"
-                        ? `${event.item.name}(${(event.item.arguments ?? "").slice(0, 40)})`
-                        : event.item?.type === "function_call_output"
-                          ? (event.item.output?.slice(0, 60) ?? "")
-                          : (event.item?.status ?? event.item?.type ?? "");
-                    break;
-                  case "response.completed":
-                    detail = "done";
-                    break;
-                  case "error":
-                    detail = event.error ?? "unknown";
-                    break;
-                  case "appkit.metadata":
-                    detail = JSON.stringify(event.data).slice(0, 60);
-                    break;
-                  case "appkit.thinking":
-                    detail = event.content?.slice(0, 60) ?? "";
-                    break;
-                  default:
-                    detail = JSON.stringify(event).slice(0, 60);
-                }
-                return (
-                  <div
-                    key={`${event.type}-${i}`}
-                    className="font-mono text-xs text-muted-foreground"
-                  >
-                    <span className="inline-block w-24 text-right mr-2 opacity-50">
-                      {event.type
-                        .replace("response.", "")
-                        .replace("appkit.", "")}
-                    </span>
-                    <span className="opacity-80 break-all">{detail}</span>
+                <div className="flex gap-6 h-[700px]">
+                  <div className="flex-1 flex flex-col border rounded-lg bg-card min-w-0">
+                    <div
+                      ref={containerRef}
+                      className="flex-1 overflow-y-auto p-4 space-y-4"
+                    >
+                      {messages.length === 0 && (
+                        <div className="text-center text-muted-foreground py-20">
+                          <p className="text-lg">
+                            Send a message to start a conversation
+                          </p>
+                          <p className="text-sm mt-2">
+                            The agent can use analytics, files, genie, and
+                            lakebase tools.
+                            {hasAutocomplete &&
+                              " Start typing for inline suggestions."}
+                          </p>
+                        </div>
+                      )}
+
+                      {messages.map((msg) => {
+                        const body = messageBodyText(msg);
+                        if (!body) return null;
+                        return (
+                          <div
+                            key={msg.id}
+                            className={`flex ${
+                              msg.role === "user"
+                                ? "justify-end"
+                                : "justify-start"
+                            }`}
+                          >
+                            <div
+                              className={`max-w-[85%] rounded-lg px-4 py-2 ${
+                                msg.role === "user"
+                                  ? "bg-primary text-primary-foreground"
+                                  : "bg-muted"
+                              }`}
+                            >
+                              <p className="whitespace-pre-wrap text-sm">
+                                {body}
+                              </p>
+                            </div>
+                          </div>
+                        );
+                      })}
+
+                      {pendingApprovals.map((approval) => (
+                        <div
+                          key={approval.approvalId}
+                          className="flex justify-start"
+                        >
+                          <div className="max-w-[80%] rounded-lg border border-orange-500/60 bg-orange-500/10 px-4 py-3">
+                            <div className="mb-2 flex items-center gap-2">
+                              <span className="rounded bg-orange-600 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-white">
+                                Destructive tool — approval required
+                              </span>
+                            </div>
+                            <div className="text-sm">
+                              <strong>{approval.toolName}</strong>
+                              <pre className="mt-1 max-h-52 overflow-auto whitespace-pre-wrap break-words rounded bg-background p-2 text-xs">
+                                {JSON.stringify(approval.args, null, 2)}
+                              </pre>
+                            </div>
+                            <div className="mt-3 flex justify-end gap-2">
+                              <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                onClick={() =>
+                                  decideApproval(
+                                    approval.approvalId,
+                                    approval.streamId,
+                                    "deny",
+                                  )
+                                }
+                              >
+                                Deny
+                              </Button>
+                              <Button
+                                type="button"
+                                size="sm"
+                                onClick={() =>
+                                  decideApproval(
+                                    approval.approvalId,
+                                    approval.streamId,
+                                    "approve",
+                                  )
+                                }
+                              >
+                                Approve
+                              </Button>
+                            </div>
+                          </div>
+                        </div>
+                      ))}
+
+                      {showThinking && (
+                        <div className="flex justify-start">
+                          <div className="bg-muted rounded-lg px-4 py-2">
+                            <p className="text-sm text-muted-foreground animate-pulse">
+                              Thinking...
+                            </p>
+                          </div>
+                        </div>
+                      )}
+
+                      {error && (
+                        <div className="flex justify-start">
+                          <div className="max-w-[85%] rounded-lg border border-red-500/60 bg-red-500/10 px-4 py-2">
+                            <p className="text-sm">Error: {error.message}</p>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+
+                    <div className="border-t p-4">
+                      {hasAutocomplete && (suggestion || isAutocompleting) && (
+                        <div className="flex items-center gap-2 mb-2 text-xs text-muted-foreground">
+                          {isAutocompleting && (
+                            <span className="animate-pulse">Thinking...</span>
+                          )}
+                          {suggestion && (
+                            <span>
+                              Press{" "}
+                              <kbd className="px-1.5 py-0.5 rounded bg-muted border text-[10px] font-mono">
+                                Tab
+                              </kbd>{" "}
+                              to accept suggestion
+                            </span>
+                          )}
+                        </div>
+                      )}
+                      <ChatInput
+                        onSubmit={(message) => {
+                          // Cancel pending autocomplete so its debounced
+                          // request doesn't fire on stale input.
+                          clearSuggestion();
+                          return sendMessage(message);
+                        }}
+                        status={status}
+                        stop={stop}
+                      >
+                        {({
+                          value,
+                          onChange,
+                          submit,
+                          isStreaming,
+                          canSubmit,
+                          handleKeyDown,
+                        }) => (
+                          <form onSubmit={submit} className="flex gap-2">
+                            <div className="flex-1 relative">
+                              <div
+                                aria-hidden
+                                className="absolute inset-0 px-3 py-2 text-sm pointer-events-none whitespace-pre-wrap break-words overflow-hidden"
+                              >
+                                <span className="invisible">{value}</span>
+                                <span className="text-muted-foreground/40">
+                                  {suggestion}
+                                </span>
+                              </div>
+                              <textarea
+                                ref={inputRef}
+                                value={value}
+                                onChange={(e) => {
+                                  onChange(e.target.value);
+                                  requestSuggestion(e.target.value);
+                                }}
+                                onKeyDown={(e) => {
+                                  if (e.key === "Tab" && suggestion) {
+                                    e.preventDefault();
+                                    onChange(value + suggestion);
+                                    clearSuggestion();
+                                    inputRef.current?.focus();
+                                    return;
+                                  }
+                                  if (e.key === "Escape" && suggestion) {
+                                    clearSuggestion();
+                                    return;
+                                  }
+                                  // Don't submit while a suggestion is shown.
+                                  if (suggestion) return;
+                                  handleKeyDown(e);
+                                }}
+                                placeholder="Ask a question..."
+                                disabled={isStreaming}
+                                rows={1}
+                                className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50 resize-none"
+                              />
+                            </div>
+                            {isStreaming ? (
+                              <Button
+                                type="button"
+                                variant="outline"
+                                onClick={stop}
+                                className="self-end"
+                              >
+                                Stop
+                              </Button>
+                            ) : (
+                              <Button
+                                type="submit"
+                                disabled={!canSubmit}
+                                className="self-end"
+                              >
+                                Send
+                              </Button>
+                            )}
+                          </form>
+                        )}
+                      </ChatInput>
+                    </div>
                   </div>
-                );
-              })}
-            </div>
-          </div>
-        </div>
+
+                  <EventStreamPanel chunks={streamLog} />
+                </div>
+              </>
+            );
+          }}
+        </Conversation>
       </div>
     </div>
   );
+}
+
+// Debug panel: one row per chunk, no coalescing.
+function EventStreamPanel({
+  chunks,
+}: {
+  chunks: Array<{ id: number; chunk: UIMessageChunk }>;
+}) {
+  return (
+    <div className="w-80 shrink-0 flex flex-col border rounded-lg bg-card">
+      <div className="px-3 py-2 border-b flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-muted-foreground">
+          Event Stream
+        </h3>
+        <span className="text-[10px] font-mono text-muted-foreground/60">
+          {chunks.length} chunk{chunks.length === 1 ? "" : "s"}
+        </span>
+      </div>
+      <div className="flex-1 overflow-y-auto p-3 space-y-1">
+        {chunks.length === 0 && (
+          <p className="text-xs text-muted-foreground/50 text-center py-8">
+            Events will appear here
+          </p>
+        )}
+        {chunks.map(({ id, chunk }) => {
+          const { label, detail } = describeChunk(chunk);
+          return (
+            <div key={id} className="font-mono text-xs text-muted-foreground">
+              <span className="inline-block w-24 text-right mr-2 opacity-50">
+                {label}
+              </span>
+              <span className="opacity-80 break-all">{detail}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function describeChunk(chunk: UIMessageChunk): {
+  label: string;
+  detail: string;
+} {
+  const c = chunk as Record<string, unknown> & { type: string };
+  if (c.type === "text-delta") {
+    return { label: "text-Δ", detail: String(c.delta ?? "").slice(0, 80) };
+  }
+  if (c.type === "reasoning-delta") {
+    return {
+      label: "reasoning-Δ",
+      detail: String(c.delta ?? "").slice(0, 80),
+    };
+  }
+  if (c.type === "tool-input-available") {
+    return {
+      label: `tool→ ${String(c.toolName ?? "?")}`,
+      detail: safeStringify(c.input).slice(0, 80),
+    };
+  }
+  if (c.type === "tool-output-available") {
+    return {
+      label: `tool← ${String(c.toolName ?? "?")}`,
+      detail: safeStringify(c.output).slice(0, 80),
+    };
+  }
+  if (c.type.startsWith("data-")) {
+    return {
+      label: c.type.replace(/^data-/, "data:"),
+      detail: safeStringify(c.data).slice(0, 80),
+    };
+  }
+  return { label: c.type, detail: "" };
+}
+
+function safeStringify(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === undefined) return "";
+  try {
+    return JSON.stringify(value) ?? "";
+  } catch {
+    return String(value);
+  }
 }

--- a/docs/docs/api/appkit-ui/chat/ChatInput.mdx
+++ b/docs/docs/api/appkit-ui/chat/ChatInput.mdx
@@ -1,0 +1,37 @@
+# ChatInput
+
+Render-prop component that owns the input string, debounces submit, handles `Enter` / `Shift+Enter` / IME composition, and forwards an `isStreaming` flag for stop-button toggles. Wire `onSubmit`, `status`, and `stop` from `useChat` / `Conversation`; the render prop returns a `submit` callback you can attach to either a form `onSubmit` or a button `onClick`.
+
+
+## ChatInput
+
+Render-prop component that owns the input string, debounces submit,
+handles `Enter` / `Shift+Enter` / IME composition, and forwards an
+`isStreaming` flag for stop-button toggles. Wire `onSubmit`, `status`,
+and `stop` from `useChat` / `Conversation`; the render prop returns a
+`submit` callback you can attach to either a form `onSubmit` or a
+button `onClick`.
+
+
+**Source:** [`packages/appkit-ui/src/react/chat/headless/chat-input.tsx`](https://github.com/databricks/appkit/blob/main/packages/appkit-ui/src/react/chat/headless/chat-input.tsx)
+
+
+### Props
+
+| Prop | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `onSubmit` | `(message?: (Omit<TMessage, "id" \| "role"> & { id?: TMessage["id"] \| undefined; role?: TMessage["role"] \| undefined; } & { text?: undefined; files?: undefined; messageId?: string \| undefined; }) \| { ...; } \| { ...; } \| undefined, options?: ChatRequestOptions \| undefined) => Promise<...>` | ✓ | - | Pass `sendMessage` straight through from `useChat` / `Conversation`. |
+| `status` | `enum` | ✓ | - | Pass `status` from the chat helpers — drives `isStreaming`. |
+| `stop` | `() => void` | ✓ | - | Pass `stop` from the chat helpers — exposed back to the render prop. |
+| `children` | `(props: ChatInputRenderProps) => ReactNode` | ✓ | - | Render prop receiving the input state and submit/stop handlers. |
+
+
+
+### Usage
+
+```tsx
+import { ChatInput } from '@databricks/appkit-ui';
+
+<ChatInput /* props */ />
+```
+

--- a/docs/docs/api/appkit-ui/chat/Conversation.mdx
+++ b/docs/docs/api/appkit-ui/chat/Conversation.mdx
@@ -1,0 +1,41 @@
+# Conversation
+
+Render-prop convenience over `useChat` + `useScrollToBottom`. Streams Responses-API SSE from an AppKit `agents()`-backed endpoint, captures the server-allocated `threadId` for multi-turn continuity, and auto-sticks the scroll container to the bottom while the user is at the bottom. Drop down to the underlying hooks for non-standard layouts (split panes, virtualized lists, external send buttons).
+
+
+## Conversation
+
+Render-prop convenience over `useChat` + `useScrollToBottom`. Streams
+Responses-API SSE from an AppKit `agents()`-backed endpoint, captures
+the server-allocated `threadId` for multi-turn continuity, and
+auto-sticks the scroll container to the bottom while the user is at
+the bottom. Drop down to the underlying hooks for non-standard
+layouts (split panes, virtualized lists, external send buttons).
+
+
+**Source:** [`packages/appkit-ui/src/react/chat/headless/conversation.tsx`](https://github.com/databricks/appkit/blob/main/packages/appkit-ui/src/react/chat/headless/conversation.tsx)
+
+
+### Props
+
+| Prop | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `children` | `(props: ConversationRenderProps<TMessage>) => ReactNode` | ✓ | - | Render prop receiving merged `useChat` + `useScrollToBottom` state. |
+| `api` | `string` | ✓ | - | Chat endpoint URL (e.g. "/api/agents/chat"). |
+| `id` | `string` |  | - | Stable chat id. Defaults to a fresh UUID per mount. |
+| `messages` | `TMessage[]` |  | - | Initial messages (e.g. when hydrating from history). |
+| `headers` | `Resolvable<Record<string, string> \| Headers>` |  | - | Extra fetch headers forwarded to the transport. |
+| `onData` | `ChatOnDataCallback<TMessage>` |  | - | Fires for every `data-*` chunk (e.g. `data-approval-pending`). |
+| `onStreamPart` | `((chunk: UIMessageChunk) => void)` |  | - | Fires synchronously for every chunk. Unaffected by render throttling. |
+| `onError` | `((error: Error) => void)` |  | - | Called on stream errors. |
+
+
+
+### Usage
+
+```tsx
+import { Conversation } from '@databricks/appkit-ui';
+
+<Conversation /* props */ />
+```
+

--- a/docs/docs/api/appkit-ui/chat/_category_.json
+++ b/docs/docs/api/appkit-ui/chat/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Chat primitives",
+  "position": 7
+}

--- a/docs/docs/api/appkit-ui/chat/index.md
+++ b/docs/docs/api/appkit-ui/chat/index.md
@@ -1,0 +1,302 @@
+---
+sidebar_position: 6
+---
+
+# Chat primitives
+
+Headless React building blocks for talking to the AppKit [`agents`](../../plugins/agents.md) plugin from the browser. The primitives are an opinionated wrapper over the [Vercel AI SDK](https://sdk.vercel.ai/) (`@ai-sdk/react`, `ai`) that translates the agents plugin's Responses-API SSE wire format into the SDK's `UIMessageChunk` protocol — so you get streaming text, reasoning, tool calls, approval gates, and thread continuity without writing a server-side adapter.
+
+Everything ships from a single subpath import:
+
+```ts
+import {
+  Conversation,
+  ChatInput,
+  ResponsesApiTransport,
+  useChat,
+  useScrollToBottom,
+} from "@databricks/appkit-ui/react/chat";
+```
+
+`@ai-sdk/react` and `ai` are **optional peer dependencies**. Install them in your app if you use these primitives:
+
+```bash
+pnpm add @ai-sdk/react ai
+```
+
+## Quick start
+
+The smallest end-to-end chat against an `agents()`-backed AppKit server:
+
+```tsx
+import {
+  ChatInput,
+  Conversation,
+} from "@databricks/appkit-ui/react/chat";
+
+export function Chat() {
+  return (
+    <Conversation api="/api/agents/chat">
+      {({ messages, status, sendMessage, stop, containerRef }) => (
+        <div className="flex flex-col h-[600px] border rounded-lg">
+          <div ref={containerRef} className="flex-1 overflow-y-auto p-4 space-y-2">
+            {messages.map((m) => (
+              <div key={m.id} className={m.role === "user" ? "text-right" : "text-left"}>
+                {m.parts.map((p, i) =>
+                  p.type === "text" ? <p key={i}>{p.text}</p> : null,
+                )}
+              </div>
+            ))}
+          </div>
+          <ChatInput onSubmit={sendMessage} status={status} stop={stop}>
+            {({ value, onChange, submit, isStreaming, canSubmit, handleKeyDown }) => (
+              <form onSubmit={submit} className="border-t p-3 flex gap-2">
+                <input
+                  value={value}
+                  onChange={(e) => onChange(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  disabled={isStreaming}
+                  placeholder="Ask a question…"
+                  className="flex-1"
+                />
+                <button type="submit" disabled={!canSubmit}>Send</button>
+              </form>
+            )}
+          </ChatInput>
+        </div>
+      )}
+    </Conversation>
+  );
+}
+```
+
+That single component:
+
+- Posts to `POST /api/agents/chat` (the agents plugin's default route).
+- Streams Responses-API SSE back, translates each event to a `UIMessageChunk` on the fly, and feeds the AI SDK reducer.
+- Captures the server-allocated `threadId` from `appkit.metadata` events and replays it on every subsequent request — multi-turn conversations Just Work, no wiring required.
+- Auto-sticks the scroll container to the bottom as long as the user hasn't scrolled up.
+
+## How it fits together
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  <Conversation>                                          │
+│   ├─ useChat()             ── stable id + threadId ref   │
+│   │   └─ ResponsesApiTransport                           │
+│   │        ├─ prepareSendMessagesRequest                 │
+│   │        │   → { message, threadId?, ...extras }       │
+│   │        └─ processResponseStream                      │
+│   │            SSE bytes → text → events → UIChunks      │
+│   └─ useScrollToBottom()   ── containerRef + auto-stick  │
+│                                                          │
+│  <ChatInput>                                             │
+│   value / submit / canSubmit / handleKeyDown / stop      │
+└──────────────────────────────────────────────────────────┘
+```
+
+The `Conversation` component is a thin render-prop convenience over `useChat` + `useScrollToBottom`. Reach for the underlying hooks when you need a non-standard layout (split panes, virtualized lists, etc).
+
+## `useChat`
+
+A minimal wrapper around the AI SDK's `useChat` that wires up `ResponsesApiTransport` and stabilizes the chat `id` and `threadId` across re-renders.
+
+```ts
+const chat = useChat<AgentUIMessage>({
+  api: "/api/agents/chat",
+  onData: (part) => { /* react to data-* parts */ },
+  onError: (err) => console.error(err),
+});
+```
+
+### Options
+
+| Option         | Type                                    | Required | Description |
+|----------------|-----------------------------------------|----------|-------------|
+| `api`          | `string`                                | ✓        | Chat endpoint URL (typically `/api/agents/chat`). |
+| `id`           | `string`                                |          | Stable chat id. Defaults to a fresh UUID per mount. |
+| `messages`     | `TMessage[]`                            |          | Initial messages (e.g. when hydrating from history). |
+| `headers`      | fetch headers / accessor                |          | Extra request headers forwarded to the transport. |
+| `onData`       | `(part) => void`                        |          | Fires for every `data-*` chunk. Use this to react to AppKit-specific data parts like `data-approval-pending`. |
+| `onStreamPart` | `(chunk: UIMessageChunk) => void`       |          | Fires synchronously for every translated chunk before the reducer sees it. Ideal for debug panels and stream logs — unaffected by render throttling. |
+| `onError`      | `(error: Error) => void`                |          | Network, transport, or server-side stream errors. |
+
+### Returns
+
+The full [`UseChatHelpers`](https://sdk.vercel.ai/docs/reference/ai-sdk-ui/use-chat) surface (`messages`, `status`, `error`, `sendMessage`, `stop`, …) plus a stable `id`.
+
+### Thread continuity
+
+The first SSE event of a new conversation carries an `appkit.metadata` payload with the server-allocated `threadId`. The hook stashes it in a ref, then `ResponsesApiTransport` echoes it on subsequent requests — even if the transport is re-created mid-session (e.g. because `headers` is passed as an inline object literal). You don't need to manage thread ids yourself.
+
+## `useScrollToBottom`
+
+Tracks whether a scroll container is at the bottom and exposes an imperative `scrollToBottom`. When `trigger` changes and the user was already at the bottom, the container auto-sticks — preserving the typical chat "follow latest" behavior without overriding manual scroll-up.
+
+```ts
+const { containerRef, isAtBottom, scrollToBottom } =
+  useScrollToBottom<HTMLDivElement>({ trigger: messages });
+```
+
+| Option      | Type      | Default | Description |
+|-------------|-----------|---------|-------------|
+| `threshold` | `number`  | `50`    | Pixels from the bottom that still count as "at bottom". |
+| `trigger`   | `unknown` | —       | Reactive value (usually `messages`) that triggers an auto-stick when the user is at the bottom. |
+
+`scrollToBottom(behavior)` defaults to `"smooth"`. The auto-stick path uses `"instant"` to avoid piling up smooth-scroll animations under throttled streaming re-renders.
+
+## `<Conversation>`
+
+Render-prop component that combines `useChat` and `useScrollToBottom` for the common case. Accepts every `useChat` option as a top-level prop and exposes both hooks' return values to its `children` callback.
+
+```tsx
+<Conversation<AgentUIMessage>
+  api="/api/agents/chat"
+  onData={(part) => {/* … */}}
+>
+  {({ messages, status, sendMessage, stop, containerRef, isAtBottom, scrollToBottom }) => (
+    /* … */
+  )}
+</Conversation>
+```
+
+If you need to drive the chat from outside the render tree (e.g. an external "Send" button), drop down to `useChat` directly.
+
+## `<ChatInput>`
+
+Render-prop component that owns the input string, debounces submit, handles `Enter`/`Shift+Enter`/IME composition, and forwards an `isStreaming` flag for stop-button toggles.
+
+```tsx
+<ChatInput<AgentUIMessage> onSubmit={sendMessage} status={status} stop={stop}>
+  {({ value, onChange, submit, isStreaming, stop, canSubmit, handleKeyDown }) => (
+    <form onSubmit={submit}>
+      <textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+        disabled={isStreaming}
+      />
+      {isStreaming
+        ? <button type="button" onClick={stop}>Stop</button>
+        : <button type="submit" disabled={!canSubmit}>Send</button>}
+    </form>
+  )}
+</ChatInput>
+```
+
+| Prop       | Type                                      | Description |
+|------------|-------------------------------------------|-------------|
+| `onSubmit` | `UseChatHelpers<TMessage>["sendMessage"]` | Pass `sendMessage` straight through from `useChat` / `Conversation`. |
+| `status`   | `ChatStatus`                              | Pass `status` from the chat helpers — drives `isStreaming`. |
+| `stop`     | `() => void`                              | Pass `stop` from the chat helpers — exposed back to the render prop for stop buttons. |
+
+The render prop returns a `submit` callback you can wire to either a form `onSubmit` or a button `onClick`. `Enter` submits (unless `Shift` is held or an IME is composing); the input clears on successful submit.
+
+## Typed messages
+
+Pass a `UIMessage` subtype to type `messages[].parts`, `onData`, and `sendMessage` end-to-end:
+
+```ts
+import type { UIMessage } from "ai";
+
+type MyMessage = UIMessage<unknown, {
+  "approval-pending": { approvalId: string; toolName: string };
+}>;
+
+const chat = useChat<MyMessage>({ api: "/api/agents/chat" });
+```
+
+The data-parts map must be a `type` (not `interface`) to satisfy the SDK's `Record<string, unknown>` constraint.
+
+## Approval gates
+
+When the agents plugin emits an `appkit.approval_pending` SSE event (a destructive tool is paused on the server-side approval gate), the transport surfaces it as a `data-approval-pending` chunk. Subscribe via `onData`:
+
+```tsx
+<Conversation
+  api="/api/agents/chat"
+  onData={(part) => {
+    if (part.type === "data-approval-pending") {
+      const { approvalId, streamId, toolName, args } = part.data;
+      // Render an approval card; POST the decision back to the plugin:
+      // fetch("/api/agents/approve", {
+      //   method: "POST",
+      //   body: JSON.stringify({ streamId, approvalId, decision: "approve" }),
+      // });
+    }
+  }}
+>
+  {/* … */}
+</Conversation>
+```
+
+The chunk `id` is the `approvalId`, so duplicate events (re-renders, reconnects) collapse cleanly.
+
+## `ResponsesApiTransport`
+
+The `Conversation` / `useChat` flow is enough for almost every consumer. Drop down to the transport directly if you're composing it with a different React hook surface (e.g. plain `@ai-sdk/react`'s `useChat`) or you need to extend `prepareSendMessagesRequest` to carry attachments, agent ids, or other custom body fields.
+
+```ts
+import { ResponsesApiTransport } from "@databricks/appkit-ui/react/chat";
+import { useChat } from "@ai-sdk/react";
+
+const threadIdRef = useRef<string | undefined>(undefined);
+
+const transport = useMemo(
+  () =>
+    new ResponsesApiTransport({
+      api: "/api/agents/chat",
+      getThreadId: () => threadIdRef.current,
+      onThreadId: (tid) => { threadIdRef.current = tid; },
+    }),
+  [],
+);
+
+const chat = useChat({ transport });
+```
+
+### Constructor options
+
+Extends `HttpChatTransportInitOptions` (everything except `prepareSendMessagesRequest`, which is owned by the transport) with:
+
+| Option         | Type                                | Description |
+|----------------|-------------------------------------|-------------|
+| `getThreadId`  | `() => string \| undefined`         | Read the persisted server thread id. Held outside the transport so re-creation doesn't fork the conversation. |
+| `onThreadId`   | `(id: string) => void`              | Persist the server thread id snooped from the first `appkit.metadata` event. |
+| `onStreamPart` | `(chunk: UIMessageChunk) => void`   | Synchronous tap fired before each chunk reaches the SDK reducer. |
+
+### Wire format
+
+`prepareSendMessagesRequest` builds:
+
+```json
+{
+  "message": "<latest user-message text>",
+  "threadId": "<server-allocated id, omitted on first request>",
+  "...extras": "any non-reserved fields you pass via `body`"
+}
+```
+
+`message` and `threadId` are reserved — values you pass via the `body` option for those keys are ignored. Any other fields you set on `body` are passed through (useful for routing to a specific agent: `body: { agent: "support" }`).
+
+### Event translation
+
+| Server (`ResponseStreamEvent`)                        | Client (`UIMessageChunk`)                            |
+|-------------------------------------------------------|------------------------------------------------------|
+| `response.output_item.added` (`type: message`)        | `text-start`                                         |
+| `response.output_text.delta`                          | `text-delta`                                         |
+| `response.output_item.done` (`type: message`)         | `text-end`                                           |
+| `response.output_item.added` (`function_call`)        | `tool-input-available`                               |
+| `response.output_item.added` (`function_call_output`) | `tool-output-available`                              |
+| `appkit.thinking`                                     | `reasoning-start` (lazy) + `reasoning-delta`         |
+| `appkit.metadata`                                     | `message-metadata` (and captures `threadId`)         |
+| `appkit.approval_pending`                             | `data-approval-pending`                              |
+| `error` / `response.failed`                           | `error` + `finish`                                   |
+| `response.completed`                                  | `finish`                                             |
+
+A defensive `finish` is emitted in the transform's `flush` callback so the SDK leaves the streaming state even if the server's terminal event is lost (disconnect, timeout).
+
+## Limitations
+
+- **Text-only user messages.** The agents plugin's `chatRequestSchema` accepts `message: string` only. The transport `console.warn`s and drops non-text parts (images, files) from the latest user message. Subclass `ResponsesApiTransport` and override `prepareSendMessagesRequest` to carry attachments via a parallel field, or use a different server endpoint.
+- **Beta peer dependencies.** This release is pinned to `@ai-sdk/react@~4.0.0-beta` and `ai@~7.0.0-beta`. The wire-translator may need adjustments when the AI SDK reaches stable.

--- a/docs/static/appkit-ui/styles.gen.css
+++ b/docs/static/appkit-ui/styles.gen.css
@@ -8,8 +8,38 @@
       "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
     --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
       "Courier New", monospace;
+    --color-red-100: oklch(93.6% 0.032 17.717);
+    --color-red-300: oklch(80.8% 0.114 19.571);
+    --color-red-600: oklch(57.7% 0.245 27.325);
+    --color-red-700: oklch(50.5% 0.213 27.518);
+    --color-red-800: oklch(44.4% 0.177 26.899);
+    --color-red-900: oklch(39.6% 0.141 25.723);
+    --color-amber-50: oklch(98.7% 0.022 95.277);
+    --color-amber-100: oklch(96.2% 0.059 95.617);
+    --color-amber-200: oklch(92.4% 0.12 95.746);
+    --color-amber-300: oklch(87.9% 0.169 91.605);
+    --color-amber-400: oklch(82.8% 0.189 84.429);
+    --color-amber-600: oklch(66.6% 0.179 58.318);
+    --color-amber-700: oklch(55.5% 0.163 48.998);
+    --color-amber-800: oklch(47.3% 0.137 46.201);
+    --color-amber-900: oklch(41.4% 0.112 45.904);
+    --color-amber-950: oklch(27.9% 0.077 45.635);
+    --color-yellow-600: oklch(68.1% 0.162 75.834);
+    --color-green-100: oklch(96.2% 0.044 156.743);
+    --color-green-300: oklch(87.1% 0.15 154.449);
+    --color-green-600: oklch(62.7% 0.194 149.214);
+    --color-green-700: oklch(52.7% 0.154 150.069);
+    --color-green-900: oklch(39.3% 0.095 152.535);
     --color-sky-500: oklch(68.5% 0.169 237.323);
+    --color-blue-100: oklch(93.2% 0.032 255.585);
+    --color-blue-300: oklch(80.9% 0.105 251.813);
     --color-blue-500: oklch(62.3% 0.214 259.815);
+    --color-blue-600: oklch(54.6% 0.245 262.881);
+    --color-blue-700: oklch(48.8% 0.243 264.376);
+    --color-blue-800: oklch(42.4% 0.199 265.638);
+    --color-blue-900: oklch(37.9% 0.146 265.522);
+    --color-neutral-300: oklch(87% 0 0);
+    --color-neutral-600: oklch(43.9% 0 0);
     --color-black: #000;
     --color-white: #fff;
     --spacing: 0.25rem;
@@ -17,6 +47,9 @@
     --container-sm: 24rem;
     --container-md: 28rem;
     --container-lg: 32rem;
+    --container-xl: 36rem;
+    --container-3xl: 48rem;
+    --container-4xl: 56rem;
     --text-xs: 0.75rem;
     --text-xs--line-height: calc(1 / 0.75);
     --text-sm: 0.875rem;
@@ -25,6 +58,8 @@
     --text-base--line-height: calc(1.5 / 1);
     --text-lg: 1.125rem;
     --text-lg--line-height: calc(1.75 / 1.125);
+    --text-xl: 1.25rem;
+    --text-xl--line-height: calc(1.75 / 1.25);
     --text-2xl: 1.5rem;
     --text-2xl--line-height: calc(2 / 1.5);
     --text-4xl: 2.25rem;
@@ -37,6 +72,7 @@
     --font-weight-bold: 700;
     --tracking-tighter: -0.05em;
     --tracking-tight: -0.025em;
+    --tracking-wide: 0.025em;
     --tracking-widest: 0.1em;
     --leading-tight: 1.25;
     --leading-snug: 1.375;
@@ -47,9 +83,11 @@
     --radius-md: 0.375rem;
     --radius-lg: 0.5rem;
     --radius-xl: 0.75rem;
+    --radius-2xl: 1rem;
     --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
     --animate-spin: spin 1s linear infinite;
     --animate-pulse: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+    --blur-sm: 8px;
     --aspect-video: 16 / 9;
     --default-transition-duration: 150ms;
     --default-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
@@ -317,6 +355,9 @@
   .bottom-0 {
     bottom: calc(var(--spacing) * 0);
   }
+  .bottom-4 {
+    bottom: calc(var(--spacing) * 4);
+  }
   .-left-12 {
     left: calc(var(--spacing) * -12);
   }
@@ -425,6 +466,9 @@
   .-mt-4 {
     margin-top: calc(var(--spacing) * -4);
   }
+  .mt-0\.5 {
+    margin-top: calc(var(--spacing) * 0.5);
+  }
   .mt-1 {
     margin-top: calc(var(--spacing) * 1);
   }
@@ -443,6 +487,12 @@
   .mt-auto {
     margin-top: auto;
   }
+  .-mr-1\.5 {
+    margin-right: calc(var(--spacing) * -1.5);
+  }
+  .mr-1\.5 {
+    margin-right: calc(var(--spacing) * 1.5);
+  }
   .mr-2 {
     margin-right: calc(var(--spacing) * 2);
   }
@@ -458,8 +508,14 @@
   .mb-4 {
     margin-bottom: calc(var(--spacing) * 4);
   }
+  .mb-6 {
+    margin-bottom: calc(var(--spacing) * 6);
+  }
   .-ml-1 {
     margin-left: calc(var(--spacing) * -1);
+  }
+  .-ml-1\.5 {
+    margin-left: calc(var(--spacing) * -1.5);
   }
   .-ml-4 {
     margin-left: calc(var(--spacing) * -4);
@@ -505,6 +561,9 @@
   }
   .inline {
     display: inline;
+  }
+  .inline-block {
+    display: inline-block;
   }
   .inline-flex {
     display: inline-flex;
@@ -684,6 +743,9 @@
   .max-h-80 {
     max-height: calc(var(--spacing) * 80);
   }
+  .max-h-\[8lh\] {
+    max-height: 8lh;
+  }
   .max-h-\[300px\] {
     max-height: 300px;
   }
@@ -831,6 +893,12 @@
   .max-w-\(--skeleton-width\) {
     max-width: var(--skeleton-width);
   }
+  .max-w-3xl {
+    max-width: var(--container-3xl);
+  }
+  .max-w-4xl {
+    max-width: var(--container-4xl);
+  }
   .max-w-\[80\%\] {
     max-width: 80%;
   }
@@ -845,6 +913,9 @@
   }
   .max-w-sm {
     max-width: var(--container-sm);
+  }
+  .max-w-xl {
+    max-width: var(--container-xl);
   }
   .max-w-xs {
     max-width: var(--container-xs);
@@ -957,11 +1028,17 @@
     --tw-translate-y: calc(-50% - 2px);
     translate: var(--tw-translate-x) var(--tw-translate-y);
   }
+  .rotate-0 {
+    rotate: 0deg;
+  }
   .rotate-45 {
     rotate: 45deg;
   }
   .rotate-90 {
     rotate: 90deg;
+  }
+  .rotate-180 {
+    rotate: 180deg;
   }
   .transform {
     transform: var(--tw-rotate-x,) var(--tw-rotate-y,) var(--tw-rotate-z,) var(--tw-skew-x,) var(--tw-skew-y,);
@@ -1044,6 +1121,9 @@
   .place-content-center {
     place-content: center;
   }
+  .items-baseline {
+    align-items: baseline;
+  }
   .items-center {
     align-items: center;
   }
@@ -1106,6 +1186,13 @@
       --tw-space-y-reverse: 0;
       margin-block-start: calc(calc(var(--spacing) * 1) * var(--tw-space-y-reverse));
       margin-block-end: calc(calc(var(--spacing) * 1) * calc(1 - var(--tw-space-y-reverse)));
+    }
+  }
+  .space-y-1\.5 {
+    :where(& > :not(:last-child)) {
+      --tw-space-y-reverse: 0;
+      margin-block-start: calc(calc(var(--spacing) * 1.5) * var(--tw-space-y-reverse));
+      margin-block-end: calc(calc(var(--spacing) * 1.5) * calc(1 - var(--tw-space-y-reverse)));
     }
   }
   .space-y-2 {
@@ -1181,11 +1268,17 @@
   .rounded {
     border-radius: var(--radius);
   }
+  .rounded-2xl {
+    border-radius: var(--radius-2xl);
+  }
   .rounded-\[2px\] {
     border-radius: 2px;
   }
   .rounded-\[4px\] {
     border-radius: 4px;
+  }
+  .rounded-\[24px\] {
+    border-radius: 24px;
   }
   .rounded-\[calc\(var\(--radius\)-5px\)\] {
     border-radius: calc(var(--radius) - 5px);
@@ -1233,6 +1326,10 @@
     border-style: var(--tw-border-style);
     border-width: 0px;
   }
+  .border-4 {
+    border-style: var(--tw-border-style);
+    border-width: 4px;
+  }
   .border-\[1\.5px\] {
     border-style: var(--tw-border-style);
     border-width: 1.5px;
@@ -1264,6 +1361,21 @@
   .border-\(--color-border\) {
     border-color: var(--color-border);
   }
+  .border-amber-300 {
+    border-color: var(--color-amber-300);
+  }
+  .border-black\/\[0\.02\] {
+    border-color: color-mix(in srgb, #000 2%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      border-color: color-mix(in oklab, var(--color-black) 2%, transparent);
+    }
+  }
+  .border-black\/\[0\.08\] {
+    border-color: color-mix(in srgb, #000 8%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      border-color: color-mix(in oklab, var(--color-black) 8%, transparent);
+    }
+  }
   .border-border {
     border-color: var(--border);
   }
@@ -1273,8 +1385,17 @@
       border-color: color-mix(in oklab, var(--border) 50%, transparent);
     }
   }
+  .border-destructive\/30 {
+    border-color: var(--destructive);
+    @supports (color: color-mix(in lab, red, red)) {
+      border-color: color-mix(in oklab, var(--destructive) 30%, transparent);
+    }
+  }
   .border-input {
     border-color: var(--input);
+  }
+  .border-neutral-300 {
+    border-color: var(--color-neutral-300);
   }
   .border-primary {
     border-color: var(--primary);
@@ -1297,8 +1418,23 @@
   .bg-accent {
     background-color: var(--accent);
   }
+  .bg-amber-50\/50 {
+    background-color: color-mix(in srgb, oklch(98.7% 0.022 95.277) 50%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-amber-50) 50%, transparent);
+    }
+  }
+  .bg-amber-100 {
+    background-color: var(--color-amber-100);
+  }
   .bg-background {
     background-color: var(--background);
+  }
+  .bg-background\/75 {
+    background-color: var(--background);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--background) 75%, transparent);
+    }
   }
   .bg-black\/50 {
     background-color: color-mix(in srgb, #000 50%, transparent);
@@ -1306,14 +1442,29 @@
       background-color: color-mix(in oklab, var(--color-black) 50%, transparent);
     }
   }
+  .bg-blue-100 {
+    background-color: var(--color-blue-100);
+  }
   .bg-border {
     background-color: var(--border);
   }
   .bg-card {
     background-color: var(--card);
   }
+  .bg-card\/60 {
+    background-color: var(--card);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--card) 60%, transparent);
+    }
+  }
   .bg-destructive {
     background-color: var(--destructive);
+  }
+  .bg-destructive\/5 {
+    background-color: var(--destructive);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--destructive) 5%, transparent);
+    }
   }
   .bg-destructive\/10 {
     background-color: var(--destructive);
@@ -1323,6 +1474,12 @@
   }
   .bg-foreground {
     background-color: var(--foreground);
+  }
+  .bg-green-100 {
+    background-color: var(--color-green-100);
+  }
+  .bg-green-600 {
+    background-color: var(--color-green-600);
   }
   .bg-input {
     background-color: var(--input);
@@ -1342,6 +1499,12 @@
       background-color: color-mix(in oklab, var(--muted) 50%, transparent);
     }
   }
+  .bg-muted\/60 {
+    background-color: var(--muted);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--muted) 60%, transparent);
+    }
+  }
   .bg-popover {
     background-color: var(--popover);
   }
@@ -1353,6 +1516,9 @@
     @supports (color: color-mix(in lab, red, red)) {
       background-color: color-mix(in oklab, var(--primary) 20%, transparent);
     }
+  }
+  .bg-red-100 {
+    background-color: var(--color-red-100);
   }
   .bg-secondary {
     background-color: var(--secondary);
@@ -1405,8 +1571,14 @@
   .p-1 {
     padding: calc(var(--spacing) * 1);
   }
+  .p-1\.5 {
+    padding: calc(var(--spacing) * 1.5);
+  }
   .p-2 {
     padding: calc(var(--spacing) * 2);
+  }
+  .p-2\.5 {
+    padding: calc(var(--spacing) * 2.5);
   }
   .p-3 {
     padding: calc(var(--spacing) * 3);
@@ -1444,6 +1616,9 @@
   .px-3 {
     padding-inline: calc(var(--spacing) * 3);
   }
+  .px-3\.5 {
+    padding-inline: calc(var(--spacing) * 3.5);
+  }
   .px-4 {
     padding-inline: calc(var(--spacing) * 4);
   }
@@ -1468,6 +1643,9 @@
   .py-2 {
     padding-block: calc(var(--spacing) * 2);
   }
+  .py-2\.5 {
+    padding-block: calc(var(--spacing) * 2.5);
+  }
   .py-3 {
     padding-block: calc(var(--spacing) * 3);
   }
@@ -1485,6 +1663,9 @@
   }
   .pt-0 {
     padding-top: calc(var(--spacing) * 0);
+  }
+  .pt-1 {
+    padding-top: calc(var(--spacing) * 1);
   }
   .pt-2 {
     padding-top: calc(var(--spacing) * 2);
@@ -1515,6 +1696,9 @@
   }
   .pb-1 {
     padding-bottom: calc(var(--spacing) * 1);
+  }
+  .pb-2 {
+    padding-bottom: calc(var(--spacing) * 2);
   }
   .pb-3 {
     padding-bottom: calc(var(--spacing) * 3);
@@ -1596,6 +1780,9 @@
   .text-\[0\.70rem\] {
     font-size: 0.70rem;
   }
+  .text-\[10px\] {
+    font-size: 10px;
+  }
   .text-\[11px\] {
     font-size: 11px;
   }
@@ -1606,6 +1793,10 @@
   .leading-normal {
     --tw-leading: var(--leading-normal);
     line-height: var(--leading-normal);
+  }
+  .leading-relaxed {
+    --tw-leading: var(--leading-relaxed);
+    line-height: var(--leading-relaxed);
   }
   .leading-snug {
     --tw-leading: var(--leading-snug);
@@ -1639,6 +1830,10 @@
     --tw-tracking: var(--tracking-tighter);
     letter-spacing: var(--tracking-tighter);
   }
+  .tracking-wide {
+    --tw-tracking: var(--tracking-wide);
+    letter-spacing: var(--tracking-wide);
+  }
   .tracking-widest {
     --tw-tracking: var(--tracking-widest);
     letter-spacing: var(--tracking-widest);
@@ -1647,6 +1842,9 @@
     text-wrap: balance;
   }
   .break-words {
+    overflow-wrap: break-word;
+  }
+  .wrap-break-word {
     overflow-wrap: break-word;
   }
   .break-all {
@@ -1658,14 +1856,32 @@
   .whitespace-pre-wrap {
     white-space: pre-wrap;
   }
+  .text-\[var\(--success\)\] {
+    color: var(--success);
+  }
+  .text-\[var\(--warning\)\] {
+    color: var(--warning);
+  }
   .text-accent-foreground {
     color: var(--accent-foreground);
+  }
+  .text-amber-600 {
+    color: var(--color-amber-600);
+  }
+  .text-amber-700 {
+    color: var(--color-amber-700);
+  }
+  .text-amber-800 {
+    color: var(--color-amber-800);
   }
   .text-background {
     color: var(--background);
   }
   .text-blue-500 {
     color: var(--color-blue-500);
+  }
+  .text-blue-700 {
+    color: var(--color-blue-700);
   }
   .text-card-foreground {
     color: var(--card-foreground);
@@ -1679,8 +1895,17 @@
   .text-foreground {
     color: var(--foreground);
   }
+  .text-green-700 {
+    color: var(--color-green-700);
+  }
   .text-muted-foreground {
     color: var(--muted-foreground);
+  }
+  .text-muted-foreground\/50 {
+    color: var(--muted-foreground);
+    @supports (color: color-mix(in lab, red, red)) {
+      color: color-mix(in oklab, var(--muted-foreground) 50%, transparent);
+    }
   }
   .text-popover-foreground {
     color: var(--popover-foreground);
@@ -1690,6 +1915,9 @@
   }
   .text-primary-foreground {
     color: var(--primary-foreground);
+  }
+  .text-red-700 {
+    color: var(--color-red-700);
   }
   .text-secondary-foreground {
     color: var(--secondary-foreground);
@@ -1702,6 +1930,9 @@
     @supports (color: color-mix(in lab, red, red)) {
       color: color-mix(in oklab, var(--sidebar-foreground) 70%, transparent);
     }
+  }
+  .text-transparent {
+    color: transparent;
   }
   .text-white {
     color: var(--color-white);
@@ -1813,6 +2044,11 @@
   }
   .filter {
     filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
+  }
+  .backdrop-blur-sm {
+    --tw-backdrop-blur: blur(var(--blur-sm));
+    -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+    backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
   }
   .transition {
     transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to, opacity, box-shadow, transform, translate, scale, rotate, filter, -webkit-backdrop-filter, backdrop-filter, display, content-visibility, overlay, pointer-events;
@@ -1928,6 +2164,13 @@
   }
   .group-hover\/menu-item\:opacity-100 {
     &:is(:where(.group\/menu-item):hover *) {
+      @media (hover: hover) {
+        opacity: 100%;
+      }
+    }
+  }
+  .group-hover\/message\:opacity-100 {
+    &:is(:where(.group\/message):hover *) {
       @media (hover: hover) {
         opacity: 100%;
       }
@@ -2398,10 +2641,31 @@
       padding-bottom: calc(var(--spacing) * 0);
     }
   }
+  .focus-within\:border-ring\/40 {
+    &:focus-within {
+      border-color: var(--ring);
+      @supports (color: color-mix(in lab, red, red)) {
+        border-color: color-mix(in oklab, var(--ring) 40%, transparent);
+      }
+    }
+  }
+  .focus-within\:shadow-sm {
+    &:focus-within {
+      --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
+      box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+    }
+  }
   .hover\:cursor-pointer {
     &:hover {
       @media (hover: hover) {
         cursor: pointer;
+      }
+    }
+  }
+  .hover\:border-primary {
+    &:hover {
+      @media (hover: hover) {
+        border-color: var(--primary);
       }
     }
   }
@@ -2412,6 +2676,24 @@
       }
     }
   }
+  .hover\:bg-action-default-background-hover {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(
+    --action-default-background-hover
+  );
+      }
+    }
+  }
+  .hover\:bg-action-primary-background-hover {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(
+    --action-primary-background-hover
+  );
+      }
+    }
+  }
   .hover\:bg-destructive\/90 {
     &:hover {
       @media (hover: hover) {
@@ -2419,6 +2701,13 @@
         @supports (color: color-mix(in lab, red, red)) {
           background-color: color-mix(in oklab, var(--destructive) 90%, transparent);
         }
+      }
+    }
+  }
+  .hover\:bg-green-700 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-green-700);
       }
     }
   }
@@ -2597,6 +2886,12 @@
       }
     }
   }
+  .focus\:outline-none {
+    &:focus {
+      --tw-outline-style: none;
+      outline-style: none;
+    }
+  }
   .focus-visible\:z-10 {
     &:focus-visible {
       z-index: 10;
@@ -2605,6 +2900,11 @@
   .focus-visible\:border-ring {
     &:focus-visible {
       border-color: var(--ring);
+    }
+  }
+  .focus-visible\:opacity-100 {
+    &:focus-visible {
+      opacity: 100%;
     }
   }
   .focus-visible\:ring-0 {
@@ -2664,6 +2964,12 @@
       --tw-ring-offset-shadow: var(--tw-ring-inset,) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
     }
   }
+  .focus-visible\:ring-offset-2 {
+    &:focus-visible {
+      --tw-ring-offset-width: 2px;
+      --tw-ring-offset-shadow: var(--tw-ring-inset,) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+    }
+  }
   .focus-visible\:outline-hidden {
     &:focus-visible {
       --tw-outline-style: none;
@@ -2691,6 +2997,20 @@
       outline-style: none;
     }
   }
+  .active\:bg-action-default-background-press {
+    &:active {
+      background-color: var(
+    --action-default-background-press
+  );
+    }
+  }
+  .active\:bg-action-primary-background-press {
+    &:active {
+      background-color: var(
+    --action-primary-background-press
+  );
+    }
+  }
   .active\:bg-sidebar-accent {
     &:active {
       background-color: var(--sidebar-accent);
@@ -2711,9 +3031,24 @@
       cursor: not-allowed;
     }
   }
+  .disabled\:bg-muted {
+    &:disabled {
+      background-color: var(--muted);
+    }
+  }
+  .disabled\:text-muted-foreground {
+    &:disabled {
+      color: var(--muted-foreground);
+    }
+  }
   .disabled\:opacity-50 {
     &:disabled {
       opacity: 50%;
+    }
+  }
+  .disabled\:opacity-60 {
+    &:disabled {
+      opacity: 60%;
     }
   }
   .in-data-\[side\=left\]\:cursor-w-resize {
@@ -3563,6 +3898,11 @@
       --tw-exit-translate-y: -100%;
     }
   }
+  .data-\[state\=closed\]\:slide-out-to-top-2 {
+    &[data-state="closed"] {
+      --tw-exit-translate-y: calc(2*var(--spacing)*-1);
+    }
+  }
   .group-data-\[viewport\=false\]\/navigation-menu\:data-\[state\=closed\]\:animate-out {
     &:is(:where(.group\/navigation-menu)[data-viewport="false"] *) {
       &[data-state="closed"] {
@@ -3696,6 +4036,11 @@
   .data-\[state\=open\]\:slide-in-from-top {
     &[data-state="open"] {
       --tw-enter-translate-y: -100%;
+    }
+  }
+  .data-\[state\=open\]\:slide-in-from-top-2 {
+    &[data-state="open"] {
+      --tw-enter-translate-y: calc(2*var(--spacing)*-1);
     }
   }
   .group-data-\[viewport\=false\]\/navigation-menu\:data-\[state\=open\]\:animate-in {
@@ -4086,9 +4431,29 @@
       gap: calc(var(--spacing) * 1.5);
     }
   }
+  .md\:gap-6 {
+    @media (width >= 48rem) {
+      gap: calc(var(--spacing) * 6);
+    }
+  }
   .md\:p-12 {
     @media (width >= 48rem) {
       padding: calc(var(--spacing) * 12);
+    }
+  }
+  .md\:px-4 {
+    @media (width >= 48rem) {
+      padding-inline: calc(var(--spacing) * 4);
+    }
+  }
+  .md\:px-6 {
+    @media (width >= 48rem) {
+      padding-inline: calc(var(--spacing) * 6);
+    }
+  }
+  .md\:pb-4 {
+    @media (width >= 48rem) {
+      padding-bottom: calc(var(--spacing) * 4);
     }
   }
   .md\:text-left {
@@ -4096,10 +4461,22 @@
       text-align: left;
     }
   }
+  .md\:text-base {
+    @media (width >= 48rem) {
+      font-size: var(--text-base);
+      line-height: var(--tw-leading, var(--text-base--line-height));
+    }
+  }
   .md\:text-sm {
     @media (width >= 48rem) {
       font-size: var(--text-sm);
       line-height: var(--tw-leading, var(--text-sm--line-height));
+    }
+  }
+  .md\:text-xl {
+    @media (width >= 48rem) {
+      font-size: var(--text-xl);
+      line-height: var(--tw-leading, var(--text-xl--line-height));
     }
   }
   .md\:opacity-0 {
@@ -4185,9 +4562,54 @@
       }
     }
   }
+  .dark\:border-amber-700 {
+    @media (prefers-color-scheme: dark) {
+      border-color: var(--color-amber-700);
+    }
+  }
   .dark\:border-input {
     @media (prefers-color-scheme: dark) {
       border-color: var(--input);
+    }
+  }
+  .dark\:border-white\/\[0\.02\] {
+    @media (prefers-color-scheme: dark) {
+      border-color: color-mix(in srgb, #fff 2%, transparent);
+      @supports (color: color-mix(in lab, red, red)) {
+        border-color: color-mix(in oklab, var(--color-white) 2%, transparent);
+      }
+    }
+  }
+  .dark\:border-white\/\[0\.08\] {
+    @media (prefers-color-scheme: dark) {
+      border-color: color-mix(in srgb, #fff 8%, transparent);
+      @supports (color: color-mix(in lab, red, red)) {
+        border-color: color-mix(in oklab, var(--color-white) 8%, transparent);
+      }
+    }
+  }
+  .dark\:bg-amber-900\/40 {
+    @media (prefers-color-scheme: dark) {
+      background-color: color-mix(in srgb, oklch(41.4% 0.112 45.904) 40%, transparent);
+      @supports (color: color-mix(in lab, red, red)) {
+        background-color: color-mix(in oklab, var(--color-amber-900) 40%, transparent);
+      }
+    }
+  }
+  .dark\:bg-amber-950\/20 {
+    @media (prefers-color-scheme: dark) {
+      background-color: color-mix(in srgb, oklch(27.9% 0.077 45.635) 20%, transparent);
+      @supports (color: color-mix(in lab, red, red)) {
+        background-color: color-mix(in oklab, var(--color-amber-950) 20%, transparent);
+      }
+    }
+  }
+  .dark\:bg-blue-900\/40 {
+    @media (prefers-color-scheme: dark) {
+      background-color: color-mix(in srgb, oklch(37.9% 0.146 265.522) 40%, transparent);
+      @supports (color: color-mix(in lab, red, red)) {
+        background-color: color-mix(in oklab, var(--color-blue-900) 40%, transparent);
+      }
     }
   }
   .dark\:bg-destructive\/60 {
@@ -4195,6 +4617,14 @@
       background-color: var(--destructive);
       @supports (color: color-mix(in lab, red, red)) {
         background-color: color-mix(in oklab, var(--destructive) 60%, transparent);
+      }
+    }
+  }
+  .dark\:bg-green-900\/40 {
+    @media (prefers-color-scheme: dark) {
+      background-color: color-mix(in srgb, oklch(39.3% 0.095 152.535) 40%, transparent);
+      @supports (color: color-mix(in lab, red, red)) {
+        background-color: color-mix(in oklab, var(--color-green-900) 40%, transparent);
       }
     }
   }
@@ -4206,14 +4636,52 @@
       }
     }
   }
+  .dark\:bg-red-900\/40 {
+    @media (prefers-color-scheme: dark) {
+      background-color: color-mix(in srgb, oklch(39.6% 0.141 25.723) 40%, transparent);
+      @supports (color: color-mix(in lab, red, red)) {
+        background-color: color-mix(in oklab, var(--color-red-900) 40%, transparent);
+      }
+    }
+  }
   .dark\:bg-transparent {
     @media (prefers-color-scheme: dark) {
       background-color: transparent;
     }
   }
+  .dark\:text-amber-200 {
+    @media (prefers-color-scheme: dark) {
+      color: var(--color-amber-200);
+    }
+  }
+  .dark\:text-amber-300 {
+    @media (prefers-color-scheme: dark) {
+      color: var(--color-amber-300);
+    }
+  }
+  .dark\:text-amber-400 {
+    @media (prefers-color-scheme: dark) {
+      color: var(--color-amber-400);
+    }
+  }
+  .dark\:text-blue-300 {
+    @media (prefers-color-scheme: dark) {
+      color: var(--color-blue-300);
+    }
+  }
+  .dark\:text-green-300 {
+    @media (prefers-color-scheme: dark) {
+      color: var(--color-green-300);
+    }
+  }
   .dark\:text-muted-foreground {
     @media (prefers-color-scheme: dark) {
       color: var(--muted-foreground);
+    }
+  }
+  .dark\:text-red-300 {
+    @media (prefers-color-scheme: dark) {
+      color: var(--color-red-300);
     }
   }
   .dark\:hover\:bg-accent\/50 {
@@ -4531,9 +4999,40 @@
       display: block !important;
     }
   }
+  .\[\&_a\]\:text-primary {
+    & a {
+      color: var(--primary);
+    }
+  }
   .\[\&_a\]\:underline {
     & a {
       text-decoration-line: underline;
+    }
+  }
+  .\[\&_a\:hover\]\:no-underline {
+    & a:hover {
+      text-decoration-line: none;
+    }
+  }
+  .\[\&_blockquote\]\:border-l-2 {
+    & blockquote {
+      border-left-style: var(--tw-border-style);
+      border-left-width: 2px;
+    }
+  }
+  .\[\&_blockquote\]\:border-border {
+    & blockquote {
+      border-color: var(--border);
+    }
+  }
+  .\[\&_blockquote\]\:pl-3 {
+    & blockquote {
+      padding-left: calc(var(--spacing) * 3);
+    }
+  }
+  .\[\&_blockquote\]\:text-muted-foreground {
+    & blockquote {
+      color: var(--muted-foreground);
     }
   }
   .\[\&_code\]\:rounded {
@@ -4549,6 +5048,11 @@
       }
     }
   }
+  .\[\&_code\]\:bg-muted {
+    & code {
+      background-color: var(--muted);
+    }
+  }
   .\[\&_code\]\:px-1 {
     & code {
       padding-inline: calc(var(--spacing) * 1);
@@ -4558,6 +5062,72 @@
     & code {
       font-size: var(--text-xs);
       line-height: var(--tw-leading, var(--text-xs--line-height));
+    }
+  }
+  .\[\&_h1\]\:mt-4 {
+    & h1 {
+      margin-top: calc(var(--spacing) * 4);
+    }
+  }
+  .\[\&_h1\]\:mb-2 {
+    & h1 {
+      margin-bottom: calc(var(--spacing) * 2);
+    }
+  }
+  .\[\&_h1\]\:text-xl {
+    & h1 {
+      font-size: var(--text-xl);
+      line-height: var(--tw-leading, var(--text-xl--line-height));
+    }
+  }
+  .\[\&_h1\]\:font-semibold {
+    & h1 {
+      --tw-font-weight: var(--font-weight-semibold);
+      font-weight: var(--font-weight-semibold);
+    }
+  }
+  .\[\&_h2\]\:mt-4 {
+    & h2 {
+      margin-top: calc(var(--spacing) * 4);
+    }
+  }
+  .\[\&_h2\]\:mb-2 {
+    & h2 {
+      margin-bottom: calc(var(--spacing) * 2);
+    }
+  }
+  .\[\&_h2\]\:text-lg {
+    & h2 {
+      font-size: var(--text-lg);
+      line-height: var(--tw-leading, var(--text-lg--line-height));
+    }
+  }
+  .\[\&_h2\]\:font-semibold {
+    & h2 {
+      --tw-font-weight: var(--font-weight-semibold);
+      font-weight: var(--font-weight-semibold);
+    }
+  }
+  .\[\&_h3\]\:mt-3 {
+    & h3 {
+      margin-top: calc(var(--spacing) * 3);
+    }
+  }
+  .\[\&_h3\]\:mb-1 {
+    & h3 {
+      margin-bottom: calc(var(--spacing) * 1);
+    }
+  }
+  .\[\&_h3\]\:text-base {
+    & h3 {
+      font-size: var(--text-base);
+      line-height: var(--tw-leading, var(--text-base--line-height));
+    }
+  }
+  .\[\&_h3\]\:font-semibold {
+    & h3 {
+      --tw-font-weight: var(--font-weight-semibold);
+      font-weight: var(--font-weight-semibold);
     }
   }
   .\[\&_img\]\:size-full {
@@ -4581,6 +5151,21 @@
       margin-block: calc(var(--spacing) * 1);
     }
   }
+  .\[\&_ol\]\:my-4 {
+    & ol {
+      margin-block: calc(var(--spacing) * 4);
+    }
+  }
+  .\[\&_ol\]\:list-decimal {
+    & ol {
+      list-style-type: decimal;
+    }
+  }
+  .\[\&_ol\]\:pl-6 {
+    & ol {
+      padding-left: calc(var(--spacing) * 6);
+    }
+  }
   .\[\&_p\]\:my-1 {
     & p {
       margin-block: calc(var(--spacing) * 1);
@@ -4590,6 +5175,11 @@
     & p {
       --tw-leading: var(--leading-relaxed);
       line-height: var(--leading-relaxed);
+    }
+  }
+  .\[\&_pre\]\:my-2 {
+    & pre {
+      margin-block: calc(var(--spacing) * 2);
     }
   }
   .\[\&_pre\]\:overflow-x-auto {
@@ -4602,6 +5192,11 @@
       border-radius: var(--radius);
     }
   }
+  .\[\&_pre\]\:rounded-md {
+    & pre {
+      border-radius: var(--radius-md);
+    }
+  }
   .\[\&_pre\]\:bg-background\/50 {
     & pre {
       background-color: var(--background);
@@ -4610,9 +5205,19 @@
       }
     }
   }
+  .\[\&_pre\]\:bg-muted {
+    & pre {
+      background-color: var(--muted);
+    }
+  }
   .\[\&_pre\]\:p-2 {
     & pre {
       padding: calc(var(--spacing) * 2);
+    }
+  }
+  .\[\&_pre\]\:p-3 {
+    & pre {
+      padding: calc(var(--spacing) * 3);
     }
   }
   .\[\&_pre\]\:text-xs {
@@ -4621,9 +5226,25 @@
       line-height: var(--tw-leading, var(--text-xs--line-height));
     }
   }
+  .\[\&_pre_code\]\:bg-transparent {
+    & pre code {
+      background-color: transparent;
+    }
+  }
+  .\[\&_pre_code\]\:p-0 {
+    & pre code {
+      padding: calc(var(--spacing) * 0);
+    }
+  }
   .\[\&_svg\]\:pointer-events-none {
     & svg {
       pointer-events: none;
+    }
+  }
+  .\[\&_svg\]\:size-4 {
+    & svg {
+      width: calc(var(--spacing) * 4);
+      height: calc(var(--spacing) * 4);
     }
   }
   .\[\&_svg\]\:shrink-0 {
@@ -4652,6 +5273,11 @@
   .\[\&_svg\:not\(\[class\*\=\'text-\'\]\)\]\:text-muted-foreground {
     & svg:not([class*='text-']) {
       color: var(--muted-foreground);
+    }
+  }
+  .\[\&_table\]\:my-2 {
+    & table {
+      margin-block: calc(var(--spacing) * 2);
     }
   }
   .\[\&_table\]\:block {
@@ -4737,6 +5363,21 @@
   .\[\&_ul\]\:my-1 {
     & ul {
       margin-block: calc(var(--spacing) * 1);
+    }
+  }
+  .\[\&_ul\]\:my-4 {
+    & ul {
+      margin-block: calc(var(--spacing) * 4);
+    }
+  }
+  .\[\&_ul\]\:list-disc {
+    & ul {
+      list-style-type: disc;
+    }
+  }
+  .\[\&_ul\]\:pl-6 {
+    & ul {
+      padding-left: calc(var(--spacing) * 6);
     }
   }
   .\[\&\+\[data-slot\=item-content\]\]\:flex-none {
@@ -5382,6 +6023,196 @@
   initial-value: 0;
 }
 :root {
+  --action-default-background-hover: var(--accent);
+  @supports (color: color-mix(in lab, red, red)) {
+    --action-default-background-hover: color-mix(
+    in oklch,
+    var(--accent) 50%,
+    transparent
+  );
+  }
+  --action-default-background-press: var(--accent);
+  @supports (color: color-mix(in lab, red, red)) {
+    --action-default-background-press: color-mix(
+    in oklch,
+    var(--accent) 100%,
+    transparent
+  );
+  }
+  --action-primary-background-hover: var(--primary);
+  @supports (color: color-mix(in lab, red, red)) {
+    --action-primary-background-hover: color-mix(
+    in oklch,
+    var(--primary) 90%,
+    black
+  );
+  }
+  --action-primary-background-press: var(--primary);
+  @supports (color: color-mix(in lab, red, red)) {
+    --action-primary-background-press: color-mix(
+    in oklch,
+    var(--primary) 80%,
+    black
+  );
+  }
+  --action-tertiary-background-hover: var(--primary);
+  @supports (color: color-mix(in lab, red, red)) {
+    --action-tertiary-background-hover: color-mix(
+    in oklch,
+    var(--primary) 8%,
+    transparent
+  );
+  }
+  --action-tertiary-background-press: var(--primary);
+  @supports (color: color-mix(in lab, red, red)) {
+    --action-tertiary-background-press: color-mix(
+    in oklch,
+    var(--primary) 16%,
+    transparent
+  );
+  }
+  --action-danger-primary-background-hover: var(--destructive);
+  @supports (color: color-mix(in lab, red, red)) {
+    --action-danger-primary-background-hover: color-mix(
+    in oklch,
+    var(--destructive) 90%,
+    black
+  );
+  }
+  --action-danger-primary-background-press: var(--destructive);
+  @supports (color: color-mix(in lab, red, red)) {
+    --action-danger-primary-background-press: color-mix(
+    in oklch,
+    var(--destructive) 80%,
+    black
+  );
+  }
+}
+[data-appkit-chat] {
+  --color-blue-300: #bae1fc;
+  --color-blue-400: #4ba3d6;
+  --color-blue-500: #2e86c1;
+  --color-blue-600: #2272b4;
+  --color-blue-700: #0e538b;
+  --color-blue-800: #04355d;
+  --color-grey-050: #f6f7f9;
+  --color-grey-100: #e8ecf0;
+  --color-grey-200: #d1dce5;
+  --color-grey-300: #bdcdd9;
+  --color-grey-400: #8d9fad;
+  --color-grey-500: #5f7281;
+  --color-grey-600: #44535f;
+  --color-grey-700: #1f272d;
+  --color-grey-800: #11171c;
+  --color-neutral-050: #f7f7f7;
+  --color-neutral-100: #ebebeb;
+  --color-neutral-200: #d8d8d8;
+  --color-neutral-300: #cbcbcb;
+  --color-neutral-350: #a2a2a2;
+  --color-neutral-400: #939393;
+  --color-neutral-500: #6f6f6f;
+  --color-neutral-600: #525252;
+  --color-neutral-650: #424242;
+  --color-neutral-700: #262626;
+  --color-neutral-800: #161616;
+  --color-red-300: #fbd0d8;
+  --color-red-400: #f06e87;
+  --color-red-500: #e83a5f;
+  --color-red-600: #c82d4c;
+  --color-red-700: #9e1d38;
+  --color-red-800: #630316;
+  --color-green-400: #59c47a;
+  --color-green-500: #3ca45e;
+  --color-green-600: #277c43;
+  --color-green-700: #1a5c30;
+  --color-yellow-500: #dc6222;
+  --color-yellow-600: #be501e;
+  --color-yellow-700: #8f3c14;
+  --background: #ffffff;
+  --foreground: var(--color-grey-800);
+  --card: #ffffff;
+  --card-foreground: var(--color-grey-800);
+  --popover: #ffffff;
+  --popover-foreground: var(--color-grey-800);
+  --primary: var(--color-blue-600);
+  --primary-foreground: #ffffff;
+  --secondary: var(--color-grey-050);
+  --secondary-foreground: var(--color-grey-800);
+  --muted: var(--color-grey-050);
+  --muted-foreground: var(--color-neutral-600);
+  --accent: var(--color-grey-050);
+  --accent-foreground: var(--color-grey-800);
+  --destructive: var(--color-red-600);
+  --destructive-foreground: #ffffff;
+  --warning: var(--color-yellow-600);
+  --success: var(--color-green-600);
+  --border: var(--color-grey-100);
+  --input: var(--color-grey-100);
+  --ring: #2272b4;
+  --action-default-background-hover: rgba(34, 114, 180, 0.08);
+  --action-default-background-press: rgba(34, 114, 180, 0.16);
+  --action-primary-background-hover: var(--color-blue-700);
+  --action-primary-background-press: var(--color-blue-800);
+  --action-tertiary-background-hover: rgba(34, 114, 180, 0.08);
+  --action-tertiary-background-press: rgba(34, 114, 180, 0.16);
+  --action-danger-primary-background-hover: var(--color-red-700);
+  --action-danger-primary-background-press: var(--color-red-800);
+  --border-danger: #fbd0d8;
+  --border-warning: #f8d4a5;
+  --border-success: #a3d9b6;
+  --background-danger: #fff5f7;
+  --background-warning: #fff9eb;
+  --background-success: #f0faf4;
+  --radius: 0.25rem;
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --text-xs: 0.6875rem;
+  --text-sm: 0.75rem;
+  --text-base: 0.8125rem;
+  --text-base--line-height: 20px;
+  --text-lg: 1.125rem;
+  --text-xl: 1.375rem;
+  --text-2xl: 2rem;
+}
+.dark [data-appkit-chat], [data-appkit-chat].dark {
+  --background: var(--color-grey-800);
+  --foreground: var(--color-grey-100);
+  --card: #1a2530;
+  --card-foreground: var(--color-grey-100);
+  --popover: #1a2530;
+  --popover-foreground: var(--color-grey-100);
+  --primary: var(--color-blue-500);
+  --primary-foreground: #ffffff;
+  --secondary: #283035;
+  --secondary-foreground: #e8ecf0;
+  --muted: #2a3a45;
+  --muted-foreground: #bdcdd9;
+  --accent: #2a3a45;
+  --accent-foreground: #e8ecf0;
+  --destructive: #e65677;
+  --border: #2a3a45;
+  --input: #2a3a45;
+  --ring: #4ba3d6;
+  --warning: #dc6222;
+  --success: #3ca45e;
+  --action-default-background-hover: rgba(138, 202, 255, 0.08);
+  --action-default-background-press: rgba(138, 202, 255, 0.16);
+  --action-primary-background-hover: #4ba3d6;
+  --action-primary-background-press: #bae1fc;
+  --action-tertiary-background-hover: rgba(143, 205, 255, 0.08);
+  --action-tertiary-background-press: rgba(143, 205, 255, 0.16);
+  --action-danger-primary-background-hover: #f06e87;
+  --action-danger-primary-background-press: #fbd0d8;
+  --border-danger: rgba(232, 58, 95, 0.3);
+  --border-warning: rgba(220, 98, 34, 0.3);
+  --border-success: rgba(60, 164, 94, 0.3);
+  --background-danger: rgba(232, 58, 95, 0.08);
+  --background-warning: rgba(220, 98, 34, 0.08);
+  --background-success: rgba(60, 164, 94, 0.08);
+}
+:root {
   --radius: 0.625rem;
   --background: oklch(1 0 0);
   --foreground: oklch(0.141 0.005 285.823);
@@ -5918,6 +6749,42 @@
   syntax: "*";
   inherits: false;
 }
+@property --tw-backdrop-blur {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-brightness {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-contrast {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-grayscale {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-hue-rotate {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-invert {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-opacity {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-saturate {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-sepia {
+  syntax: "*";
+  inherits: false;
+}
 @property --tw-duration {
   syntax: "*";
   inherits: false;
@@ -6038,6 +6905,15 @@
       --tw-drop-shadow-color: initial;
       --tw-drop-shadow-alpha: 100%;
       --tw-drop-shadow-size: initial;
+      --tw-backdrop-blur: initial;
+      --tw-backdrop-brightness: initial;
+      --tw-backdrop-contrast: initial;
+      --tw-backdrop-grayscale: initial;
+      --tw-backdrop-hue-rotate: initial;
+      --tw-backdrop-invert: initial;
+      --tw-backdrop-opacity: initial;
+      --tw-backdrop-saturate: initial;
+      --tw-backdrop-sepia: initial;
       --tw-duration: initial;
       --tw-ease: initial;
       --tw-content: "";

--- a/docs/static/appkit-ui/styles.gen.css
+++ b/docs/static/appkit-ui/styles.gen.css
@@ -219,6 +219,9 @@
   .pointer-events-none {
     pointer-events: none;
   }
+  .collapse {
+    visibility: collapse;
+  }
   .invisible {
     visibility: hidden;
   }
@@ -644,6 +647,9 @@
   }
   .h-\[200px\] {
     height: 200px;
+  }
+  .h-\[600px\] {
+    height: 600px;
   }
   .h-\[calc\(100\%-1px\)\] {
     height: calc(100% - 1px);
@@ -1531,11 +1537,17 @@
   .text-center {
     text-align: center;
   }
+  .text-end {
+    text-align: end;
+  }
   .text-left {
     text-align: left;
   }
   .text-right {
     text-align: right;
+  }
+  .text-start {
+    text-align: start;
   }
   .align-middle {
     vertical-align: middle;
@@ -1902,6 +1914,9 @@
   }
   .\[--cell-size\:--spacing\(8\)\] {
     --cell-size: calc(var(--spacing) * 8);
+  }
+  .paused {
+    animation-play-state: paused;
   }
   .running {
     animation-play-state: running;

--- a/knip.json
+++ b/knip.json
@@ -8,7 +8,12 @@
   ],
   "workspaces": {
     "packages/appkit-ui": {
-      "ignoreDependencies": ["tailwindcss", "tw-animate-css"]
+      "ignoreDependencies": [
+        "@ai-sdk/react",
+        "ai",
+        "tailwindcss",
+        "tw-animate-css"
+      ]
     }
   },
   "ignore": [

--- a/packages/appkit-ui/package.json
+++ b/packages/appkit-ui/package.json
@@ -39,6 +39,10 @@
       "development": "./src/react/beta.ts",
       "default": "./dist/react/beta.js"
     },
+    "./react/chat": {
+      "development": "./src/react/chat/index.ts",
+      "default": "./dist/react/chat/index.js"
+    },
     "./package.json": "./package.json",
     "./styles.css": {
       "development": "./src/react/styles/globals.css",
@@ -103,13 +107,25 @@
     "vaul": "1.1.2"
   },
   "peerDependencies": {
+    "@ai-sdk/react": "~4.0.0-beta",
+    "ai": "~7.0.0-beta",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "recharts": "^2.0.0 || ^3.0.0"
   },
+  "peerDependenciesMeta": {
+    "@ai-sdk/react": {
+      "optional": true
+    },
+    "ai": {
+      "optional": true
+    }
+  },
   "devDependencies": {
+    "@ai-sdk/react": "4.0.0-beta.76",
     "@types/react": "19.2.2",
     "@types/react-dom": "19.2.2",
+    "ai": "7.0.0-beta.76",
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "recharts": "2.15.4",
@@ -122,6 +138,7 @@
       "./js/beta": "./dist/js/beta.js",
       "./react": "./dist/react/index.js",
       "./react/beta": "./dist/react/beta.js",
+      "./react/chat": "./dist/react/chat/index.js",
       "./package.json": "./package.json",
       "./styles.css": "./dist/styles.css"
     }

--- a/packages/appkit-ui/src/react/chat/app/chat-app.tsx
+++ b/packages/appkit-ui/src/react/chat/app/chat-app.tsx
@@ -1,0 +1,244 @@
+import type { UseChatHelpers } from "@ai-sdk/react";
+import type { ChatStatus, UIMessage, UIMessageChunk } from "ai";
+import { type ReactNode, useCallback, useRef, useState } from "react";
+import { cn } from "../../lib/utils";
+import { type UseChatOptions, useChat } from "../hooks/use-chat";
+import { useScrollToBottom } from "../hooks/use-scroll-to-bottom";
+import { ChatComposer, type ChatComposerProps } from "./chat-composer";
+import { ChatGreeting } from "./chat-greeting";
+import type { ApprovalEntry, ChatMessageProps } from "./chat-message";
+import { ChatMessages } from "./chat-messages";
+import type { ChatToolCallProps } from "./chat-tool-call";
+
+export interface ApprovalDecision {
+  approvalId: string;
+  streamId: string;
+  decision: "approve" | "deny";
+}
+
+const DEFAULT_API = "/api/agents/chat";
+
+export interface ChatAppProps<TMessage extends UIMessage = UIMessage>
+  extends Omit<UseChatOptions<TMessage>, "api"> {
+  /** Chat endpoint URL. Defaults to `/api/agents/chat`. */
+  api?: string;
+  /** Empty-state node shown when there are no messages yet. */
+  emptyState?: ReactNode;
+  /** Placeholder text for the default composer. */
+  placeholder?: string;
+  /** Caption shown below the composer. Pass `null` to suppress. */
+  composerCaption?: string | null;
+  /** Override per-message rendering. Return undefined to fall through. */
+  renderMessage?: (props: ChatMessageProps<TMessage>) => ReactNode | undefined;
+  /** Override tool-call rendering. Return undefined to fall through. */
+  renderToolCall?: (props: ChatToolCallProps) => ReactNode | undefined;
+  /** Override the composer entirely. */
+  renderComposer?: (
+    props: ChatComposerProps<TMessage>,
+  ) => ReactNode | undefined;
+  /**
+   * Called when the user clicks Allow / Deny. Throw to keep the card
+   * `pending`. Defaults to a POST against {@link approveUrl}.
+   */
+  onApprovalDecision?: (decision: ApprovalDecision) => Promise<void> | void;
+  /** Defaults to `api` with `/chat` swapped for `/approve`. */
+  approveUrl?: string;
+  className?: string;
+}
+
+function deriveApproveUrl(api: string, override: string | undefined): string {
+  if (override) return override;
+  if (api.endsWith("/chat")) return `${api.slice(0, -"/chat".length)}/approve`;
+  return `${api}/approve`;
+}
+
+/**
+ * Drop-in chat against an `agents()`-backed AppKit server. Fills its
+ * parent — provide a sized container. For history, feedback, or file
+ * attachments, wrap `useChat` directly instead.
+ */
+export function ChatApp<TMessage extends UIMessage = UIMessage>({
+  api = DEFAULT_API,
+  emptyState,
+  placeholder,
+  composerCaption,
+  renderMessage,
+  renderToolCall,
+  renderComposer,
+  onApprovalDecision,
+  approveUrl,
+  className,
+  ...chatOptions
+}: ChatAppProps<TMessage>) {
+  const [approvals, setApprovals] = useState<Map<string, ApprovalEntry>>(
+    () => new Map(),
+  );
+
+  // Ref'd so an inline `onData` doesn't re-bind the transport every render.
+  const consumerOnDataRef = useRef(chatOptions.onData);
+  consumerOnDataRef.current = chatOptions.onData;
+
+  const handleData = useCallback<
+    NonNullable<UseChatOptions<TMessage>["onData"]>
+  >((part) => {
+    if (part.type === "data-approval-pending") {
+      const data = (part as { data: Record<string, unknown> }).data;
+      const approvalId = String(data.approvalId ?? "");
+      if (approvalId) {
+        setApprovals((prev) => {
+          // Don't clobber an in-flight or completed decision if the
+          // server re-emits the pending event.
+          if (prev.has(approvalId)) return prev;
+          const next = new Map(prev);
+          next.set(approvalId, {
+            approvalId,
+            streamId: String(data.streamId ?? ""),
+            toolName: String(data.toolName ?? "tool"),
+            args: data.args,
+            annotations: data.annotations as ApprovalEntry["annotations"],
+            state: "pending",
+          });
+          return next;
+        });
+      }
+    }
+    consumerOnDataRef.current?.(part);
+  }, []);
+
+  const chat = useChat<TMessage>({
+    ...chatOptions,
+    api,
+    onData: handleData,
+  });
+
+  const { containerRef, isAtBottom, scrollToBottom } =
+    useScrollToBottom<HTMLDivElement>({ trigger: chat.messages });
+
+  const submitDecision = useCallback(
+    async (decision: ApprovalDecision) => {
+      const setState = (state: ApprovalEntry["state"]) => {
+        setApprovals((prev) => {
+          const next = new Map(prev);
+          const existing = next.get(decision.approvalId);
+          next.set(decision.approvalId, {
+            approvalId: decision.approvalId,
+            streamId: decision.streamId,
+            toolName: existing?.toolName ?? "",
+            args: existing?.args,
+            annotations: existing?.annotations,
+            state,
+          });
+          return next;
+        });
+      };
+      setState("submitting");
+      try {
+        if (onApprovalDecision) {
+          await onApprovalDecision(decision);
+        } else {
+          const url = deriveApproveUrl(api, approveUrl);
+          const res = await fetch(url, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              streamId: decision.streamId,
+              approvalId: decision.approvalId,
+              decision: decision.decision,
+            }),
+          });
+          if (!res.ok) {
+            throw new Error(
+              `Approval POST failed: ${res.status} ${res.statusText}`,
+            );
+          }
+        }
+        setState(decision.decision === "approve" ? "approved" : "denied");
+      } catch (err) {
+        // Roll back to pending so the user can retry.
+        console.error("[ChatApp] approval decision failed", err);
+        setState("pending");
+      }
+    },
+    [onApprovalDecision, approveUrl, api],
+  );
+
+  const onApprove = useCallback(
+    (approvalId: string, streamId: string) => {
+      void submitDecision({ approvalId, streamId, decision: "approve" });
+    },
+    [submitDecision],
+  );
+  const onDeny = useCallback(
+    (approvalId: string, streamId: string) => {
+      void submitDecision({ approvalId, streamId, decision: "deny" });
+    },
+    [submitDecision],
+  );
+
+  const composerProps: ChatComposerProps<TMessage> = {
+    sendMessage: chat.sendMessage,
+    status: chat.status,
+    stop: chat.stop,
+    placeholder,
+    caption: composerCaption,
+  };
+  const composer = renderComposer?.(composerProps) ?? (
+    <ChatComposer<TMessage> {...composerProps} />
+  );
+
+  const isEmpty = chat.messages.length === 0;
+
+  return (
+    <div
+      data-appkit-chat=""
+      className={cn("flex h-full min-h-0 flex-col bg-background", className)}
+    >
+      {isEmpty ? (
+        <div className="flex flex-1 items-center justify-center px-4 py-6">
+          <div className="flex w-full max-w-3xl flex-col items-stretch">
+            {emptyState ?? <ChatGreeting />}
+            {composer}
+          </div>
+        </div>
+      ) : (
+        <>
+          <ChatMessages<TMessage>
+            messages={chat.messages}
+            status={chat.status}
+            containerRef={containerRef}
+            isAtBottom={isAtBottom}
+            scrollToBottom={scrollToBottom}
+            approvals={approvals}
+            onApprove={onApprove}
+            onDeny={onDeny}
+            setMessages={chat.setMessages}
+            regenerate={chat.regenerate}
+            renderMessage={renderMessage}
+            renderToolCall={renderToolCall}
+          />
+          {chat.error && (
+            <div className="mx-auto w-full max-w-4xl px-4 pb-2">
+              <div className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+                {chat.error.message}
+              </div>
+            </div>
+          )}
+          <div className="sticky bottom-0 z-10 mx-auto w-full max-w-3xl px-2 pb-3 md:px-4 md:pb-4">
+            {composer}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// Re-exports for slot consumers.
+export type {
+  ApprovalEntry,
+  ChatComposerProps,
+  ChatMessageProps,
+  ChatStatus,
+  ChatToolCallProps,
+  UIMessageChunk,
+  UseChatHelpers,
+};

--- a/packages/appkit-ui/src/react/chat/app/chat-awaiting-response.tsx
+++ b/packages/appkit-ui/src/react/chat/app/chat-awaiting-response.tsx
@@ -1,0 +1,23 @@
+import { cn } from "../../lib/utils";
+import { ChatShimmer } from "./chat-shimmer";
+
+interface ChatAwaitingResponseProps {
+  /** Customise the shimmering label. */
+  label?: string;
+  className?: string;
+}
+
+/** "Generating response" placeholder shown before the first chunk arrives. */
+export function ChatAwaitingResponse({
+  label = "Generating response",
+  className,
+}: ChatAwaitingResponseProps) {
+  return (
+    <div
+      data-testid="chat-awaiting-response"
+      className={cn("flex items-center gap-2", className)}
+    >
+      <ChatShimmer className="text-base">{label}</ChatShimmer>
+    </div>
+  );
+}

--- a/packages/appkit-ui/src/react/chat/app/chat-composer.tsx
+++ b/packages/appkit-ui/src/react/chat/app/chat-composer.tsx
@@ -1,0 +1,95 @@
+import type { UseChatHelpers } from "@ai-sdk/react";
+import type { ChatStatus, UIMessage } from "ai";
+import { cn } from "../../lib/utils";
+import { Button } from "../../ui/button";
+import { ArrowUpIcon, DbIcon, StopIcon } from "../db-icons";
+import { ChatInput } from "../headless/chat-input";
+
+export interface ChatComposerProps<TMessage extends UIMessage = UIMessage> {
+  sendMessage: UseChatHelpers<TMessage>["sendMessage"];
+  status: ChatStatus;
+  stop: () => void;
+  placeholder?: string;
+  /** Caption below the input. Pass `null` to suppress. */
+  caption?: string | null;
+  className?: string;
+}
+
+/**
+ * Default composer. Built on the `<ChatInput>` headless primitive so
+ * Enter-to-submit, IME composition, and value clearing match
+ * roll-your-own composers.
+ */
+export function ChatComposer<TMessage extends UIMessage = UIMessage>({
+  sendMessage,
+  status,
+  stop,
+  placeholder = "Ask a question…",
+  caption = "Always review the accuracy of responses.",
+  className,
+}: ChatComposerProps<TMessage>) {
+  return (
+    <ChatInput<TMessage> onSubmit={sendMessage} status={status} stop={stop}>
+      {({ value, onChange, submit, isStreaming, canSubmit, handleKeyDown }) => (
+        <div className={cn("flex w-full flex-col gap-1.5", className)}>
+          <div className="w-full rounded-[24px] border-4 border-black/[0.02] dark:border-white/[0.02]">
+            <form
+              onSubmit={submit}
+              className={cn(
+                "rounded-[24px] border border-black/[0.08] bg-background/75 p-3 backdrop-blur-sm",
+                "transition-all duration-200",
+                "dark:border-white/[0.08]",
+                "focus-within:border-ring/40 focus-within:shadow-sm",
+              )}
+            >
+              <textarea
+                value={value}
+                onChange={(e) => onChange(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder={placeholder}
+                disabled={isStreaming}
+                rows={1}
+                className={cn(
+                  "w-full resize-none border-0 bg-transparent px-2 py-1.5 text-sm outline-none",
+                  "field-sizing-content max-h-[8lh]",
+                  "placeholder:text-muted-foreground",
+                  "focus:outline-none focus-visible:ring-0",
+                  "disabled:cursor-not-allowed disabled:opacity-60",
+                )}
+              />
+              <div className="flex items-center justify-end pt-1">
+                {isStreaming ? (
+                  <Button
+                    type="button"
+                    size="icon-sm"
+                    variant="default"
+                    onClick={stop}
+                    aria-label="Stop generating"
+                    className="rounded-full"
+                  >
+                    <DbIcon icon={StopIcon} />
+                  </Button>
+                ) : (
+                  <Button
+                    type="submit"
+                    size="icon-sm"
+                    disabled={!canSubmit}
+                    aria-label="Send message"
+                    className="rounded-full bg-secondary text-secondary-foreground hover:bg-secondary/80 disabled:bg-muted disabled:text-muted-foreground"
+                  >
+                    <DbIcon icon={ArrowUpIcon} />
+                  </Button>
+                )}
+              </div>
+            </form>
+          </div>
+          {caption && (
+            <p className="text-center text-sm text-muted-foreground">
+              {caption}
+            </p>
+          )}
+        </div>
+      )}
+    </ChatInput>
+  );
+}

--- a/packages/appkit-ui/src/react/chat/app/chat-greeting.tsx
+++ b/packages/appkit-ui/src/react/chat/app/chat-greeting.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from "react";
+import { cn } from "../../lib/utils";
+
+interface ChatGreetingProps {
+  /** Headline shown when the conversation is empty. */
+  title?: ReactNode;
+  /** Optional subtitle below the headline. */
+  subtitle?: ReactNode;
+  className?: string;
+}
+
+/** Empty-state hero shown above the composer before the first message. */
+export function ChatGreeting({
+  title = "What would you like to know?",
+  subtitle,
+  className,
+}: ChatGreetingProps) {
+  return (
+    <div
+      className={cn(
+        "mx-auto flex w-full max-w-3xl flex-col items-center justify-center gap-2 px-4 text-center mb-6",
+        className,
+      )}
+    >
+      <div className="text-lg font-semibold text-foreground md:text-xl">
+        {title}
+      </div>
+      {subtitle && (
+        <div className="max-w-xl text-sm text-muted-foreground md:text-base">
+          {subtitle}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/appkit-ui/src/react/chat/app/chat-markdown.tsx
+++ b/packages/appkit-ui/src/react/chat/app/chat-markdown.tsx
@@ -1,0 +1,42 @@
+import DOMPurify from "dompurify";
+import { marked } from "marked";
+import { useMemo } from "react";
+import { cn } from "../../lib/utils";
+
+const MARKED_OPTIONS = { breaks: true, gfm: true, async: false } as const;
+
+const markdownStyles = cn(
+  "text-base wrap-break-word",
+  "[&_p]:my-1 [&_ul]:my-4 [&_ul]:pl-6 [&_ul]:list-disc [&_ol]:my-4 [&_ol]:pl-6 [&_ol]:list-decimal [&_li]:my-0",
+  "[&_h1]:text-xl [&_h1]:font-semibold [&_h1]:mt-4 [&_h1]:mb-2",
+  "[&_h2]:text-lg [&_h2]:font-semibold [&_h2]:mt-4 [&_h2]:mb-2",
+  "[&_h3]:text-base [&_h3]:font-semibold [&_h3]:mt-3 [&_h3]:mb-1",
+  "[&_pre]:bg-muted [&_pre]:p-3 [&_pre]:rounded-md [&_pre]:text-xs [&_pre]:overflow-x-auto [&_pre]:my-2",
+  "[&_code]:text-xs [&_code]:bg-muted [&_code]:px-1 [&_code]:rounded",
+  "[&_pre_code]:bg-transparent [&_pre_code]:p-0",
+  "[&_table]:text-xs [&_table]:block [&_table]:overflow-x-auto [&_table]:max-w-full [&_table]:my-2",
+  "[&_th]:px-2 [&_th]:py-1 [&_td]:px-2 [&_td]:py-1",
+  "[&_table]:border-collapse [&_th]:border [&_td]:border",
+  "[&_th]:border-border [&_td]:border-border",
+  "[&_a]:text-primary [&_a]:underline [&_a:hover]:no-underline",
+  "[&_blockquote]:border-l-2 [&_blockquote]:border-border [&_blockquote]:pl-3 [&_blockquote]:text-muted-foreground",
+);
+
+interface MarkdownProps {
+  children: string;
+  className?: string;
+}
+
+/** Markdown renderer: `marked` → DOMPurify → `dangerouslySetInnerHTML`. */
+export function ChatMarkdown({ children, className }: MarkdownProps) {
+  const html = useMemo(
+    () => DOMPurify.sanitize(marked.parse(children, MARKED_OPTIONS)),
+    [children],
+  );
+  return (
+    <div
+      className={cn(markdownStyles, className)}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}

--- a/packages/appkit-ui/src/react/chat/app/chat-message-actions.tsx
+++ b/packages/appkit-ui/src/react/chat/app/chat-message-actions.tsx
@@ -1,0 +1,90 @@
+import type { UIMessage } from "ai";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { cn } from "../../lib/utils";
+import { Button } from "../../ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../../ui/tooltip";
+import { CheckIcon, CopyIcon, DbIcon, PencilIcon } from "../db-icons";
+import { getMessageText } from "./utils";
+
+interface ChatMessageActionsProps<TMessage extends UIMessage = UIMessage> {
+  message: TMessage;
+  /** When set on user messages, an Edit button toggles edit mode. */
+  onEdit?: () => void;
+  className?: string;
+}
+
+/**
+ * Hover-revealed Edit (user only) and always-visible Copy actions
+ * shown below a message bubble.
+ */
+export function ChatMessageActions<TMessage extends UIMessage = UIMessage>({
+  message,
+  onEdit,
+  className,
+}: ChatMessageActionsProps<TMessage>) {
+  const isUser = message.role === "user";
+  const [copied, setCopied] = useState(false);
+  const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
+    };
+  }, []);
+
+  const handleCopy = useCallback(async () => {
+    const text = getMessageText(message).trim();
+    if (!text) return;
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
+      resetTimerRef.current = setTimeout(() => setCopied(false), 1500);
+    } catch (err) {
+      console.error("[ChatMessageActions] copy failed", err);
+    }
+  }, [message]);
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-1",
+        isUser ? "-mr-1.5 justify-end" : "-ml-1.5",
+        className,
+      )}
+    >
+      {isUser && onEdit && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={onEdit}
+              data-testid="message-edit-button"
+              aria-label="Edit message"
+              className="size-6 rounded-lg p-1.5 text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover/message:opacity-100 focus-visible:opacity-100"
+            >
+              <DbIcon icon={PencilIcon} />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Edit</TooltipContent>
+        </Tooltip>
+      )}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={handleCopy}
+            data-testid="message-copy-button"
+            aria-label={copied ? "Copied" : "Copy message"}
+            className="size-6 rounded-lg p-1.5 text-muted-foreground hover:text-foreground"
+          >
+            {copied ? <DbIcon icon={CheckIcon} /> : <DbIcon icon={CopyIcon} />}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>{copied ? "Copied" : "Copy"}</TooltipContent>
+      </Tooltip>
+    </div>
+  );
+}

--- a/packages/appkit-ui/src/react/chat/app/chat-message-editor.tsx
+++ b/packages/appkit-ui/src/react/chat/app/chat-message-editor.tsx
@@ -1,0 +1,85 @@
+import type { UseChatHelpers } from "@ai-sdk/react";
+import type { UIMessage } from "ai";
+import { useState } from "react";
+import { cn } from "../../lib/utils";
+import { Textarea } from "../../ui/textarea";
+import { getMessageText } from "./utils";
+
+interface ChatMessageEditorProps<TMessage extends UIMessage = UIMessage> {
+  message: TMessage;
+  onCancel: () => void;
+  setMessages: UseChatHelpers<TMessage>["setMessages"];
+  regenerate: UseChatHelpers<TMessage>["regenerate"];
+}
+
+const editorButtonBase =
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-base ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 cursor-pointer h-8 px-3 py-1";
+
+const editorButtonDefault =
+  "text-foreground hover:bg-action-default-background-hover border border-neutral-300 hover:border-primary active:bg-action-default-background-press";
+
+const editorButtonPrimary =
+  "bg-primary text-background hover:bg-action-primary-background-hover active:bg-action-primary-background-press";
+
+/**
+ * Inline editor for a user message. Replaces the message text, drops
+ * everything after it, and triggers a regeneration.
+ */
+export function ChatMessageEditor<TMessage extends UIMessage = UIMessage>({
+  message,
+  onCancel,
+  setMessages,
+  regenerate,
+}: ChatMessageEditorProps<TMessage>) {
+  const [draft, setDraft] = useState(() => getMessageText(message));
+
+  const handleSubmit = async () => {
+    setMessages((messages) => {
+      const index = messages.findIndex((m) => m.id === message.id);
+      if (index === -1) return messages;
+      const updated = {
+        ...message,
+        parts: [{ type: "text", text: draft }],
+      } as TMessage;
+      return [...messages.slice(0, index), updated];
+    });
+    onCancel();
+    // `useChat` surfaces failures via `chat.error`; swallow here so the
+    // promise doesn't reject unhandled.
+    try {
+      await regenerate();
+    } catch (err) {
+      console.error("[ChatMessageEditor] regenerate failed", err);
+    }
+  };
+
+  return (
+    <div className="flex w-full flex-col gap-2">
+      <Textarea
+        data-testid="message-editor"
+        autoFocus
+        className="w-full resize-none rounded-2xl bg-secondary text-base outline-none"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+      />
+      <div className="flex flex-row justify-end gap-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          className={cn(editorButtonBase, editorButtonDefault)}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          data-testid="message-editor-send-button"
+          disabled={draft.trim().length === 0}
+          onClick={handleSubmit}
+          className={cn(editorButtonBase, editorButtonPrimary)}
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/appkit-ui/src/react/chat/app/chat-message.tsx
+++ b/packages/appkit-ui/src/react/chat/app/chat-message.tsx
@@ -1,0 +1,252 @@
+import type { UseChatHelpers } from "@ai-sdk/react";
+import type { UIMessage } from "ai";
+import { type ReactNode, useState } from "react";
+import { cn } from "../../lib/utils";
+import { ChatAwaitingResponse } from "./chat-awaiting-response";
+import { ChatMarkdown } from "./chat-markdown";
+import { ChatMessageActions } from "./chat-message-actions";
+import { ChatMessageEditor } from "./chat-message-editor";
+import { ChatReasoning } from "./chat-reasoning";
+import {
+  ChatToolCall,
+  type ChatToolCallProps,
+  type ChatToolCallState,
+} from "./chat-tool-call";
+
+/** Approval-gate lifecycle, owned by `ChatApp`. */
+export interface ApprovalEntry {
+  approvalId: string;
+  streamId: string;
+  toolName: string;
+  args: unknown;
+  state: "pending" | "submitting" | "approved" | "denied";
+  annotations?: {
+    effect?: "read" | "write" | "update" | "destructive";
+    readOnly?: boolean;
+    destructive?: boolean;
+    idempotent?: boolean;
+  };
+}
+
+export interface ChatMessageProps<TMessage extends UIMessage = UIMessage> {
+  message: TMessage;
+  /** True while this message is the last assistant message and the chat is streaming. */
+  isLoading: boolean;
+  /** Approval state map keyed by `approvalId`. */
+  approvals: Map<string, ApprovalEntry>;
+  onApprove: (approvalId: string, streamId: string) => void;
+  onDeny: (approvalId: string, streamId: string) => void;
+  /** Required to enable inline editing of user messages. */
+  setMessages?: UseChatHelpers<TMessage>["setMessages"];
+  regenerate?: UseChatHelpers<TMessage>["regenerate"];
+  /** Return a ReactNode to override, `undefined` to fall through. */
+  renderToolCall?: (props: ChatToolCallProps) => ReactNode | undefined;
+}
+
+interface ToolPart {
+  type: string;
+  toolCallId: string;
+  toolName?: string;
+  state?: string;
+  input?: unknown;
+  output?: unknown;
+  errorText?: string;
+}
+
+function isToolPart(part: { type: string }): part is ToolPart {
+  return part.type === "dynamic-tool" || part.type.startsWith("tool-");
+}
+
+function approvalStateBadge(s: ApprovalEntry["state"]): ChatToolCallState {
+  switch (s) {
+    case "pending":
+      return "approval-pending";
+    case "submitting":
+      return "approving";
+    case "approved":
+      return "approved";
+    case "denied":
+      return "denied";
+  }
+}
+
+function toolStateBadge(s: string | undefined): ChatToolCallState {
+  switch (s) {
+    case "output-available":
+      return "completed";
+    case "output-error":
+      return "error";
+    default:
+      return "pending";
+  }
+}
+
+/**
+ * Renders a single chat message. Unknown part types are ignored so
+ * older builds don't break on future protocol additions.
+ */
+export function ChatMessage<TMessage extends UIMessage = UIMessage>({
+  message,
+  isLoading,
+  approvals,
+  onApprove,
+  onDeny,
+  setMessages,
+  regenerate,
+  renderToolCall,
+}: ChatMessageProps<TMessage>) {
+  const isUser = message.role === "user";
+  const [mode, setMode] = useState<"view" | "edit">("view");
+  const canEdit = isUser && Boolean(setMessages && regenerate);
+  const parts = message.parts as Array<
+    { type: string } & Record<string, unknown>
+  >;
+
+  // Show a shimmer inline once `start` has landed but no chunks yet.
+  const visibleParts = parts.filter((p) => {
+    if (p.type === "text") return Boolean((p as { text?: unknown }).text);
+    if (p.type === "reasoning") {
+      return String((p as { text?: unknown }).text ?? "").trim().length > 0;
+    }
+    return true;
+  });
+  const showInlineAwaiting = !isUser && isLoading && visibleParts.length === 0;
+
+  return (
+    <div
+      data-role={message.role}
+      data-testid={`message-${message.role}`}
+      className={cn(
+        "group/message flex w-full",
+        isUser ? "justify-end" : "justify-start",
+      )}
+    >
+      <div
+        className={cn(
+          "flex min-w-0 flex-col gap-3",
+          isUser && mode === "view" ? "max-w-[80%]" : "w-full",
+        )}
+      >
+        {showInlineAwaiting && <ChatAwaitingResponse />}
+
+        {canEdit && mode === "edit" && setMessages && regenerate && (
+          <ChatMessageEditor<TMessage>
+            message={message}
+            onCancel={() => setMode("view")}
+            setMessages={setMessages}
+            regenerate={regenerate}
+          />
+        )}
+
+        {(!canEdit || mode === "view") &&
+          parts.map((part, index) => {
+            const key = `${message.id}-${index}`;
+
+            if (part.type === "text") {
+              const text = String((part as { text?: unknown }).text ?? "");
+              if (!text) return null;
+              if (isUser) {
+                return (
+                  <div
+                    key={key}
+                    className="bg-secondary text-secondary-foreground w-fit self-end wrap-break-word rounded-2xl px-3.5 py-2 text-left text-base whitespace-pre-wrap"
+                  >
+                    {text}
+                  </div>
+                );
+              }
+              return (
+                <div key={key} className="text-base leading-relaxed">
+                  <ChatMarkdown>{text}</ChatMarkdown>
+                </div>
+              );
+            }
+
+            if (part.type === "reasoning") {
+              const text = String((part as { text?: unknown }).text ?? "");
+              if (!text.trim()) return null;
+              // Reasoning is only live while it's the trailing part.
+              const isLastPart = index === parts.length - 1;
+              return (
+                <ChatReasoning
+                  key={key}
+                  text={text}
+                  isStreaming={isLoading && isLastPart}
+                />
+              );
+            }
+
+            if (isToolPart(part)) {
+              const toolPart = part as unknown as ToolPart;
+              const toolName =
+                toolPart.toolName ?? part.type.replace(/^tool-/, "");
+              const props: ChatToolCallProps = {
+                toolName,
+                input: toolPart.input,
+                output: toolPart.output,
+                errorText: toolPart.errorText,
+                state: toolStateBadge(toolPart.state),
+              };
+              const custom = renderToolCall?.(props);
+              if (custom !== undefined) {
+                return <div key={key}>{custom}</div>;
+              }
+              return <ChatToolCall key={key} {...props} />;
+            }
+
+            if (part.type === "data-approval-pending") {
+              const data =
+                (part as { data?: Record<string, unknown> }).data ?? {};
+              const approvalId = String(data.approvalId ?? "");
+              const entry = approvals.get(approvalId);
+              const toolName = String(
+                data.toolName ?? entry?.toolName ?? "tool",
+              );
+              const args = data.args ?? entry?.args;
+              const streamId = String(data.streamId ?? entry?.streamId ?? "");
+              const state: ApprovalEntry["state"] = entry?.state ?? "pending";
+              const props: ChatToolCallProps = {
+                toolName,
+                input: args,
+                state: approvalStateBadge(state),
+                isApproval: true,
+                onApprove: () => onApprove(approvalId, streamId),
+                onDeny: () => onDeny(approvalId, streamId),
+              };
+              const custom = renderToolCall?.(props);
+              if (custom !== undefined) {
+                return <div key={key}>{custom}</div>;
+              }
+              return <ChatToolCall key={key} {...props} />;
+            }
+
+            if (part.type === "source-url") {
+              const url = String((part as { url?: unknown }).url ?? "");
+              const title = String((part as { title?: unknown }).title ?? url);
+              if (!url) return null;
+              return (
+                <a
+                  key={key}
+                  href={url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-baseline text-primary hover:underline"
+                >
+                  <sup className="text-xs">[{title}]</sup>
+                </a>
+              );
+            }
+
+            return null;
+          })}
+
+        {mode === "view" && !isLoading && visibleParts.length > 0 && (
+          <ChatMessageActions<TMessage>
+            message={message}
+            onEdit={canEdit ? () => setMode("edit") : undefined}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/appkit-ui/src/react/chat/app/chat-messages.tsx
+++ b/packages/appkit-ui/src/react/chat/app/chat-messages.tsx
@@ -1,0 +1,107 @@
+import type { UseChatHelpers } from "@ai-sdk/react";
+import type { ChatStatus, UIMessage } from "ai";
+import type { ReactNode, RefObject } from "react";
+import { cn } from "../../lib/utils";
+import { Button } from "../../ui/button";
+import { ArrowDownIcon, DbIcon } from "../db-icons";
+import { ChatAwaitingResponse } from "./chat-awaiting-response";
+import {
+  type ApprovalEntry,
+  ChatMessage,
+  type ChatMessageProps,
+} from "./chat-message";
+import type { ChatToolCallProps } from "./chat-tool-call";
+
+interface ChatMessagesProps<TMessage extends UIMessage = UIMessage> {
+  messages: TMessage[];
+  status: ChatStatus;
+  containerRef: RefObject<HTMLDivElement | null>;
+  isAtBottom: boolean;
+  scrollToBottom: () => void;
+  approvals: Map<string, ApprovalEntry>;
+  onApprove: (approvalId: string, streamId: string) => void;
+  onDeny: (approvalId: string, streamId: string) => void;
+  /** Forwarded to each `<ChatMessage>` to enable user-message editing. */
+  setMessages?: UseChatHelpers<TMessage>["setMessages"];
+  regenerate?: UseChatHelpers<TMessage>["regenerate"];
+  /** Override per-message rendering. Return undefined to fall through. */
+  renderMessage?: (props: ChatMessageProps<TMessage>) => ReactNode | undefined;
+  /** Forwarded to each `<ChatMessage>`. */
+  renderToolCall?: (props: ChatToolCallProps) => ReactNode | undefined;
+  className?: string;
+}
+
+/**
+ * Auto-sticking conversation list with a floating scroll-to-bottom
+ * button when the user has scrolled up.
+ */
+export function ChatMessages<TMessage extends UIMessage = UIMessage>({
+  messages,
+  status,
+  containerRef,
+  isAtBottom,
+  scrollToBottom,
+  approvals,
+  onApprove,
+  onDeny,
+  setMessages,
+  regenerate,
+  renderMessage,
+  renderToolCall,
+  className,
+}: ChatMessagesProps<TMessage>) {
+  // Shimmer between the user's message and the not-yet-created
+  // assistant stub. Once the stub exists, ChatMessage handles it inline.
+  const lastMessage = messages[messages.length - 1];
+  const needsBetweenAwaiting =
+    (status === "submitted" || status === "streaming") &&
+    lastMessage?.role === "user";
+
+  return (
+    <div className={cn("relative min-h-0 flex-1 overflow-hidden", className)}>
+      <div
+        ref={containerRef}
+        className="h-full overflow-y-auto"
+        style={{ overflowAnchor: "none" }}
+      >
+        <div className="mx-auto flex max-w-4xl flex-col gap-4 px-4 py-6 md:gap-6 md:px-6">
+          {messages.map((message, index) => {
+            const isLastAssistant =
+              index === messages.length - 1 && message.role === "assistant";
+            const isLoading = status === "streaming" && isLastAssistant;
+            const props: ChatMessageProps<TMessage> = {
+              message,
+              isLoading,
+              approvals,
+              onApprove,
+              onDeny,
+              setMessages,
+              regenerate,
+              renderToolCall,
+            };
+            const custom = renderMessage?.(props);
+            if (custom !== undefined) {
+              return <div key={message.id}>{custom}</div>;
+            }
+            return <ChatMessage key={message.id} {...props} />;
+          })}
+
+          {needsBetweenAwaiting && <ChatAwaitingResponse />}
+        </div>
+      </div>
+
+      {!isAtBottom && messages.length > 0 && (
+        <Button
+          type="button"
+          size="icon"
+          variant="outline"
+          onClick={() => scrollToBottom()}
+          aria-label="Scroll to bottom"
+          className="absolute bottom-4 left-1/2 -translate-x-1/2 rounded-full shadow-lg"
+        >
+          <DbIcon icon={ArrowDownIcon} />
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/packages/appkit-ui/src/react/chat/app/chat-messages.tsx
+++ b/packages/appkit-ui/src/react/chat/app/chat-messages.tsx
@@ -1,6 +1,6 @@
 import type { UseChatHelpers } from "@ai-sdk/react";
 import type { ChatStatus, UIMessage } from "ai";
-import type { ReactNode, RefObject } from "react";
+import type { ReactNode } from "react";
 import { cn } from "../../lib/utils";
 import { Button } from "../../ui/button";
 import { ArrowDownIcon, DbIcon } from "../db-icons";
@@ -15,7 +15,12 @@ import type { ChatToolCallProps } from "./chat-tool-call";
 interface ChatMessagesProps<TMessage extends UIMessage = UIMessage> {
   messages: TMessage[];
   status: ChatStatus;
-  containerRef: RefObject<HTMLDivElement | null>;
+  /**
+   * Scroll-container ref. `useScrollToBottom` returns a ref callback
+   * (not a RefObject) so the listener attaches when the node mounts —
+   * forward whatever the hook gives you.
+   */
+  containerRef: (node: HTMLDivElement | null) => void;
   isAtBottom: boolean;
   scrollToBottom: () => void;
   approvals: Map<string, ApprovalEntry>;

--- a/packages/appkit-ui/src/react/chat/app/chat-reasoning.tsx
+++ b/packages/appkit-ui/src/react/chat/app/chat-reasoning.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from "react";
+import { cn } from "../../lib/utils";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "../../ui/collapsible";
+import { ChevronDownIcon } from "../db-icons";
+import { ChatMarkdown } from "./chat-markdown";
+import { ChatShimmer } from "./chat-shimmer";
+
+const AUTO_CLOSE_DELAY_MS = 500;
+const MS_IN_S = 1000;
+
+interface ChatReasoningProps {
+  /** Reasoning text streamed as `appkit.thinking` events. */
+  text: string;
+  /** True while the model is still emitting reasoning deltas. */
+  isStreaming: boolean;
+  className?: string;
+}
+
+/**
+ * Collapsible "Thinking…" panel. Auto-opens while streaming, auto-closes
+ * shortly after, and shows elapsed time once finished.
+ */
+export function ChatReasoning({
+  text,
+  isStreaming,
+  className,
+}: ChatReasoningProps) {
+  const [isOpen, setIsOpen] = useState(true);
+  const [hasAutoClosed, setHasAutoClosed] = useState(false);
+  const [duration, setDuration] = useState(0);
+  const [startTime, setStartTime] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (isStreaming) {
+      if (startTime === null) setStartTime(Date.now());
+      // Re-arm for multi-round reasoning within a single part: a fresh
+      // streaming round reopens the panel and clears the prior duration.
+      setHasAutoClosed(false);
+      setIsOpen(true);
+      setDuration(0);
+    } else if (startTime !== null) {
+      setDuration(Math.round((Date.now() - startTime) / MS_IN_S));
+      setStartTime(null);
+    }
+  }, [isStreaming, startTime]);
+
+  useEffect(() => {
+    if (!isStreaming && isOpen && !hasAutoClosed) {
+      const t = setTimeout(() => {
+        setIsOpen(false);
+        setHasAutoClosed(true);
+      }, AUTO_CLOSE_DELAY_MS);
+      return () => clearTimeout(t);
+    }
+  }, [isStreaming, isOpen, hasAutoClosed]);
+
+  return (
+    <Collapsible
+      open={isOpen}
+      onOpenChange={setIsOpen}
+      className={cn("not-prose", className)}
+    >
+      <CollapsibleTrigger className="group/reasoning flex cursor-pointer items-center gap-1.5 text-base transition-colors hover:text-foreground">
+        {isStreaming ? (
+          <ChatShimmer className="text-base font-medium">
+            Thinking...
+          </ChatShimmer>
+        ) : (
+          <span className="font-medium text-muted-foreground">
+            {duration > 0 ? `Thought for ${duration}s` : "Thoughts"}
+          </span>
+        )}
+        <ChevronDownIcon
+          className={cn(
+            "size-3 text-muted-foreground transition-transform",
+            isOpen ? "rotate-180" : "rotate-0",
+          )}
+        />
+      </CollapsibleTrigger>
+      <CollapsibleContent
+        className={cn(
+          "mt-2 border-l border-border pl-4 text-base text-muted-foreground",
+          "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2",
+          "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-top-2",
+          "outline-hidden",
+        )}
+      >
+        <ChatMarkdown>{text}</ChatMarkdown>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/packages/appkit-ui/src/react/chat/app/chat-shimmer.tsx
+++ b/packages/appkit-ui/src/react/chat/app/chat-shimmer.tsx
@@ -1,0 +1,44 @@
+import type { HTMLAttributes } from "react";
+import { cn } from "../../lib/utils";
+
+// Shimmer text via a moving gradient clipped to the glyphs. Keyframes
+// are injected once so we don't depend on consumer `globals.css`.
+
+let injected = false;
+function ensureKeyframes() {
+  if (injected || typeof document === "undefined") return;
+  injected = true;
+  const style = document.createElement("style");
+  style.setAttribute("data-appkit-chat-shimmer", "");
+  style.textContent =
+    "@keyframes appkit-chat-shimmer-text {0%{background-position:100% 50%}100%{background-position:-100% 50%}}";
+  document.head.appendChild(style);
+}
+
+interface ChatShimmerProps extends HTMLAttributes<HTMLSpanElement> {}
+
+export function ChatShimmer({
+  className,
+  children,
+  style,
+  ...props
+}: ChatShimmerProps) {
+  ensureKeyframes();
+  return (
+    <span
+      className={cn("inline-block text-transparent", className)}
+      style={{
+        backgroundImage:
+          "linear-gradient(90deg, var(--color-neutral-600) 0%, var(--color-neutral-300) 35%, var(--color-neutral-600) 50%, var(--color-neutral-600) 65%, var(--color-neutral-600) 100%)",
+        backgroundSize: "200% 100%",
+        WebkitBackgroundClip: "text",
+        backgroundClip: "text",
+        animation: "appkit-chat-shimmer-text 1.5s linear infinite",
+        ...style,
+      }}
+      {...props}
+    >
+      {children}
+    </span>
+  );
+}

--- a/packages/appkit-ui/src/react/chat/app/chat-tool-call.tsx
+++ b/packages/appkit-ui/src/react/chat/app/chat-tool-call.tsx
@@ -1,0 +1,265 @@
+import { ServerIcon, ShieldAlertIcon } from "lucide-react";
+import { type ReactNode, useState } from "react";
+import { cn } from "../../lib/utils";
+import { Badge } from "../../ui/badge";
+import { Button } from "../../ui/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "../../ui/collapsible";
+import {
+  CheckCircleIcon,
+  ChevronDownIcon,
+  ClockIcon,
+  ShieldCheckIcon,
+  ShieldOffIcon as ShieldXIcon,
+  WrenchIcon,
+  XCircleIcon,
+} from "../db-icons";
+
+export type ChatToolCallState =
+  /** Tool input received, waiting for output. */
+  | "pending"
+  /** Tool produced output. */
+  | "completed"
+  /** Tool produced an error. */
+  | "error"
+  /** Approval gate waiting on user decision. */
+  | "approval-pending"
+  /** Approval decision in flight. */
+  | "approving"
+  /** User approved the tool call. */
+  | "approved"
+  /** User denied the tool call. */
+  | "denied";
+
+export interface ChatToolCallProps {
+  toolName: string;
+  /** Tool call input — rendered as JSON in the parameters block. */
+  input: unknown;
+  /** Tool output (regular tool calls). Stringified if not already a string. */
+  output?: unknown;
+  /** Server-reported error for this tool call. */
+  errorText?: string;
+  state: ChatToolCallState;
+  /** Render as an approval gate (banner + Allow/Deny footer). */
+  isApproval?: boolean;
+  /** Optional MCP server name shown in the approval banner. */
+  serverName?: string;
+  /** Approval-variant callbacks. Required when `isApproval` is true. */
+  onApprove?: () => void;
+  onDeny?: () => void;
+  className?: string;
+}
+
+function StatusBadge({ state }: { state: ChatToolCallState }) {
+  // Tones map to chat-theme `--badge-*` token pairs so host apps can
+  // rebrand by re-assigning `--primary`/`--success`/`--warning`/
+  // `--destructive` (see `chat-theme.css`).
+  const config: Record<
+    ChatToolCallState,
+    { label: string; icon: ReactNode; className: string }
+  > = {
+    pending: {
+      label: "Running",
+      icon: <ClockIcon className="size-3 animate-pulse" />,
+      className: "bg-[var(--badge-info-bg)] text-[var(--badge-info-fg)]",
+    },
+    completed: {
+      label: "Completed",
+      icon: <CheckCircleIcon className="size-3" />,
+      className: "bg-[var(--badge-success-bg)] text-[var(--badge-success-fg)]",
+    },
+    error: {
+      label: "Error",
+      icon: <XCircleIcon className="size-3" />,
+      className: "bg-[var(--badge-error-bg)] text-[var(--badge-error-fg)]",
+    },
+    "approval-pending": {
+      label: "Pending",
+      icon: <ShieldAlertIcon className="size-3" />,
+      className: "bg-[var(--badge-warning-bg)] text-[var(--badge-warning-fg)]",
+    },
+    approving: {
+      label: "Submitting",
+      icon: <ClockIcon className="size-3 animate-pulse" />,
+      className: "bg-[var(--badge-warning-bg)] text-[var(--badge-warning-fg)]",
+    },
+    approved: {
+      label: "Allowed",
+      icon: <ShieldCheckIcon className="size-3" />,
+      className: "bg-[var(--badge-success-bg)] text-[var(--badge-success-fg)]",
+    },
+    denied: {
+      label: "Denied",
+      icon: <ShieldXIcon className="size-3" />,
+      className: "bg-[var(--badge-error-bg)] text-[var(--badge-error-fg)]",
+    },
+  };
+  const c = config[state];
+  return (
+    <Badge
+      variant="secondary"
+      className={cn(
+        "flex items-center gap-1 rounded-full border-0 font-medium text-xs",
+        c.className,
+      )}
+    >
+      {c.icon}
+      <span>{c.label}</span>
+    </Badge>
+  );
+}
+
+function formatJson(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function formatOutput(value: unknown): string {
+  if (typeof value === "string") return value;
+  return formatJson(value);
+}
+
+/**
+ * Collapsible tool-call card. Renders both regular tool invocations and
+ * approval gates with a shared layout — only the banner and footer differ.
+ */
+export function ChatToolCall({
+  toolName,
+  input,
+  output,
+  errorText,
+  state,
+  isApproval = false,
+  serverName,
+  onApprove,
+  onDeny,
+  className,
+}: ChatToolCallProps) {
+  // Initial-only: collapsed iff the call already finished successfully.
+  // Pending/error/approval calls open by default; once the user toggles
+  // the card, their choice sticks regardless of subsequent state changes.
+  const [isOpen, setIsOpen] = useState(state !== "completed");
+  const showOutput =
+    !isApproval && (state === "completed" || state === "error");
+  const showApprovalActions = isApproval && state === "approval-pending";
+
+  return (
+    <Collapsible
+      open={isOpen}
+      onOpenChange={setIsOpen}
+      className={cn(
+        "not-prose w-full overflow-hidden rounded-xl border bg-card/60",
+        isApproval && "bg-muted/30",
+        className,
+      )}
+    >
+      {isApproval && (
+        <div className="flex items-center gap-2 border-b border-border bg-muted/50 px-3 py-1.5 text-xs">
+          <ServerIcon className="size-3 text-muted-foreground" />
+          <span className="font-medium text-muted-foreground">
+            Tool Call Request
+          </span>
+          {serverName && (
+            <>
+              <span className="text-muted-foreground/50">•</span>
+              <span className="truncate text-muted-foreground">
+                {serverName}
+              </span>
+            </>
+          )}
+          <span className="ml-auto">
+            <StatusBadge state={state} />
+          </span>
+        </div>
+      )}
+
+      <CollapsibleTrigger className="group/tool flex w-full min-w-0 cursor-pointer items-center justify-between gap-2 px-3 py-2.5">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <WrenchIcon className="size-4 shrink-0 text-muted-foreground" />
+          <span
+            className={cn(
+              "truncate text-sm",
+              isApproval ? "font-mono" : "font-medium",
+            )}
+          >
+            {toolName}
+          </span>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {!isApproval && <StatusBadge state={state} />}
+          <ChevronDownIcon
+            className={cn(
+              "size-4 text-muted-foreground transition-transform",
+              isOpen ? "rotate-180" : "rotate-0",
+            )}
+          />
+        </div>
+      </CollapsibleTrigger>
+
+      <CollapsibleContent
+        className={cn(
+          "data-[state=closed]:animate-out data-[state=closed]:fade-out-0",
+          "data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        )}
+      >
+        <div className="space-y-1.5 px-3 pb-3">
+          <h4 className="font-medium text-muted-foreground text-[10px] uppercase tracking-wide">
+            Parameters
+          </h4>
+          <pre className="overflow-x-auto whitespace-pre-wrap wrap-break-word rounded-md bg-muted/60 p-2.5 text-xs font-mono">
+            {formatJson(input)}
+          </pre>
+        </div>
+
+        {showOutput && (
+          <div className="space-y-1.5 px-3 pb-3">
+            <h4 className="font-medium text-muted-foreground text-[10px] uppercase tracking-wide">
+              {errorText ? "Error" : "Result"}
+            </h4>
+            <pre
+              className={cn(
+                "overflow-x-auto whitespace-pre-wrap wrap-break-word rounded-md p-2.5 text-xs font-mono",
+                errorText
+                  ? "bg-destructive/10 text-destructive"
+                  : "bg-muted/60",
+              )}
+            >
+              {errorText ?? formatOutput(output)}
+            </pre>
+          </div>
+        )}
+
+        {showApprovalActions && (
+          <div className="flex flex-col gap-3 border-t border-amber-300 bg-amber-50/50 p-3 dark:border-amber-700 dark:bg-amber-950/20">
+            <div className="flex items-start gap-2">
+              <ShieldAlertIcon className="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-400" />
+              <p className="text-amber-800 text-sm dark:text-amber-200">
+                This tool requires your permission to run.
+              </p>
+            </div>
+            <div className="flex gap-2">
+              <Button
+                size="sm"
+                onClick={onApprove}
+                className="bg-green-600 text-white hover:bg-green-700"
+              >
+                <ShieldCheckIcon className="mr-1.5 size-4" />
+                Allow
+              </Button>
+              <Button size="sm" variant="outline" onClick={onDeny}>
+                <ShieldXIcon className="mr-1.5 size-4" />
+                Deny
+              </Button>
+            </div>
+          </div>
+        )}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/packages/appkit-ui/src/react/chat/app/index.ts
+++ b/packages/appkit-ui/src/react/chat/app/index.ts
@@ -1,0 +1,1 @@
+export * from "./chat-app";

--- a/packages/appkit-ui/src/react/chat/app/utils.ts
+++ b/packages/appkit-ui/src/react/chat/app/utils.ts
@@ -1,0 +1,11 @@
+import type { UIMessage } from "ai";
+
+/** Concatenate the text of all `text` parts in a message. */
+export function getMessageText<TMessage extends UIMessage>(
+  message: TMessage,
+): string {
+  return (message.parts as Array<{ type: string; text?: unknown }>)
+    .filter((p) => p.type === "text")
+    .map((p) => String(p.text ?? ""))
+    .join("");
+}

--- a/packages/appkit-ui/src/react/chat/db-icons/arrow-down-icon.tsx
+++ b/packages/appkit-ui/src/react/chat/db-icons/arrow-down-icon.tsx
@@ -1,0 +1,34 @@
+import { forwardRef, type SVGProps } from "react";
+import { cn } from "../../lib/utils";
+
+interface ArrowDownIconProps extends SVGProps<SVGSVGElement> {
+  size?: number | string;
+  className?: string;
+  ariaLabel?: string;
+}
+
+export const ArrowDownIcon = forwardRef<SVGSVGElement, ArrowDownIconProps>(
+  ({ size = 16, className, ariaLabel, ...props }, ref) => (
+    <svg
+      ref={ref}
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="none"
+      className={cn("shrink-0", className)}
+      aria-hidden={!ariaLabel}
+      aria-label={ariaLabel}
+      role={ariaLabel ? "img" : undefined}
+      {...props}
+    >
+      <path
+        fill="currentColor"
+        fillRule="evenodd"
+        d="M8.03 15.06 1 8.03l1.06-1.06 5.22 5.22V1h1.5v11.19L14 6.97l1.06 1.06z"
+        clipRule="evenodd"
+      />
+    </svg>
+  ),
+);
+ArrowDownIcon.displayName = "ArrowDownIcon";

--- a/packages/appkit-ui/src/react/chat/db-icons/arrow-up-icon.tsx
+++ b/packages/appkit-ui/src/react/chat/db-icons/arrow-up-icon.tsx
@@ -1,0 +1,36 @@
+import { forwardRef, type SVGProps } from "react";
+import { cn } from "../../lib/utils";
+
+interface ArrowUpIconProps extends SVGProps<SVGSVGElement> {
+  /** Pixel size; defaults to DuBois standard 16. */
+  size?: number | string;
+  className?: string;
+  /** When set, the icon gets `role="img"`. */
+  ariaLabel?: string;
+}
+
+export const ArrowUpIcon = forwardRef<SVGSVGElement, ArrowUpIconProps>(
+  ({ size = 16, className, ariaLabel, ...props }, ref) => (
+    <svg
+      ref={ref}
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="none"
+      className={cn("shrink-0", className)}
+      aria-hidden={!ariaLabel}
+      aria-label={ariaLabel}
+      role={ariaLabel ? "img" : undefined}
+      {...props}
+    >
+      <path
+        fill="currentColor"
+        fillRule="evenodd"
+        d="m8.03 1 7.03 7.03L14 9.091l-5.22-5.22v11.19h-1.5V3.87l-5.22 5.22L1 8.031z"
+        clipRule="evenodd"
+      />
+    </svg>
+  ),
+);
+ArrowUpIcon.displayName = "ArrowUpIcon";

--- a/packages/appkit-ui/src/react/chat/db-icons/check-circle-icon.tsx
+++ b/packages/appkit-ui/src/react/chat/db-icons/check-circle-icon.tsx
@@ -1,0 +1,38 @@
+import { forwardRef, type SVGProps } from "react";
+import { cn } from "../../lib/utils";
+
+interface CheckCircleIconProps extends SVGProps<SVGSVGElement> {
+  size?: number | string;
+  className?: string;
+  ariaLabel?: string;
+}
+
+export const CheckCircleIcon = forwardRef<SVGSVGElement, CheckCircleIconProps>(
+  ({ size = 16, className, ariaLabel, ...props }, ref) => (
+    <svg
+      ref={ref}
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="none"
+      className={cn("shrink-0", className)}
+      aria-hidden={!ariaLabel}
+      aria-label={ariaLabel}
+      role={ariaLabel ? "img" : undefined}
+      {...props}
+    >
+      <path
+        fill="currentColor"
+        d="M11.53 6.53 7 11.06 4.47 8.53l1.06-1.06L7 8.94l3.47-3.47z"
+      />
+      <path
+        fill="currentColor"
+        fillRule="evenodd"
+        d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8m8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13"
+        clipRule="evenodd"
+      />
+    </svg>
+  ),
+);
+CheckCircleIcon.displayName = "CheckCircleIcon";

--- a/packages/appkit-ui/src/react/chat/db-icons/check-icon.tsx
+++ b/packages/appkit-ui/src/react/chat/db-icons/check-icon.tsx
@@ -1,0 +1,34 @@
+import { forwardRef, type SVGProps } from "react";
+import { cn } from "../../lib/utils";
+
+interface CheckIconProps extends SVGProps<SVGSVGElement> {
+  size?: number | string;
+  className?: string;
+  ariaLabel?: string;
+}
+
+export const CheckIcon = forwardRef<SVGSVGElement, CheckIconProps>(
+  ({ size = 16, className, ariaLabel, ...props }, ref) => (
+    <svg
+      ref={ref}
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="none"
+      className={cn("shrink-0", className)}
+      aria-hidden={!ariaLabel}
+      aria-label={ariaLabel}
+      role={ariaLabel ? "img" : undefined}
+      {...props}
+    >
+      <path
+        fill="currentColor"
+        fillRule="evenodd"
+        d="m15.06 3.56-9.53 9.531L1 8.561 2.06 7.5l3.47 3.47L14 2.5z"
+        clipRule="evenodd"
+      />
+    </svg>
+  ),
+);
+CheckIcon.displayName = "CheckIcon";

--- a/packages/appkit-ui/src/react/chat/db-icons/chevron-down-icon.tsx
+++ b/packages/appkit-ui/src/react/chat/db-icons/chevron-down-icon.tsx
@@ -1,0 +1,34 @@
+import { forwardRef, type SVGProps } from "react";
+import { cn } from "../../lib/utils";
+
+interface ChevronDownIconProps extends SVGProps<SVGSVGElement> {
+  size?: number | string;
+  className?: string;
+  ariaLabel?: string;
+}
+
+export const ChevronDownIcon = forwardRef<SVGSVGElement, ChevronDownIconProps>(
+  ({ size = 16, className, ariaLabel, ...props }, ref) => (
+    <svg
+      ref={ref}
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="none"
+      className={cn("shrink-0", className)}
+      aria-hidden={!ariaLabel}
+      aria-label={ariaLabel}
+      role={ariaLabel ? "img" : undefined}
+      {...props}
+    >
+      <path
+        fill="currentColor"
+        fillRule="evenodd"
+        d="M8 8.917 10.947 6 12 7.042 8 11 4 7.042 5.053 6z"
+        clipRule="evenodd"
+      />
+    </svg>
+  ),
+);
+ChevronDownIcon.displayName = "ChevronDownIcon";

--- a/packages/appkit-ui/src/react/chat/db-icons/clock-icon.tsx
+++ b/packages/appkit-ui/src/react/chat/db-icons/clock-icon.tsx
@@ -1,0 +1,38 @@
+import { forwardRef, type SVGProps } from "react";
+import { cn } from "../../lib/utils";
+
+interface ClockIconProps extends SVGProps<SVGSVGElement> {
+  size?: number | string;
+  className?: string;
+  ariaLabel?: string;
+}
+
+export const ClockIcon = forwardRef<SVGSVGElement, ClockIconProps>(
+  ({ size = 16, className, ariaLabel, ...props }, ref) => (
+    <svg
+      ref={ref}
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="none"
+      className={cn("shrink-0", className)}
+      aria-hidden={!ariaLabel}
+      aria-label={ariaLabel}
+      role={ariaLabel ? "img" : undefined}
+      {...props}
+    >
+      <path
+        fill="currentColor"
+        d="M7.25 4v4c0 .199.079.39.22.53l2 2 1.06-1.06-1.78-1.78V4z"
+      />
+      <path
+        fill="currentColor"
+        fillRule="evenodd"
+        d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0M1.5 8a6.5 6.5 0 1 1 13 0 6.5 6.5 0 0 1-13 0"
+        clipRule="evenodd"
+      />
+    </svg>
+  ),
+);
+ClockIcon.displayName = "ClockIcon";

--- a/packages/appkit-ui/src/react/chat/db-icons/copy-icon.tsx
+++ b/packages/appkit-ui/src/react/chat/db-icons/copy-icon.tsx
@@ -1,0 +1,36 @@
+import { forwardRef, type SVGProps } from "react";
+import { cn } from "../../lib/utils";
+
+interface CopyIconProps extends SVGProps<SVGSVGElement> {
+  /** Pixel size; defaults to DuBois standard 16. */
+  size?: number | string;
+  className?: string;
+  /** When set, the icon gets `role="img"`. */
+  ariaLabel?: string;
+}
+
+export const CopyIcon = forwardRef<SVGSVGElement, CopyIconProps>(
+  ({ size = 16, className, ariaLabel, ...props }, ref) => (
+    <svg
+      ref={ref}
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="none"
+      className={cn("shrink-0", className)}
+      aria-hidden={!ariaLabel}
+      aria-label={ariaLabel}
+      role={ariaLabel ? "img" : undefined}
+      {...props}
+    >
+      <path
+        fill="currentColor"
+        fillRule="evenodd"
+        d="M1.75 1a.75.75 0 0 0-.75.75v8.5c0 .414.336.75.75.75H5v3.25c0 .414.336.75.75.75h8.5a.75.75 0 0 0 .75-.75v-8.5a.75.75 0 0 0-.75-.75H11V1.75a.75.75 0 0 0-.75-.75zM9.5 5V2.5h-7v7H5V5.75A.75.75 0 0 1 5.75 5zm-3 8.5v-7h7v7z"
+        clipRule="evenodd"
+      />
+    </svg>
+  ),
+);
+CopyIcon.displayName = "CopyIcon";

--- a/packages/appkit-ui/src/react/chat/db-icons/db-icon.tsx
+++ b/packages/appkit-ui/src/react/chat/db-icons/db-icon.tsx
@@ -1,0 +1,60 @@
+import type { ComponentType, SVGProps } from "react";
+import { cn } from "../../lib/utils";
+
+type IconColor =
+  | "default"
+  | "muted"
+  | "primary"
+  | "danger"
+  | "warning"
+  | "success";
+
+type DbIconComponent = ComponentType<
+  SVGProps<SVGSVGElement> & {
+    size?: number | string;
+    ariaLabel?: string;
+  }
+>;
+
+interface DbIconProps {
+  /** Icon component (DuBois SVG or compatible). */
+  icon: DbIconComponent;
+  /** Pixel size; defaults to DuBois standard 16. */
+  size?: number;
+  color?: IconColor;
+  className?: string;
+  /** When set, the icon gets `role="img"` and is announced. */
+  ariaLabel?: string;
+}
+
+const colorMap: Record<IconColor, string> = {
+  default: "",
+  muted: "text-muted-foreground",
+  primary: "text-primary",
+  danger: "text-destructive",
+  warning: "text-[var(--warning)]",
+  success: "text-[var(--success)]",
+};
+
+/**
+ * DuBois icon wrapper. Standardises sizing, semantic colour tokens,
+ * and accessibility for the icon set vendored under `./*-icon.tsx`.
+ */
+export function DbIcon({
+  icon: Icon,
+  size = 16,
+  color = "default",
+  className,
+  ariaLabel,
+}: DbIconProps) {
+  return (
+    <Icon
+      width={size}
+      height={size}
+      className={cn("shrink-0", colorMap[color], className)}
+      aria-label={ariaLabel}
+      role={ariaLabel ? "img" : undefined}
+      aria-hidden={!ariaLabel}
+    />
+  );
+}

--- a/packages/appkit-ui/src/react/chat/db-icons/index.ts
+++ b/packages/appkit-ui/src/react/chat/db-icons/index.ts
@@ -1,0 +1,14 @@
+export { ArrowDownIcon } from "./arrow-down-icon";
+export { ArrowUpIcon } from "./arrow-up-icon";
+export { CheckCircleIcon } from "./check-circle-icon";
+export { CheckIcon } from "./check-icon";
+export { ChevronDownIcon } from "./chevron-down-icon";
+export { ClockIcon } from "./clock-icon";
+export { CopyIcon } from "./copy-icon";
+export { DbIcon } from "./db-icon";
+export { PencilIcon } from "./pencil-icon";
+export { ShieldCheckIcon } from "./shield-check-icon";
+export { ShieldOffIcon } from "./shield-off-icon";
+export { StopIcon } from "./stop-icon";
+export { WrenchIcon } from "./wrench-icon";
+export { XCircleIcon } from "./x-circle-icon";

--- a/packages/appkit-ui/src/react/chat/db-icons/pencil-icon.tsx
+++ b/packages/appkit-ui/src/react/chat/db-icons/pencil-icon.tsx
@@ -1,0 +1,36 @@
+import { forwardRef, type SVGProps } from "react";
+import { cn } from "../../lib/utils";
+
+interface PencilIconProps extends SVGProps<SVGSVGElement> {
+  /** Pixel size; defaults to DuBois standard 16. */
+  size?: number | string;
+  className?: string;
+  /** When set, the icon gets `role="img"`. */
+  ariaLabel?: string;
+}
+
+export const PencilIcon = forwardRef<SVGSVGElement, PencilIconProps>(
+  ({ size = 16, className, ariaLabel, ...props }, ref) => (
+    <svg
+      ref={ref}
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="none"
+      className={cn("shrink-0", className)}
+      aria-hidden={!ariaLabel}
+      aria-label={ariaLabel}
+      role={ariaLabel ? "img" : undefined}
+      {...props}
+    >
+      <path
+        fill="currentColor"
+        fillRule="evenodd"
+        d="M13.487 1.513a1.75 1.75 0 0 0-2.474 0L1.22 11.306a.75.75 0 0 0-.22.53v2.5c0 .414.336.75.75.75h2.5a.75.75 0 0 0 .53-.22l9.793-9.793a1.75 1.75 0 0 0 0-2.475zm-1.414 1.06a.25.25 0 0 1 .354 0l1.086 1.086a.25.25 0 0 1 0 .354L12 5.525l-1.44-1.44zM9.5 5.146l-7 7v1.44h1.44l7-7z"
+        clipRule="evenodd"
+      />
+    </svg>
+  ),
+);
+PencilIcon.displayName = "PencilIcon";

--- a/packages/appkit-ui/src/react/chat/db-icons/shield-check-icon.tsx
+++ b/packages/appkit-ui/src/react/chat/db-icons/shield-check-icon.tsx
@@ -1,0 +1,34 @@
+import { forwardRef, type SVGProps } from "react";
+import { cn } from "../../lib/utils";
+
+interface ShieldCheckIconProps extends SVGProps<SVGSVGElement> {
+  size?: number | string;
+  className?: string;
+  ariaLabel?: string;
+}
+
+export const ShieldCheckIcon = forwardRef<SVGSVGElement, ShieldCheckIconProps>(
+  ({ size = 16, className, ariaLabel, ...props }, ref) => (
+    <svg
+      ref={ref}
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="none"
+      className={cn("shrink-0", className)}
+      aria-hidden={!ariaLabel}
+      aria-label={ariaLabel}
+      role={ariaLabel ? "img" : undefined}
+      {...props}
+    >
+      <path
+        fill="currentColor"
+        fillRule="evenodd"
+        d="M2 1.75A.75.75 0 0 1 2.75 1h10.5a.75.75 0 0 1 .75.75v7.465a5.75 5.75 0 0 1-2.723 4.889l-2.882 1.784a.75.75 0 0 1-.79 0l-2.882-1.784A5.75 5.75 0 0 1 2 9.214zm1.5.75v6.715a4.25 4.25 0 0 0 2.013 3.613L8 14.368l2.487-1.54A4.25 4.25 0 0 0 12.5 9.215V2.5zm6.22 2.97 1.06 1.06-3.53 3.53-2.03-2.03 1.06-1.06.97.97z"
+        clipRule="evenodd"
+      />
+    </svg>
+  ),
+);
+ShieldCheckIcon.displayName = "ShieldCheckIcon";

--- a/packages/appkit-ui/src/react/chat/db-icons/shield-off-icon.tsx
+++ b/packages/appkit-ui/src/react/chat/db-icons/shield-off-icon.tsx
@@ -1,0 +1,38 @@
+import { forwardRef, type SVGProps } from "react";
+import { cn } from "../../lib/utils";
+
+interface ShieldOffIconProps extends SVGProps<SVGSVGElement> {
+  size?: number | string;
+  className?: string;
+  ariaLabel?: string;
+}
+
+export const ShieldOffIcon = forwardRef<SVGSVGElement, ShieldOffIconProps>(
+  ({ size = 16, className, ariaLabel, ...props }, ref) => (
+    <svg
+      ref={ref}
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="none"
+      className={cn("shrink-0", className)}
+      aria-hidden={!ariaLabel}
+      aria-label={ariaLabel}
+      role={ariaLabel ? "img" : undefined}
+      {...props}
+    >
+      <path
+        fill="currentColor"
+        d="M13.378 11.817A5.75 5.75 0 0 0 14 9.215V1.75a.75.75 0 0 0-.75-.75H2.75a.8.8 0 0 0-.17.02L4.06 2.5h8.44v6.715c0 .507-.09 1.002-.26 1.464z"
+      />
+      <path
+        fill="currentColor"
+        fillRule="evenodd"
+        d="m1.97 2.53-1 1L2 4.56v4.655a5.75 5.75 0 0 0 2.723 4.889l2.882 1.784a.75.75 0 0 0 .79 0l2.882-1.784.162-.104 1.53 1.53 1-1zM3.5 9.215V6.06l6.852 6.851L8 14.368l-2.487-1.54A4.25 4.25 0 0 1 3.5 9.215"
+        clipRule="evenodd"
+      />
+    </svg>
+  ),
+);
+ShieldOffIcon.displayName = "ShieldOffIcon";

--- a/packages/appkit-ui/src/react/chat/db-icons/stop-icon.tsx
+++ b/packages/appkit-ui/src/react/chat/db-icons/stop-icon.tsx
@@ -1,0 +1,34 @@
+import { forwardRef, type SVGProps } from "react";
+import { cn } from "../../lib/utils";
+
+interface StopIconProps extends SVGProps<SVGSVGElement> {
+  /** Pixel size; defaults to DuBois standard 16. */
+  size?: number | string;
+  className?: string;
+  /** When set, the icon gets `role="img"`. */
+  ariaLabel?: string;
+}
+
+export const StopIcon = forwardRef<SVGSVGElement, StopIconProps>(
+  ({ size = 16, className, ariaLabel, ...props }, ref) => (
+    <svg
+      ref={ref}
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="none"
+      className={cn("shrink-0", className)}
+      aria-hidden={!ariaLabel}
+      aria-label={ariaLabel}
+      role={ariaLabel ? "img" : undefined}
+      {...props}
+    >
+      <path
+        fill="currentColor"
+        d="M4.5 4a.5.5 0 0 0-.5.5v7a.5.5 0 0 0 .5.5h7a.5.5 0 0 0 .5-.5v-7a.5.5 0 0 0-.5-.5z"
+      />
+    </svg>
+  ),
+);
+StopIcon.displayName = "StopIcon";

--- a/packages/appkit-ui/src/react/chat/db-icons/wrench-icon.tsx
+++ b/packages/appkit-ui/src/react/chat/db-icons/wrench-icon.tsx
@@ -1,0 +1,34 @@
+import { forwardRef, type SVGProps } from "react";
+import { cn } from "../../lib/utils";
+
+interface WrenchIconProps extends SVGProps<SVGSVGElement> {
+  size?: number | string;
+  className?: string;
+  ariaLabel?: string;
+}
+
+export const WrenchIcon = forwardRef<SVGSVGElement, WrenchIconProps>(
+  ({ size = 16, className, ariaLabel, ...props }, ref) => (
+    <svg
+      ref={ref}
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="none"
+      className={cn("shrink-0", className)}
+      aria-hidden={!ariaLabel}
+      aria-label={ariaLabel}
+      role={ariaLabel ? "img" : undefined}
+      {...props}
+    >
+      <path
+        fill="currentColor"
+        fillRule="evenodd"
+        d="M14.367 3.29a.75.75 0 0 1 .547.443 5.001 5.001 0 0 1-6.072 6.736l-3.187 3.186a2.341 2.341 0 0 1-3.31-3.31L5.53 7.158a5.001 5.001 0 0 1 6.736-6.072.75.75 0 0 1 .237 1.22L10.5 4.312V5.5h1.19l2.003-2.004a.75.75 0 0 1 .674-.206m-.56 2.214L12.53 6.78A.75.75 0 0 1 12 7H9.75A.75.75 0 0 1 9 6.25V4a.75.75 0 0 1 .22-.53l1.275-1.276a3.501 3.501 0 0 0-3.407 4.865.75.75 0 0 1-.16.823l-3.523 3.523a.84.84 0 1 0 1.19 1.19L8.118 9.07a.75.75 0 0 1 .823-.16 3.5 3.5 0 0 0 4.865-3.407"
+        clipRule="evenodd"
+      />
+    </svg>
+  ),
+);
+WrenchIcon.displayName = "WrenchIcon";

--- a/packages/appkit-ui/src/react/chat/db-icons/x-circle-icon.tsx
+++ b/packages/appkit-ui/src/react/chat/db-icons/x-circle-icon.tsx
@@ -1,0 +1,38 @@
+import { forwardRef, type SVGProps } from "react";
+import { cn } from "../../lib/utils";
+
+interface XCircleIconProps extends SVGProps<SVGSVGElement> {
+  size?: number | string;
+  className?: string;
+  ariaLabel?: string;
+}
+
+export const XCircleIcon = forwardRef<SVGSVGElement, XCircleIconProps>(
+  ({ size = 16, className, ariaLabel, ...props }, ref) => (
+    <svg
+      ref={ref}
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="none"
+      className={cn("shrink-0", className)}
+      aria-hidden={!ariaLabel}
+      aria-label={ariaLabel}
+      role={ariaLabel ? "img" : undefined}
+      {...props}
+    >
+      <path
+        fill="currentColor"
+        d="M6.94 8 4.97 6.03l1.06-1.06L8 6.94l1.97-1.97 1.06 1.06L9.06 8l1.97 1.97-1.06 1.06L8 9.06l-1.97 1.97-1.06-1.06z"
+      />
+      <path
+        fill="currentColor"
+        fillRule="evenodd"
+        d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8m8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13"
+        clipRule="evenodd"
+      />
+    </svg>
+  ),
+);
+XCircleIcon.displayName = "XCircleIcon";

--- a/packages/appkit-ui/src/react/chat/headless/chat-input.tsx
+++ b/packages/appkit-ui/src/react/chat/headless/chat-input.tsx
@@ -1,0 +1,80 @@
+import type { UseChatHelpers } from "@ai-sdk/react";
+import type { ChatStatus, UIMessage } from "ai";
+import { type FormEvent, type ReactNode, useCallback, useState } from "react";
+
+export interface ChatInputRenderProps {
+  value: string;
+  onChange: (value: string) => void;
+  submit: (e?: FormEvent) => void;
+  isStreaming: boolean;
+  stop: () => void;
+  canSubmit: boolean;
+  handleKeyDown: (
+    e: React.KeyboardEvent<HTMLTextAreaElement | HTMLInputElement>,
+  ) => void;
+}
+
+export interface ChatInputProps<TMessage extends UIMessage = UIMessage> {
+  /** Pass `sendMessage` straight through from `useChat` / `Conversation`. */
+  onSubmit: UseChatHelpers<TMessage>["sendMessage"];
+  /** Pass `status` from the chat helpers — drives `isStreaming`. */
+  status: ChatStatus;
+  /** Pass `stop` from the chat helpers — exposed back to the render prop. */
+  stop: () => void;
+  /** Render prop receiving the input state and submit/stop handlers. */
+  children: (props: ChatInputRenderProps) => ReactNode;
+}
+
+/**
+ * Render-prop component that owns the input string, debounces submit,
+ * handles `Enter` / `Shift+Enter` / IME composition, and forwards an
+ * `isStreaming` flag for stop-button toggles. Wire `onSubmit`, `status`,
+ * and `stop` from `useChat` / `Conversation`; the render prop returns a
+ * `submit` callback you can attach to either a form `onSubmit` or a
+ * button `onClick`.
+ */
+export function ChatInput<TMessage extends UIMessage = UIMessage>({
+  onSubmit,
+  status,
+  stop,
+  children,
+}: ChatInputProps<TMessage>) {
+  const [value, setValue] = useState("");
+  const isStreaming = status === "streaming";
+
+  const submit = useCallback(
+    (e?: FormEvent) => {
+      e?.preventDefault();
+      // Mirror the button's `canSubmit` gate so the Enter-key path
+      // can't queue a send mid-stream.
+      if (isStreaming) return;
+      const trimmed = value.trim();
+      if (!trimmed) return;
+      onSubmit({ text: trimmed });
+      setValue("");
+    },
+    [value, onSubmit, isStreaming],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        if (e.nativeEvent.isComposing) return;
+        if (e.shiftKey) return;
+        e.preventDefault();
+        submit();
+      }
+    },
+    [submit],
+  );
+
+  return children({
+    value,
+    onChange: setValue,
+    submit,
+    isStreaming,
+    stop,
+    canSubmit: value.trim().length > 0 && !isStreaming,
+    handleKeyDown,
+  });
+}

--- a/packages/appkit-ui/src/react/chat/headless/conversation.tsx
+++ b/packages/appkit-ui/src/react/chat/headless/conversation.tsx
@@ -1,0 +1,41 @@
+import type { UIMessage } from "ai";
+import type { ReactNode } from "react";
+import {
+  type UseChatOptions,
+  type UseChatReturn,
+  useChat,
+} from "../hooks/use-chat";
+import {
+  type UseScrollToBottomReturn,
+  useScrollToBottom,
+} from "../hooks/use-scroll-to-bottom";
+
+export type ConversationRenderProps<TMessage extends UIMessage = UIMessage> =
+  UseChatReturn<TMessage> &
+    Pick<
+      UseScrollToBottomReturn<HTMLDivElement>,
+      "containerRef" | "isAtBottom" | "scrollToBottom"
+    >;
+
+export interface ConversationProps<TMessage extends UIMessage = UIMessage>
+  extends UseChatOptions<TMessage> {
+  /** Render prop receiving merged `useChat` + `useScrollToBottom` state. */
+  children: (props: ConversationRenderProps<TMessage>) => ReactNode;
+}
+
+/**
+ * Render-prop convenience over `useChat` + `useScrollToBottom`. Streams
+ * Responses-API SSE from an AppKit `agents()`-backed endpoint, captures
+ * the server-allocated `threadId` for multi-turn continuity, and
+ * auto-sticks the scroll container to the bottom while the user is at
+ * the bottom. Drop down to the underlying hooks for non-standard
+ * layouts (split panes, virtualized lists, external send buttons).
+ */
+export function Conversation<TMessage extends UIMessage = UIMessage>({
+  children,
+  ...chatOptions
+}: ConversationProps<TMessage>) {
+  const chat = useChat<TMessage>(chatOptions);
+  const scroll = useScrollToBottom({ trigger: chat.messages });
+  return children({ ...chat, ...scroll });
+}

--- a/packages/appkit-ui/src/react/chat/headless/index.ts
+++ b/packages/appkit-ui/src/react/chat/headless/index.ts
@@ -1,0 +1,2 @@
+export * from "./chat-input";
+export * from "./conversation";

--- a/packages/appkit-ui/src/react/chat/hooks/index.ts
+++ b/packages/appkit-ui/src/react/chat/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from "./use-chat";
+export * from "./use-scroll-to-bottom";

--- a/packages/appkit-ui/src/react/chat/hooks/use-chat.ts
+++ b/packages/appkit-ui/src/react/chat/hooks/use-chat.ts
@@ -1,0 +1,80 @@
+import { type UseChatHelpers, useChat as useAiChat } from "@ai-sdk/react";
+import type {
+  ChatOnDataCallback,
+  HttpChatTransportInitOptions,
+  UIMessage,
+  UIMessageChunk,
+} from "ai";
+import { useMemo, useRef, useState } from "react";
+import { ResponsesApiTransport } from "../lib/responses-api-transport";
+import { generateId } from "../lib/utils";
+
+export interface UseChatOptions<TMessage extends UIMessage = UIMessage> {
+  /** Chat endpoint URL (e.g. "/api/agents/chat"). */
+  api: string;
+  /** Stable chat id. Defaults to a fresh UUID per mount. */
+  id?: string;
+  /** Initial messages (e.g. when hydrating from history). */
+  messages?: TMessage[];
+  /** Extra fetch headers forwarded to the transport. */
+  headers?: HttpChatTransportInitOptions<TMessage>["headers"];
+  /** Fires for every `data-*` chunk (e.g. `data-approval-pending`). */
+  onData?: ChatOnDataCallback<TMessage>;
+  /** Fires synchronously for every chunk. Unaffected by render throttling. */
+  onStreamPart?: (chunk: UIMessageChunk) => void;
+  /** Called on stream errors. */
+  onError?: (error: Error) => void;
+}
+
+export type UseChatReturn<TMessage extends UIMessage = UIMessage> =
+  UseChatHelpers<TMessage> & { id: string };
+
+export function useChat<TMessage extends UIMessage = UIMessage>(
+  options: UseChatOptions<TMessage>,
+): UseChatReturn<TMessage> {
+  const { api, id: providedId, messages, onData, onError } = options;
+
+  const [id] = useState(() => providedId ?? generateId());
+  const initialMessagesRef = useRef<TMessage[]>(messages ?? []);
+
+  // Ref'd so the transport memo stays stable when consumers pass inline
+  // objects/callbacks. The transport reads them lazily on each request.
+  const onStreamPartRef = useRef(options.onStreamPart);
+  onStreamPartRef.current = options.onStreamPart;
+  const headersRef = useRef(options.headers);
+  headersRef.current = options.headers;
+
+  const threadIdRef = useRef<string | undefined>(undefined);
+
+  const transport = useMemo(
+    () =>
+      new ResponsesApiTransport<TMessage>({
+        api,
+        // Resolve the live ref each request so the transport memo stays
+        // stable even when consumers pass inline header objects/functions.
+        headers: async () => {
+          const h = headersRef.current;
+          if (typeof h === "function") return await h();
+          return h ?? {};
+        },
+        getThreadId: () => threadIdRef.current,
+        onThreadId: (tid) => {
+          threadIdRef.current = tid;
+        },
+        onStreamPart: (part) => onStreamPartRef.current?.(part),
+      }),
+    [api],
+  );
+
+  const chat = useAiChat<TMessage>({
+    id,
+    messages: initialMessagesRef.current,
+    experimental_throttle: 100,
+    generateId,
+    transport,
+    onData,
+    onError,
+  });
+
+  return { ...chat, id };
+}

--- a/packages/appkit-ui/src/react/chat/hooks/use-scroll-to-bottom.ts
+++ b/packages/appkit-ui/src/react/chat/hooks/use-scroll-to-bottom.ts
@@ -1,0 +1,62 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface UseScrollToBottomOptions {
+  /** Pixels from the bottom that still count as "at bottom". Default 50. */
+  threshold?: number;
+  /** Reactive value that triggers an auto-scroll when isAtBottom is true. */
+  trigger?: unknown;
+}
+
+export interface UseScrollToBottomReturn<T extends HTMLElement> {
+  containerRef: React.RefObject<T | null>;
+  isAtBottom: boolean;
+  scrollToBottom: (behavior?: ScrollBehavior) => void;
+}
+
+/**
+ * Sticks a scroll container to the bottom on `trigger` changes, unless
+ * the user has scrolled up.
+ */
+export function useScrollToBottom<T extends HTMLElement = HTMLDivElement>({
+  threshold = 50,
+  trigger,
+}: UseScrollToBottomOptions = {}): UseScrollToBottomReturn<T> {
+  const containerRef = useRef<T | null>(null);
+  const [isAtBottom, setIsAtBottom] = useState(true);
+
+  const handleScroll = useCallback(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    setIsAtBottom(el.scrollHeight - el.scrollTop - el.clientHeight < threshold);
+  }, [threshold]);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    el.addEventListener("scroll", handleScroll, { passive: true });
+    handleScroll();
+    return () => el.removeEventListener("scroll", handleScroll);
+  }, [handleScroll]);
+
+  useEffect(() => {
+    // `trigger` is referenced only to opt the effect into a re-run when
+    // its identity changes (e.g. on every new message during streaming).
+    void trigger;
+    if (isAtBottom && containerRef.current) {
+      // `instant` here so streaming re-renders don't queue smooth animations.
+      containerRef.current.scrollTo({
+        top: containerRef.current.scrollHeight,
+        behavior: "instant",
+      });
+    }
+  }, [trigger, isAtBottom]);
+
+  const scrollToBottom = useCallback((behavior: ScrollBehavior = "smooth") => {
+    containerRef.current?.scrollTo({
+      top: containerRef.current.scrollHeight,
+      behavior,
+    });
+  }, []);
+
+  return { containerRef, isAtBottom, scrollToBottom };
+}

--- a/packages/appkit-ui/src/react/chat/hooks/use-scroll-to-bottom.ts
+++ b/packages/appkit-ui/src/react/chat/hooks/use-scroll-to-bottom.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 export interface UseScrollToBottomOptions {
   /** Pixels from the bottom that still count as "at bottom". Default 50. */
@@ -8,7 +8,13 @@ export interface UseScrollToBottomOptions {
 }
 
 export interface UseScrollToBottomReturn<T extends HTMLElement> {
-  containerRef: React.RefObject<T | null>;
+  /**
+   * Ref callback. Attach with `ref={containerRef}` on the scroll
+   * container. Re-runs the listener-attach effect whenever the
+   * underlying DOM node changes — so containers that mount after the
+   * first render (e.g. behind a `loading` gate) still get the listener.
+   */
+  containerRef: (node: T | null) => void;
   isAtBottom: boolean;
   scrollToBottom: (behavior?: ScrollBehavior) => void;
 }
@@ -21,42 +27,49 @@ export function useScrollToBottom<T extends HTMLElement = HTMLDivElement>({
   threshold = 50,
   trigger,
 }: UseScrollToBottomOptions = {}): UseScrollToBottomReturn<T> {
-  const containerRef = useRef<T | null>(null);
+  // State-backed so changes to the underlying DOM node re-run the
+  // listener-attach effect (e.g. when the container mounts after the
+  // first render).
+  const [element, setElement] = useState<T | null>(null);
   const [isAtBottom, setIsAtBottom] = useState(true);
 
-  const handleScroll = useCallback(() => {
-    const el = containerRef.current;
-    if (!el) return;
-    setIsAtBottom(el.scrollHeight - el.scrollTop - el.clientHeight < threshold);
-  }, [threshold]);
+  const containerRef = useCallback((node: T | null) => {
+    setElement(node);
+  }, []);
 
   useEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
-    el.addEventListener("scroll", handleScroll, { passive: true });
+    if (!element) return;
+    const handleScroll = () => {
+      setIsAtBottom(
+        element.scrollHeight - element.scrollTop - element.clientHeight <
+          threshold,
+      );
+    };
+    element.addEventListener("scroll", handleScroll, { passive: true });
     handleScroll();
-    return () => el.removeEventListener("scroll", handleScroll);
-  }, [handleScroll]);
+    return () => element.removeEventListener("scroll", handleScroll);
+  }, [element, threshold]);
 
   useEffect(() => {
     // `trigger` is referenced only to opt the effect into a re-run when
     // its identity changes (e.g. on every new message during streaming).
     void trigger;
-    if (isAtBottom && containerRef.current) {
+    if (isAtBottom && element) {
       // `instant` here so streaming re-renders don't queue smooth animations.
-      containerRef.current.scrollTo({
-        top: containerRef.current.scrollHeight,
+      element.scrollTo({
+        top: element.scrollHeight,
         behavior: "instant",
       });
     }
-  }, [trigger, isAtBottom]);
+  }, [trigger, isAtBottom, element]);
 
-  const scrollToBottom = useCallback((behavior: ScrollBehavior = "smooth") => {
-    containerRef.current?.scrollTo({
-      top: containerRef.current.scrollHeight,
-      behavior,
-    });
-  }, []);
+  const scrollToBottom = useCallback(
+    (behavior: ScrollBehavior = "smooth") => {
+      if (!element) return;
+      element.scrollTo({ top: element.scrollHeight, behavior });
+    },
+    [element],
+  );
 
   return { containerRef, isAtBottom, scrollToBottom };
 }

--- a/packages/appkit-ui/src/react/chat/index.ts
+++ b/packages/appkit-ui/src/react/chat/index.ts
@@ -1,3 +1,4 @@
+export * from "./app";
 export * from "./headless";
 export * from "./hooks";
 export * from "./lib/responses-api-transport";

--- a/packages/appkit-ui/src/react/chat/index.ts
+++ b/packages/appkit-ui/src/react/chat/index.ts
@@ -1,0 +1,3 @@
+export * from "./headless";
+export * from "./hooks";
+export * from "./lib/responses-api-transport";

--- a/packages/appkit-ui/src/react/chat/lib/responses-api-transport.test.ts
+++ b/packages/appkit-ui/src/react/chat/lib/responses-api-transport.test.ts
@@ -566,4 +566,54 @@ describe("ResponsesApiTransport", () => {
     }
     expect(chunks.map((c) => c.type)).toEqual(["start", "finish"]);
   });
+
+  test("parses CRLF-encoded SSE frames (proxy normalization)", async () => {
+    const encoder = new TextEncoder();
+    const body =
+      `id: 1\r\nevent: response.output_item.added\r\ndata: ${JSON.stringify({
+        type: "response.output_item.added",
+        output_index: 0,
+        item: messageItem("msg_a"),
+        sequence_number: 0,
+      })}\r\n\r\n` +
+      `id: 2\r\nevent: response.output_text.delta\r\ndata: ${JSON.stringify({
+        type: "response.output_text.delta",
+        item_id: "msg_a",
+        output_index: 0,
+        content_index: 0,
+        delta: "hi",
+        sequence_number: 1,
+      })}\r\n\r\n` +
+      `id: 3\r\nevent: response.completed\r\ndata: ${JSON.stringify({
+        type: "response.completed",
+        sequence_number: 2,
+        response: {},
+      })}\r\n\r\n`;
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode(body));
+        controller.close();
+      },
+    });
+    const transport = new TestableTransport<UIMessage>({ api: "/test" });
+    const out = transport.process(stream);
+    const reader = out.getReader();
+    const chunks: UIMessageChunk[] = [];
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+    }
+    expect(chunks.map((c) => c.type)).toEqual([
+      "start",
+      "text-start",
+      "text-delta",
+      "finish",
+    ]);
+    expect(chunks).toContainEqual({
+      type: "text-delta",
+      id: "msg_a",
+      delta: "hi",
+    });
+  });
 });

--- a/packages/appkit-ui/src/react/chat/lib/responses-api-transport.test.ts
+++ b/packages/appkit-ui/src/react/chat/lib/responses-api-transport.test.ts
@@ -1,0 +1,569 @@
+import type { UIMessage, UIMessageChunk } from "ai";
+import type { ResponseStreamEvent } from "shared";
+import { describe, expect, test } from "vitest";
+import { ResponsesApiTransport } from "./responses-api-transport";
+
+// Exposes the protected `processResponseStream` for direct testing.
+class TestableTransport<T extends UIMessage> extends ResponsesApiTransport<T> {
+  public process(
+    stream: ReadableStream<Uint8Array>,
+  ): ReadableStream<UIMessageChunk> {
+    return this.processResponseStream(stream);
+  }
+}
+
+function encodeSseStream(
+  events: ResponseStreamEvent[],
+): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  const body = events
+    .map((e, i) => `id: ${i}\nevent: ${e.type}\ndata: ${JSON.stringify(e)}\n\n`)
+    .join("");
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(body));
+      controller.close();
+    },
+  });
+}
+
+async function translate(
+  events: ResponseStreamEvent[],
+  onStreamPart?: (chunk: UIMessageChunk) => void,
+): Promise<UIMessageChunk[]> {
+  const transport = new TestableTransport<UIMessage>({
+    api: "/test",
+    onStreamPart,
+  });
+  const out = transport.process(encodeSseStream(events));
+  const reader = out.getReader();
+  const chunks: UIMessageChunk[] = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+  return chunks;
+}
+
+// Replaces random ids with deterministic placeholders for easier assertions.
+// Server-allocated ids are preserved.
+function normalize(chunks: UIMessageChunk[]): UIMessageChunk[] {
+  let reasoningCounter = 0;
+  const reasoningMap = new Map<string, string>();
+  const slot = (id: string): string => {
+    if (!reasoningMap.has(id)) {
+      reasoningCounter++;
+      reasoningMap.set(id, `reasoning_${reasoningCounter}`);
+    }
+    return reasoningMap.get(id) as string;
+  };
+  return chunks.map((c) => {
+    if (c.type === "start") {
+      return { ...c, messageId: c.messageId ? "msg_start" : c.messageId };
+    }
+    if (
+      c.type === "reasoning-start" ||
+      c.type === "reasoning-delta" ||
+      c.type === "reasoning-end"
+    ) {
+      return { ...c, id: slot(c.id) };
+    }
+    return c;
+  });
+}
+
+const SEQ = (() => {
+  let n = 0;
+  return () => n++;
+})();
+
+const messageItem = (id: string) => ({
+  type: "message" as const,
+  id,
+  status: "in_progress" as const,
+  role: "assistant" as const,
+  content: [],
+});
+
+const messageItemDone = (id: string, text: string) => ({
+  type: "message" as const,
+  id,
+  status: "completed" as const,
+  role: "assistant" as const,
+  content: [{ type: "output_text" as const, text }],
+});
+
+describe("ResponsesApiTransport", () => {
+  test("emits exactly one start chunk on the first event", async () => {
+    const out = await translate([
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: messageItem("msg_a"),
+        sequence_number: SEQ(),
+      },
+      {
+        type: "response.output_text.delta",
+        item_id: "msg_a",
+        output_index: 0,
+        content_index: 0,
+        delta: "hello",
+        sequence_number: SEQ(),
+      },
+      {
+        type: "response.output_text.delta",
+        item_id: "msg_a",
+        output_index: 0,
+        content_index: 0,
+        delta: " world",
+        sequence_number: SEQ(),
+      },
+      {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: messageItemDone("msg_a", "hello world"),
+        sequence_number: SEQ(),
+      },
+      { type: "response.completed", sequence_number: SEQ(), response: {} },
+    ]);
+    const startChunks = out.filter((c) => c.type === "start");
+    expect(startChunks).toHaveLength(1);
+    expect(startChunks[0]).toMatchObject({ type: "start" });
+    expect((startChunks[0] as { messageId?: string }).messageId).toMatch(
+      /^msg_/,
+    );
+  });
+
+  test("text spans mirror server message item ids 1:1", async () => {
+    const out = normalize(
+      await translate([
+        {
+          type: "response.output_item.added",
+          output_index: 0,
+          item: messageItem("msg_a"),
+          sequence_number: SEQ(),
+        },
+        {
+          type: "response.output_text.delta",
+          item_id: "msg_a",
+          output_index: 0,
+          content_index: 0,
+          delta: "he",
+          sequence_number: SEQ(),
+        },
+        {
+          type: "response.output_text.delta",
+          item_id: "msg_a",
+          output_index: 0,
+          content_index: 0,
+          delta: "llo",
+          sequence_number: SEQ(),
+        },
+        {
+          type: "response.output_item.done",
+          output_index: 0,
+          item: messageItemDone("msg_a", "hello"),
+          sequence_number: SEQ(),
+        },
+        { type: "response.completed", sequence_number: SEQ(), response: {} },
+      ]),
+    );
+
+    expect(out).toEqual([
+      { type: "start", messageId: "msg_start" },
+      { type: "text-start", id: "msg_a" },
+      { type: "text-delta", id: "msg_a", delta: "he" },
+      { type: "text-delta", id: "msg_a", delta: "llo" },
+      { type: "text-end", id: "msg_a" },
+      { type: "finish" },
+    ]);
+  });
+
+  test("interleaved text → tool → text uses fresh message ids per text run", async () => {
+    const out = normalize(
+      await translate([
+        {
+          type: "response.output_item.added",
+          output_index: 0,
+          item: messageItem("msg_1"),
+          sequence_number: SEQ(),
+        },
+        {
+          type: "response.output_text.delta",
+          item_id: "msg_1",
+          output_index: 0,
+          content_index: 0,
+          delta: "thinking...",
+          sequence_number: SEQ(),
+        },
+        {
+          type: "response.output_item.done",
+          output_index: 0,
+          item: messageItemDone("msg_1", "thinking..."),
+          sequence_number: SEQ(),
+        },
+        {
+          type: "response.output_item.added",
+          output_index: 1,
+          item: {
+            type: "function_call",
+            id: "fc_1",
+            call_id: "call_1",
+            name: "search",
+            arguments: '{"q":"x"}',
+          },
+          sequence_number: SEQ(),
+        },
+        {
+          type: "response.output_item.done",
+          output_index: 1,
+          item: {
+            type: "function_call",
+            id: "fc_1",
+            call_id: "call_1",
+            name: "search",
+            arguments: '{"q":"x"}',
+          },
+          sequence_number: SEQ(),
+        },
+        {
+          type: "response.output_item.added",
+          output_index: 2,
+          item: {
+            type: "function_call_output",
+            id: "fc_out_1",
+            call_id: "call_1",
+            output: '{"hits":3}',
+          },
+          sequence_number: SEQ(),
+        },
+        {
+          type: "response.output_item.done",
+          output_index: 2,
+          item: {
+            type: "function_call_output",
+            id: "fc_out_1",
+            call_id: "call_1",
+            output: '{"hits":3}',
+          },
+          sequence_number: SEQ(),
+        },
+        {
+          type: "response.output_item.added",
+          output_index: 3,
+          item: messageItem("msg_2"),
+          sequence_number: SEQ(),
+        },
+        {
+          type: "response.output_text.delta",
+          item_id: "msg_2",
+          output_index: 3,
+          content_index: 0,
+          delta: "done",
+          sequence_number: SEQ(),
+        },
+        {
+          type: "response.output_item.done",
+          output_index: 3,
+          item: messageItemDone("msg_2", "done"),
+          sequence_number: SEQ(),
+        },
+        { type: "response.completed", sequence_number: SEQ(), response: {} },
+      ]),
+    );
+
+    expect(out).toEqual([
+      { type: "start", messageId: "msg_start" },
+      { type: "text-start", id: "msg_1" },
+      { type: "text-delta", id: "msg_1", delta: "thinking..." },
+      { type: "text-end", id: "msg_1" },
+      {
+        type: "tool-input-available",
+        toolCallId: "call_1",
+        toolName: "search",
+        input: { q: "x" },
+      },
+      {
+        type: "tool-output-available",
+        toolCallId: "call_1",
+        output: '{"hits":3}',
+      },
+      { type: "text-start", id: "msg_2" },
+      { type: "text-delta", id: "msg_2", delta: "done" },
+      { type: "text-end", id: "msg_2" },
+      { type: "finish" },
+    ]);
+  });
+
+  test("tool-input-available falls back to raw arguments when JSON.parse fails", async () => {
+    const out = await translate([
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: {
+          type: "function_call",
+          id: "fc_1",
+          call_id: "call_1",
+          name: "search",
+          arguments: "not-json",
+        },
+        sequence_number: SEQ(),
+      },
+      { type: "response.completed", sequence_number: SEQ(), response: {} },
+    ]);
+    expect(out).toContainEqual({
+      type: "tool-input-available",
+      toolCallId: "call_1",
+      toolName: "search",
+      input: "not-json",
+    });
+  });
+
+  test("approval_pending becomes a data-approval-pending part keyed by approvalId without closing open spans", async () => {
+    const out = await translate([
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: messageItem("msg_a"),
+        sequence_number: SEQ(),
+      },
+      {
+        type: "response.output_text.delta",
+        item_id: "msg_a",
+        output_index: 0,
+        content_index: 0,
+        delta: "pre",
+        sequence_number: SEQ(),
+      },
+      {
+        type: "appkit.approval_pending",
+        approval_id: "appr_1",
+        stream_id: "stream_1",
+        tool_name: "delete_view",
+        args: { id: 42 },
+        annotations: { effect: "destructive" },
+        sequence_number: SEQ(),
+      },
+    ]);
+    const dataPart = out.find((c) => c.type === "data-approval-pending") as
+      | { id?: string; data?: unknown; type: string }
+      | undefined;
+    expect(dataPart).toBeDefined();
+    expect(dataPart?.id).toBe("appr_1");
+    expect(dataPart?.data).toEqual({
+      approvalId: "appr_1",
+      streamId: "stream_1",
+      toolName: "delete_view",
+      args: { id: 42 },
+      annotations: { effect: "destructive" },
+    });
+    // Open text span must stay open while approval is pending.
+    const textEndBeforeApproval = out
+      .slice(
+        0,
+        out.findIndex((c) => c.type === "data-approval-pending"),
+      )
+      .some((c) => c.type === "text-end");
+    expect(textEndBeforeApproval).toBe(false);
+  });
+
+  test("appkit.thinking opens a reasoning span and closes it before any non-thinking event", async () => {
+    const out = normalize(
+      await translate([
+        {
+          type: "appkit.thinking",
+          content: "let me see...",
+          sequence_number: SEQ(),
+        },
+        {
+          type: "response.output_item.added",
+          output_index: 0,
+          item: messageItem("msg_a"),
+          sequence_number: SEQ(),
+        },
+        {
+          type: "response.output_text.delta",
+          item_id: "msg_a",
+          output_index: 0,
+          content_index: 0,
+          delta: "result",
+          sequence_number: SEQ(),
+        },
+        {
+          type: "response.output_item.done",
+          output_index: 0,
+          item: messageItemDone("msg_a", "result"),
+          sequence_number: SEQ(),
+        },
+        { type: "response.completed", sequence_number: SEQ(), response: {} },
+      ]),
+    );
+
+    expect(out).toEqual([
+      { type: "start", messageId: "msg_start" },
+      { type: "reasoning-start", id: "reasoning_1" },
+      {
+        type: "reasoning-delta",
+        id: "reasoning_1",
+        delta: "let me see...",
+      },
+      { type: "reasoning-end", id: "reasoning_1" },
+      { type: "text-start", id: "msg_a" },
+      { type: "text-delta", id: "msg_a", delta: "result" },
+      { type: "text-end", id: "msg_a" },
+      { type: "finish" },
+    ]);
+  });
+
+  test("appkit.metadata becomes a message-metadata chunk", async () => {
+    const out = await translate([
+      {
+        type: "appkit.metadata",
+        data: { threadId: "thread_42" },
+        sequence_number: SEQ(),
+      },
+      { type: "response.completed", sequence_number: SEQ(), response: {} },
+    ]);
+    expect(out).toContainEqual({
+      type: "message-metadata",
+      messageMetadata: { threadId: "thread_42" },
+    });
+  });
+
+  test("error event closes spans, emits error + finish (idempotent)", async () => {
+    const out = normalize(
+      await translate([
+        {
+          type: "response.output_item.added",
+          output_index: 0,
+          item: messageItem("msg_a"),
+          sequence_number: SEQ(),
+        },
+        {
+          type: "response.output_text.delta",
+          item_id: "msg_a",
+          output_index: 0,
+          content_index: 0,
+          delta: "halfway",
+          sequence_number: SEQ(),
+        },
+        {
+          type: "appkit.thinking",
+          content: "wait",
+          sequence_number: SEQ(),
+        },
+        { type: "error", error: "boom", sequence_number: SEQ() },
+        // A stray response.failed after error must not duplicate finish.
+        { type: "response.failed", sequence_number: SEQ() },
+      ]),
+    );
+    expect(out.filter((c) => c.type === "finish")).toHaveLength(1);
+    expect(out).toContainEqual({ type: "error", errorText: "boom" });
+    expect(out.filter((c) => c.type === "reasoning-end")).toHaveLength(1);
+  });
+
+  test("synthesises a finish chunk when the stream ends without a terminator", async () => {
+    const out = await translate([
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: messageItem("msg_a"),
+        sequence_number: SEQ(),
+      },
+      {
+        type: "response.output_text.delta",
+        item_id: "msg_a",
+        output_index: 0,
+        content_index: 0,
+        delta: "incomplete",
+        sequence_number: SEQ(),
+      },
+      // No terminator: stream ends mid-message.
+    ]);
+    expect(out[out.length - 1]).toEqual({ type: "finish" });
+  });
+
+  test("onStreamPart tap fires for every emitted chunk", async () => {
+    const tapped: UIMessageChunk[] = [];
+    const events: ResponseStreamEvent[] = [
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: messageItem("msg_a"),
+        sequence_number: SEQ(),
+      },
+      {
+        type: "response.output_text.delta",
+        item_id: "msg_a",
+        output_index: 0,
+        content_index: 0,
+        delta: "hi",
+        sequence_number: SEQ(),
+      },
+      { type: "response.completed", sequence_number: SEQ(), response: {} },
+    ];
+    const out = await translate(events, (chunk) => {
+      tapped.push(chunk);
+    });
+    expect(tapped).toEqual(out);
+  });
+
+  test("routes SSEWriter-style error events (no `type` field, only event header) into an error chunk", async () => {
+    // SSEWriter.writeError emits `event: error` + `{ error, code }` body
+    // without a `type` field.
+    const encoder = new TextEncoder();
+    const body = `id: 1\nevent: error\ndata: ${JSON.stringify({
+      error: "stream evicted",
+      code: "STREAM_EVICTED",
+    })}\n\n`;
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode(body));
+        controller.close();
+      },
+    });
+    const transport = new TestableTransport<UIMessage>({ api: "/test" });
+    const out = transport.process(stream);
+    const reader = out.getReader();
+    const chunks: UIMessageChunk[] = [];
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+    }
+    expect(chunks.map((c) => c.type)).toEqual(["start", "error", "finish"]);
+    expect(chunks).toContainEqual({
+      type: "error",
+      errorText: "stream evicted",
+    });
+  });
+
+  test("ignores SSE comment lines (heartbeats) and unknown event types", async () => {
+    const encoder = new TextEncoder();
+    const body =
+      `: heartbeat\n\n` +
+      `id: 1\nevent: response.completed\ndata: ${JSON.stringify({
+        type: "response.completed",
+        sequence_number: 0,
+        response: {},
+      })}\n\n` +
+      `: heartbeat\n\n`;
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode(body));
+        controller.close();
+      },
+    });
+    const transport = new TestableTransport<UIMessage>({ api: "/test" });
+    const out = transport.process(stream);
+    const reader = out.getReader();
+    const chunks: UIMessageChunk[] = [];
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+    }
+    expect(chunks.map((c) => c.type)).toEqual(["start", "finish"]);
+  });
+});

--- a/packages/appkit-ui/src/react/chat/lib/responses-api-transport.ts
+++ b/packages/appkit-ui/src/react/chat/lib/responses-api-transport.ts
@@ -1,0 +1,312 @@
+import {
+  DefaultChatTransport,
+  type HttpChatTransportInitOptions,
+  type UIMessage,
+  type UIMessageChunk,
+} from "ai";
+import type {
+  ResponseFunctionCallOutput,
+  ResponseFunctionToolCall,
+  ResponseOutputMessage,
+  ResponseStreamEvent,
+} from "shared";
+import { generateId } from "./utils";
+
+/**
+ * `useChat`-compatible transport for AppKit's agents plugin. Translates
+ * the Responses-API SSE wire format into the Vercel AI SDK's
+ * `UIMessageChunk` protocol, and shapes outgoing requests as
+ * `{ message, threadId, ... }`.
+ */
+export interface ResponsesApiTransportOptions<T extends UIMessage>
+  extends Omit<HttpChatTransportInitOptions<T>, "prepareSendMessagesRequest"> {
+  /** Fires synchronously for every translated chunk; unaffected by render throttling. */
+  onStreamPart?: (chunk: UIMessageChunk) => void;
+  /** Returns the server-allocated thread id to echo on subsequent requests. */
+  getThreadId?: () => string | undefined;
+  /** Persists the thread id snooped from the first `appkit.metadata` event. */
+  onThreadId?: (id: string) => void;
+}
+
+/** Reserved body keys the transport derives itself; consumer overrides ignored. */
+const RESERVED_BODY_KEYS = new Set(["message", "threadId"]);
+
+export class ResponsesApiTransport<
+  T extends UIMessage,
+> extends DefaultChatTransport<T> {
+  private onStreamPartTap: ((chunk: UIMessageChunk) => void) | undefined;
+  private onThreadId: ((id: string) => void) | undefined;
+
+  constructor(options: ResponsesApiTransportOptions<T>) {
+    const { onStreamPart, getThreadId, onThreadId, ...rest } = options;
+    super({
+      ...rest,
+      prepareSendMessagesRequest: ({ messages, body }) => {
+        const consumer = (body ?? {}) as Record<string, unknown>;
+        const consumerExtras: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(consumer)) {
+          if (!RESERVED_BODY_KEYS.has(key)) consumerExtras[key] = value;
+        }
+        const threadId = getThreadId?.();
+        return {
+          body: {
+            message: extractLastUserText(messages),
+            ...(threadId !== undefined && { threadId }),
+            ...consumerExtras,
+          },
+        };
+      },
+    });
+    this.onStreamPartTap = onStreamPart;
+    this.onThreadId = onThreadId;
+  }
+
+  protected processResponseStream(
+    stream: ReadableStream<Uint8Array<ArrayBufferLike>>,
+  ): ReadableStream<UIMessageChunk> {
+    // Cast: `TextDecoderStream` is typed as `BufferSource`; Uint8Array satisfies it at runtime.
+    return (stream as unknown as ReadableStream<BufferSource>)
+      .pipeThrough(new TextDecoderStream())
+      .pipeThrough(sseEventLineParser())
+      .pipeThrough(this.captureThreadIdTap())
+      .pipeThrough(responsesApiToUiChunks(this.onStreamPartTap));
+  }
+
+  /** Forwards the thread id from `appkit.metadata` events to `onThreadId`. */
+  private captureThreadIdTap(): TransformStream<
+    ResponseStreamEvent,
+    ResponseStreamEvent
+  > {
+    const onThreadId = this.onThreadId;
+    return new TransformStream({
+      transform(event, controller) {
+        if (event.type === "appkit.metadata") {
+          const tid = (event.data as { threadId?: unknown } | undefined)
+            ?.threadId;
+          if (typeof tid === "string" && tid.length > 0) {
+            onThreadId?.(tid);
+          }
+        }
+        controller.enqueue(event);
+      },
+    });
+  }
+}
+
+function extractLastUserText<T extends UIMessage>(messages: T[]): string {
+  const last = messages[messages.length - 1];
+  if (!last || last.role !== "user") return "";
+  let text = "";
+  let droppedNonText = false;
+  for (const part of last.parts as Array<{ type: string; text?: unknown }>) {
+    if (part.type === "text" && typeof part.text === "string") {
+      text += part.text;
+    } else {
+      droppedNonText = true;
+    }
+  }
+  if (droppedNonText) {
+    // Agents plugin only accepts plain text; subclass to carry attachments.
+    console.warn(
+      "[ResponsesApiTransport] Dropping non-text parts from user message — agents plugin only accepts plain text.",
+    );
+  }
+  return text;
+}
+
+/**
+ * Splits an SSE text stream into `ResponseStreamEvent`s. Falls back to
+ * the `event:` header when the JSON body lacks a `type` field (e.g.
+ * `SSEWriter.writeError` payloads).
+ */
+function sseEventLineParser(): TransformStream<string, ResponseStreamEvent> {
+  let buffer = "";
+  return new TransformStream({
+    transform(chunk, controller) {
+      buffer += chunk;
+      let separatorIdx: number;
+      // biome-ignore lint/suspicious/noAssignInExpressions: standard SSE buffer drain pattern
+      while ((separatorIdx = buffer.indexOf("\n\n")) !== -1) {
+        const message = buffer.slice(0, separatorIdx);
+        buffer = buffer.slice(separatorIdx + 2);
+        let eventName: string | undefined;
+        const dataLines: string[] = [];
+        for (const line of message.split("\n")) {
+          if (line.length === 0 || line.startsWith(":")) continue;
+          if (line.startsWith("event:")) {
+            eventName = line.slice(6).replace(/^ /, "");
+          } else if (line.startsWith("data:")) {
+            dataLines.push(line.slice(5).replace(/^ /, ""));
+          }
+        }
+        if (dataLines.length === 0) continue;
+        const data = dataLines.join("\n");
+        let parsed: Record<string, unknown>;
+        try {
+          parsed = JSON.parse(data) as Record<string, unknown>;
+        } catch {
+          continue;
+        }
+        if (typeof parsed.type !== "string" && eventName) {
+          parsed.type = eventName;
+        }
+        controller.enqueue(parsed as unknown as ResponseStreamEvent);
+      }
+    },
+  });
+}
+
+/**
+ * Stateful translator: `ResponseStreamEvent` → `UIMessageChunk`.
+ *
+ * Text spans mirror server message item ids 1:1. `appkit.thinking` has
+ * no wrapping events, so the reasoning span is opened lazily and closed
+ * on the next non-thinking event. `appkit.approval_pending` rides as a
+ * `data-*` chunk and does not close any open spans (the agent loop may
+ * resume the same span after the user decides).
+ */
+function responsesApiToUiChunks(
+  tap: ((chunk: UIMessageChunk) => void) | undefined,
+): TransformStream<ResponseStreamEvent, UIMessageChunk> {
+  let startEmitted = false;
+  let currentReasoningId: string | null = null;
+  let finalized = false;
+
+  function emit(
+    controller: TransformStreamDefaultController<UIMessageChunk>,
+    chunk: UIMessageChunk,
+  ): void {
+    tap?.(chunk);
+    controller.enqueue(chunk);
+  }
+
+  function emitStart(
+    controller: TransformStreamDefaultController<UIMessageChunk>,
+  ): void {
+    if (startEmitted) return;
+    startEmitted = true;
+    emit(controller, { type: "start", messageId: `msg_${generateId()}` });
+  }
+
+  function closeReasoning(
+    controller: TransformStreamDefaultController<UIMessageChunk>,
+  ): void {
+    if (!currentReasoningId) return;
+    emit(controller, { type: "reasoning-end", id: currentReasoningId });
+    currentReasoningId = null;
+  }
+
+  function finish(
+    controller: TransformStreamDefaultController<UIMessageChunk>,
+  ): void {
+    if (finalized) return;
+    finalized = true;
+    closeReasoning(controller);
+    emit(controller, { type: "finish" });
+  }
+
+  return new TransformStream({
+    transform(event, controller) {
+      emitStart(controller);
+      switch (event.type) {
+        case "response.output_item.added": {
+          const item = event.item;
+          closeReasoning(controller);
+          if (item.type === "message") {
+            const msg = item as ResponseOutputMessage;
+            emit(controller, { type: "text-start", id: msg.id });
+          } else if (item.type === "function_call") {
+            const fc = item as ResponseFunctionToolCall;
+            let input: unknown;
+            try {
+              input = JSON.parse(fc.arguments);
+            } catch {
+              input = fc.arguments;
+            }
+            emit(controller, {
+              type: "tool-input-available",
+              toolCallId: fc.call_id,
+              toolName: fc.name,
+              input,
+            });
+          } else if (item.type === "function_call_output") {
+            const fco = item as ResponseFunctionCallOutput;
+            emit(controller, {
+              type: "tool-output-available",
+              toolCallId: fco.call_id,
+              output: fco.output,
+            });
+          }
+          return;
+        }
+        case "response.output_item.done": {
+          const item = event.item;
+          if (item.type === "message") {
+            emit(controller, { type: "text-end", id: item.id });
+          }
+          // function_call / function_call_output `done` events have no
+          // client counterpart; they're already emitted on `added`.
+          return;
+        }
+        case "response.output_text.delta":
+          emit(controller, {
+            type: "text-delta",
+            id: event.item_id,
+            delta: event.delta,
+          });
+          return;
+        case "appkit.thinking":
+          if (!currentReasoningId) {
+            currentReasoningId = `reasoning_${generateId()}`;
+            emit(controller, {
+              type: "reasoning-start",
+              id: currentReasoningId,
+            });
+          }
+          emit(controller, {
+            type: "reasoning-delta",
+            id: currentReasoningId,
+            delta: event.content,
+          });
+          return;
+        case "appkit.metadata":
+          closeReasoning(controller);
+          emit(controller, {
+            type: "message-metadata",
+            messageMetadata: event.data,
+          });
+          return;
+        case "appkit.approval_pending":
+          emit(controller, {
+            type: "data-approval-pending",
+            id: event.approval_id,
+            data: {
+              approvalId: event.approval_id,
+              streamId: event.stream_id,
+              toolName: event.tool_name,
+              args: event.args,
+              annotations: event.annotations,
+            },
+          } as UIMessageChunk);
+          return;
+        case "error":
+          if (finalized) return;
+          closeReasoning(controller);
+          emit(controller, { type: "error", errorText: event.error });
+          finalized = true;
+          emit(controller, { type: "finish" });
+          return;
+        case "response.failed":
+          finish(controller);
+          return;
+        case "response.completed":
+          finish(controller);
+          return;
+      }
+    },
+    flush(controller) {
+      // Ensure the SDK leaves the streaming state if the terminal event was lost.
+      finish(controller);
+    },
+  });
+}

--- a/packages/appkit-ui/src/react/chat/lib/responses-api-transport.ts
+++ b/packages/appkit-ui/src/react/chat/lib/responses-api-transport.ts
@@ -123,7 +123,9 @@ function sseEventLineParser(): TransformStream<string, ResponseStreamEvent> {
   let buffer = "";
   return new TransformStream({
     transform(chunk, controller) {
-      buffer += chunk;
+      // Normalize CRLF → LF so the `\n\n` boundary split works behind
+      // intermediaries that re-emit SSE frames with CRLF line endings.
+      buffer += chunk.replace(/\r\n/g, "\n");
       let separatorIdx: number;
       // biome-ignore lint/suspicious/noAssignInExpressions: standard SSE buffer drain pattern
       while ((separatorIdx = buffer.indexOf("\n\n")) !== -1) {

--- a/packages/appkit-ui/src/react/chat/lib/utils.ts
+++ b/packages/appkit-ui/src/react/chat/lib/utils.ts
@@ -1,0 +1,14 @@
+// UUID v4, with a `Math.random` fallback for runtimes without `crypto.randomUUID`.
+export function generateId(): string {
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.randomUUID === "function"
+  ) {
+    return crypto.randomUUID();
+  }
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === "x" ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}

--- a/packages/appkit-ui/src/react/styles/chat-theme.css
+++ b/packages/appkit-ui/src/react/styles/chat-theme.css
@@ -1,0 +1,294 @@
+/*
+ * Chat-scoped theme tokens.
+ *
+ * Mirrors the palette + semantic tokens from Databricks design system 
+ * so that `<ChatApp>` (and its slot overrides) render with the branded
+ * look without leaking those overrides into the rest of the host app.
+ *
+ * The boundary is the element carrying `data-appkit-chat`; child
+ * Tailwind utilities like `bg-primary`, `bg-action-primary-background-hover`,
+ * and `border-neutral-300` resolve against the variables defined here.
+ */
+
+/*
+ * Register the action-* color tokens as Tailwind theme entries so
+ * utilities like `bg-action-primary-background-hover` exist globally.
+ * Outside the chat boundary they resolve to neutral fallbacks.
+ */
+@theme inline {
+  --color-action-default-background-hover: var(
+    --action-default-background-hover
+  );
+  --color-action-default-background-press: var(
+    --action-default-background-press
+  );
+  --color-action-primary-background-hover: var(
+    --action-primary-background-hover
+  );
+  --color-action-primary-background-press: var(
+    --action-primary-background-press
+  );
+  --color-action-tertiary-background-hover: var(
+    --action-tertiary-background-hover
+  );
+  --color-action-tertiary-background-press: var(
+    --action-tertiary-background-press
+  );
+  --color-action-danger-primary-background-hover: var(
+    --action-danger-primary-background-hover
+  );
+  --color-action-danger-primary-background-press: var(
+    --action-danger-primary-background-press
+  );
+}
+
+:root {
+  --action-default-background-hover: color-mix(
+    in oklch,
+    var(--accent) 50%,
+    transparent
+  );
+  --action-default-background-press: color-mix(
+    in oklch,
+    var(--accent) 100%,
+    transparent
+  );
+  --action-primary-background-hover: color-mix(
+    in oklch,
+    var(--primary) 90%,
+    black
+  );
+  --action-primary-background-press: color-mix(
+    in oklch,
+    var(--primary) 80%,
+    black
+  );
+  --action-tertiary-background-hover: color-mix(
+    in oklch,
+    var(--primary) 8%,
+    transparent
+  );
+  --action-tertiary-background-press: color-mix(
+    in oklch,
+    var(--primary) 16%,
+    transparent
+  );
+  --action-danger-primary-background-hover: color-mix(
+    in oklch,
+    var(--destructive) 90%,
+    black
+  );
+  --action-danger-primary-background-press: color-mix(
+    in oklch,
+    var(--destructive) 80%,
+    black
+  );
+}
+
+[data-appkit-chat] {
+  /* DuBois palette */
+  --color-blue-300: #bae1fc;
+  --color-blue-400: #4ba3d6;
+  --color-blue-500: #2e86c1;
+  --color-blue-600: #2272b4;
+  --color-blue-700: #0e538b;
+  --color-blue-800: #04355d;
+
+  --color-grey-050: #f6f7f9;
+  --color-grey-100: #e8ecf0;
+  --color-grey-200: #d1dce5;
+  --color-grey-300: #bdcdd9;
+  --color-grey-400: #8d9fad;
+  --color-grey-500: #5f7281;
+  --color-grey-600: #44535f;
+  --color-grey-700: #1f272d;
+  --color-grey-800: #11171c;
+
+  --color-neutral-050: #f7f7f7;
+  --color-neutral-100: #ebebeb;
+  --color-neutral-200: #d8d8d8;
+  --color-neutral-300: #cbcbcb;
+  --color-neutral-350: #a2a2a2;
+  --color-neutral-400: #939393;
+  --color-neutral-500: #6f6f6f;
+  --color-neutral-600: #525252;
+  --color-neutral-650: #424242;
+  --color-neutral-700: #262626;
+  --color-neutral-800: #161616;
+
+  --color-red-300: #fbd0d8;
+  --color-red-400: #f06e87;
+  --color-red-500: #e83a5f;
+  --color-red-600: #c82d4c;
+  --color-red-700: #9e1d38;
+  --color-red-800: #630316;
+
+  --color-green-400: #59c47a;
+  --color-green-500: #3ca45e;
+  --color-green-600: #277c43;
+  --color-green-700: #1a5c30;
+
+  --color-yellow-500: #dc6222;
+  --color-yellow-600: #be501e;
+  --color-yellow-700: #8f3c14;
+
+  /* Core surfaces */
+  --background: #ffffff;
+  --foreground: var(--color-grey-800);
+  --card: #ffffff;
+  --card-foreground: var(--color-grey-800);
+  --popover: #ffffff;
+  --popover-foreground: var(--color-grey-800);
+
+  /* Primary action */
+  --primary: var(--color-blue-600);
+  --primary-foreground: #ffffff;
+
+  /* Secondary surface */
+  --secondary: var(--color-grey-050);
+  --secondary-foreground: var(--color-grey-800);
+
+  --muted: var(--color-grey-050);
+  --muted-foreground: var(--color-neutral-600);
+
+  --accent: var(--color-grey-050);
+  --accent-foreground: var(--color-grey-800);
+
+  --destructive: var(--color-red-600);
+  --destructive-foreground: #ffffff;
+
+  --warning: var(--color-yellow-600);
+  --success: var(--color-green-600);
+
+  --border: var(--color-grey-100);
+  --input: var(--color-grey-100);
+  --ring: #2272b4;
+
+  /* Action token overrides */
+  --action-default-background-hover: rgba(34, 114, 180, 0.08);
+  --action-default-background-press: rgba(34, 114, 180, 0.16);
+  --action-primary-background-hover: var(--color-blue-700);
+  --action-primary-background-press: var(--color-blue-800);
+  --action-tertiary-background-hover: rgba(34, 114, 180, 0.08);
+  --action-tertiary-background-press: rgba(34, 114, 180, 0.16);
+  --action-danger-primary-background-hover: var(--color-red-700);
+  --action-danger-primary-background-press: var(--color-red-800);
+
+  /* Alert / validation tinted borders and backgrounds */
+  --border-danger: #fbd0d8;
+  --border-warning: #f8d4a5;
+  --border-success: #a3d9b6;
+  --background-danger: #fff5f7;
+  --background-warning: #fff9eb;
+  --background-success: #f0faf4;
+
+  /*
+   * Status-badge tint pairs derived from semantic tokens. Lets host
+   * apps rebrand `--primary`/`--success`/`--warning`/`--destructive`
+   * and have tool-call badges follow without further overrides.
+   */
+  --badge-info-bg: color-mix(in oklch, var(--primary) 12%, transparent);
+  --badge-info-fg: var(--primary);
+  --badge-success-bg: color-mix(in oklch, var(--success) 14%, transparent);
+  --badge-success-fg: var(--color-green-700);
+  --badge-error-bg: color-mix(in oklch, var(--destructive) 12%, transparent);
+  --badge-error-fg: var(--destructive);
+  --badge-warning-bg: color-mix(in oklch, var(--warning) 16%, transparent);
+  --badge-warning-fg: var(--color-yellow-700);
+
+  /*
+   * Border radius (DuBois is tighter than Tailwind defaults).
+   * Tailwind v4 emits `.rounded-lg { border-radius: var(--radius-lg); }`
+   * so overriding the variables here scopes the change.
+   */
+  --radius: 0.25rem;
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+
+  /*
+   * Font sizes (DuBois 11/12/13/18/22/32 ladder).
+   * Tailwind v4 emits `.text-base { font-size: var(--text-base); ... }`
+   * so overriding these CSS variables retunes the utilities in scope.
+   */
+  --text-xs: 0.6875rem; /* 11px */
+  --text-sm: 0.75rem; /* 12px */
+  --text-base: 0.8125rem; /* 13px — DuBois base */
+  --text-base--line-height: 20px;
+  --text-lg: 1.125rem; /* 18px */
+  --text-xl: 1.375rem; /* 22px */
+  --text-2xl: 2rem; /* 32px */
+
+  /*
+   * Font stacks. Overriding `--font-sans` / `--font-mono` retunes the
+   * Tailwind `font-sans` / `font-mono` utilities within the chat
+   * boundary; the explicit `font-family` below sets the base font for
+   * any descendant text that doesn't carry a utility.
+   */
+  --font-standard:
+    -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial,
+    Noto Sans, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol,
+    Noto Color Emoji, sans-serif;
+  --font-standard-mono:
+    Menlo, Monaco, Consolas, "Ubuntu Mono", "Source Code Pro", monospace, Menlo,
+    Monaco, "Courier New", monospace;
+  --font-sans: var(--font-standard);
+  --font-mono: var(--font-standard-mono);
+
+  font-family: var(--font-standard), sans-serif;
+  font-size: 13px;
+  line-height: 20px;
+}
+
+.dark [data-appkit-chat],
+[data-appkit-chat].dark {
+  --background: var(--color-grey-800);
+  --foreground: var(--color-grey-100);
+  --card: #1a2530;
+  --card-foreground: var(--color-grey-100);
+  --popover: #1a2530;
+  --popover-foreground: var(--color-grey-100);
+
+  --primary: var(--color-blue-500);
+  --primary-foreground: #ffffff;
+
+  --secondary: #283035;
+  --secondary-foreground: #e8ecf0;
+
+  --muted: #2a3a45;
+  --muted-foreground: #bdcdd9;
+
+  --accent: #2a3a45;
+  --accent-foreground: #e8ecf0;
+
+  --destructive: #e65677;
+
+  --border: #2a3a45;
+  --input: #2a3a45;
+  --ring: #4ba3d6;
+
+  --warning: #dc6222;
+  --success: #3ca45e;
+
+  --action-default-background-hover: rgba(138, 202, 255, 0.08);
+  --action-default-background-press: rgba(138, 202, 255, 0.16);
+  --action-primary-background-hover: #4ba3d6;
+  --action-primary-background-press: #bae1fc;
+  --action-tertiary-background-hover: rgba(143, 205, 255, 0.08);
+  --action-tertiary-background-press: rgba(143, 205, 255, 0.16);
+  --action-danger-primary-background-hover: #f06e87;
+  --action-danger-primary-background-press: #fbd0d8;
+
+  /* Alert / validation tints (dark) */
+  --border-danger: rgba(232, 58, 95, 0.3);
+  --border-warning: rgba(220, 98, 34, 0.3);
+  --border-success: rgba(60, 164, 94, 0.3);
+  --background-danger: rgba(232, 58, 95, 0.08);
+  --background-warning: rgba(220, 98, 34, 0.08);
+  --background-success: rgba(60, 164, 94, 0.08);
+
+  /* Status-badge foregrounds need lighter shades on dark surfaces. */
+  --badge-success-fg: var(--color-green-400);
+  --badge-warning-fg: var(--color-yellow-500);
+}

--- a/packages/appkit-ui/src/react/styles/globals.css
+++ b/packages/appkit-ui/src/react/styles/globals.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "tw-animate-css";
+@import "./chat-theme.css";
 @source "./react";
 
 :root {

--- a/packages/appkit-ui/tsdown.config.ts
+++ b/packages/appkit-ui/tsdown.config.ts
@@ -9,6 +9,7 @@ export default defineConfig([
       "src/js/beta.ts",
       "src/react/index.ts",
       "src/react/beta.ts",
+      "src/react/chat/index.ts",
     ],
     outDir: "dist",
     platform: "browser",

--- a/packages/appkit-ui/tsdown.config.ts
+++ b/packages/appkit-ui/tsdown.config.ts
@@ -23,6 +23,11 @@ export default defineConfig([
         to: "dist",
         rename: "styles.css",
       },
+      {
+        from: "src/react/styles/chat-theme.css",
+        to: "dist",
+        rename: "chat-theme.css",
+      },
     ],
     clean: false,
     hash: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -499,12 +499,18 @@ importers:
         specifier: 1.1.2
         version: 1.1.2(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     devDependencies:
+      '@ai-sdk/react':
+        specifier: 4.0.0-beta.76
+        version: 4.0.0-beta.76(react@19.2.0)(zod@4.3.6)
       '@types/react':
         specifier: 19.2.2
         version: 19.2.2
       '@types/react-dom':
         specifier: 19.2.2
         version: 19.2.2(@types/react@19.2.2)
+      ai:
+        specifier: 7.0.0-beta.76
+        version: 7.0.0-beta.76(zod@4.3.6)
       react:
         specifier: 19.2.0
         version: 19.2.0
@@ -576,14 +582,30 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/gateway@4.0.0-beta.43':
+    resolution: {integrity: sha512-EGQe4If6jt1ZhENmwZn8UAeHbEc7DRiK7ff7dwgfNthwso2hdzLbgXzuTO+W/op+oDFQK1pKiAz5RrPsVQWiew==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider-utils@3.0.19':
     resolution: {integrity: sha512-W41Wc9/jbUVXVwCN/7bWa4IKe8MtxO3EyA0Hfhx6grnmiYlCvpI8neSYWFE0zScXJkgA/YK3BRybzgyiXuu6JA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@5.0.0-beta.16':
+    resolution: {integrity: sha512-CyMV5go6libw5WaZ4m7nO0uRLTENxbIODiDrTXJNwxYIBR8p5aCGaxt9oj3prbvNkTt0Srh/Gyw+n2pR9hQ5Pg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider@2.0.0':
     resolution: {integrity: sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@4.0.0-beta.10':
+    resolution: {integrity: sha512-E2O/LCWjqOxAUfpykQR4xLmcGXySIu6L+wYJjav2xiHu38otPq0qIexgH9ZKulBvBWkrtJ3fxz0kzHDlCBkwng==}
     engines: {node: '>=18'}
 
   '@ai-sdk/react@2.0.115':
@@ -595,6 +617,12 @@ packages:
     peerDependenciesMeta:
       zod:
         optional: true
+
+  '@ai-sdk/react@4.0.0-beta.76':
+    resolution: {integrity: sha512-M5CMl+wlIZexdN+gJG06WPW6F88JFFzjwC1dEyeVNLztxDnZn8VpJy6WDNEo3QgUWjinWJCOnLDLP9qPBzTSSA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
 
   '@algolia/abtesting@1.12.0':
     resolution: {integrity: sha512-EfW0bfxjPs+C7ANkJDw2TATntfBKsFiy7APh+KO0pQ8A6HYa5I0NjFuCGCXWfzzzLXNZta3QUl3n5Kmm6aJo9Q==}
@@ -5182,6 +5210,10 @@ packages:
     resolution: {integrity: sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw==}
     engines: {node: '>= 20'}
 
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
   '@vitejs/plugin-react@5.0.4':
     resolution: {integrity: sha512-La0KD0vGkVkSk6K+piWDKRUyg8Rl5iAIKRMH0vMJI0Eg47bq1eOxmoObAaQG37WMW9MSyk7Cs8EIWwJC1PtzKA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -5333,6 +5365,12 @@ packages:
 
   ai@5.0.113:
     resolution: {integrity: sha512-26vivpSO/mzZj0k1Si2IpsFspp26ttQICHRySQiMrtWcRd5mnJMX2a8sG28vmZ38C+JUn1cWmfZrsLMxkSMw9g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  ai@7.0.0-beta.76:
+    resolution: {integrity: sha512-yJMCqsnfUi8jnFOvxmXhjMZd0YVSCLk1E5PZpqmGWynvo3uADt1XADYYYRcj0I9Q2wsL4HbCLAKe01I8aswzJg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -11972,6 +12010,13 @@ snapshots:
       '@vercel/oidc': 3.0.5
       zod: 4.3.6
 
+  '@ai-sdk/gateway@4.0.0-beta.43(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.0-beta.10
+      '@ai-sdk/provider-utils': 5.0.0-beta.16(zod@4.3.6)
+      '@vercel/oidc': 3.2.0
+      zod: 4.3.6
+
   '@ai-sdk/provider-utils@3.0.19(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
@@ -11979,7 +12024,18 @@ snapshots:
       eventsource-parser: 3.0.6
       zod: 4.3.6
 
+  '@ai-sdk/provider-utils@5.0.0-beta.16(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.0-beta.10
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 4.3.6
+
   '@ai-sdk/provider@2.0.0':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@4.0.0-beta.10':
     dependencies:
       json-schema: 0.4.0
 
@@ -11992,6 +12048,16 @@ snapshots:
       throttleit: 2.1.0
     optionalDependencies:
       zod: 4.3.6
+
+  '@ai-sdk/react@4.0.0-beta.76(react@19.2.0)(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider-utils': 5.0.0-beta.16(zod@4.3.6)
+      ai: 7.0.0-beta.76(zod@4.3.6)
+      react: 19.2.0
+      swr: 2.3.8(react@19.2.0)
+      throttleit: 2.1.0
+    transitivePeerDependencies:
+      - zod
 
   '@algolia/abtesting@1.12.0':
     dependencies:
@@ -17578,6 +17644,8 @@ snapshots:
 
   '@vercel/oidc@3.0.5': {}
 
+  '@vercel/oidc@3.2.0': {}
+
   '@vitejs/plugin-react@5.0.4(vite@7.2.4(@types/node@24.7.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.28.5
@@ -17800,6 +17868,13 @@ snapshots:
       '@ai-sdk/provider': 2.0.0
       '@ai-sdk/provider-utils': 3.0.19(zod@4.3.6)
       '@opentelemetry/api': 1.9.0
+      zod: 4.3.6
+
+  ai@7.0.0-beta.76(zod@4.3.6):
+    dependencies:
+      '@ai-sdk/gateway': 4.0.0-beta.43(zod@4.3.6)
+      '@ai-sdk/provider': 4.0.0-beta.10
+      '@ai-sdk/provider-utils': 5.0.0-beta.16(zod@4.3.6)
       zod: 4.3.6
 
   ajv-formats@2.1.1(ajv@8.17.1):

--- a/tools/generate-component-mdx.ts
+++ b/tools/generate-component-mdx.ts
@@ -602,6 +602,10 @@ function main() {
     // Exclude non-component files from chat directory.
     // Hooks (use-*.ts), the transport class, lib utilities, and barrel
     // files are documented in the hand-written `chat/index.md` overview.
+    // Within `chat/app/`, only `chat-app.tsx` is publicly exposed; the
+    // sibling sub-components are package-private slot pieces.
+    // The `chat/db-icons/` directory contains internal DuBois icon
+    // components that are not part of the public API surface.
     if (info.category === "chat") {
       const basename = path.basename(filePath);
       if (
@@ -610,6 +614,21 @@ function main() {
         basename.startsWith("use-") ||
         basename === "responses-api-transport.ts"
       ) {
+        return false;
+      }
+      if (filePath.includes(`${PATH_PATTERNS.CHAT_DIR}db-icons/`)) {
+        return false;
+      }
+      if (
+        filePath.includes(`${PATH_PATTERNS.CHAT_DIR}app/`) &&
+        basename !== "chat-app.tsx"
+      ) {
+        return false;
+      }
+      // `chat-app.tsx` re-exports type aliases (`ApprovalEntry`,
+      // `ChatComposerProps`, …) that react-docgen-typescript picks up as
+      // pseudo-components. Only the `ChatApp` component itself is public.
+      if (basename === "chat-app.tsx" && displayName !== "ChatApp") {
         return false;
       }
     }

--- a/tools/generate-component-mdx.ts
+++ b/tools/generate-component-mdx.ts
@@ -11,6 +11,7 @@ const COMPONENTS_DIR = "packages/appkit-ui/src/react/ui";
 const CHARTS_DIR = "packages/appkit-ui/src/react/charts";
 const TABLE_DIR = "packages/appkit-ui/src/react/table";
 const GENIE_DIR = "packages/appkit-ui/src/react/genie";
+const CHAT_DIR = "packages/appkit-ui/src/react/chat";
 const DOCS_OUTPUT_DIR = "docs/docs/api/appkit-ui";
 
 const FILE_BROWSER_DIR = "packages/appkit-ui/src/react/file-browser";
@@ -21,6 +22,7 @@ const SOURCE_DIRS = [
   { name: "table", path: TABLE_DIR },
   { name: "genie", path: GENIE_DIR },
   { name: "file-browser", path: FILE_BROWSER_DIR },
+  { name: "chat", path: CHAT_DIR },
 ] as const;
 
 const FILE_EXTENSIONS = {
@@ -43,6 +45,7 @@ const PATH_PATTERNS = {
   TABLE_DIR: "src/react/table/",
   GENIE_DIR: "src/react/genie/",
   FILE_BROWSER_DIR: "src/react/file-browser/",
+  CHAT_DIR: "src/react/chat/",
   DATA_TABLE_FILE: "data-table.tsx",
   REACT_TYPES: "@types/react",
 } as const;
@@ -52,6 +55,7 @@ const OUTPUT_SUBDIRS = {
   UI: "ui",
   GENIE: "genie",
   FILES: "files",
+  CHAT: "chat",
   EXAMPLES: "examples",
 } as const;
 
@@ -100,11 +104,17 @@ function stripDocSuffix(name: string): string {
     : name;
 }
 
-type ComponentCategory = "chart" | "table" | "ui" | "genie" | "file-browser";
+type ComponentCategory =
+  | "chart"
+  | "table"
+  | "ui"
+  | "genie"
+  | "file-browser"
+  | "chat";
 
 interface ComponentInfo {
   category: ComponentCategory;
-  subdir: string; // "data", "ui", or "genie"
+  subdir: string; // "data", "ui", "genie", "files", or "chat"
   chartDir?: string; // Only for charts
 }
 
@@ -131,6 +141,10 @@ function categorizeComponent(component: ComponentDoc): ComponentInfo {
 
   if (relativePath.includes(PATH_PATTERNS.FILE_BROWSER_DIR)) {
     return { category: "file-browser", subdir: OUTPUT_SUBDIRS.FILES };
+  }
+
+  if (relativePath.includes(PATH_PATTERNS.CHAT_DIR)) {
+    return { category: "chat", subdir: OUTPUT_SUBDIRS.CHAT };
   }
 
   return { category: "ui", subdir: OUTPUT_SUBDIRS.UI };
@@ -334,7 +348,7 @@ function buildExampleInfo(component: ComponentDoc): ExampleInfo | undefined {
   }
 
   // Genie / Multi-Genie / Chat components — examples next to source files
-  if (info.category === "genie") {
+  if (info.category === "genie" || info.category === "chat") {
     const sourceDir = path.dirname(filePath);
     const examplePath = path.join(
       sourceDir,
@@ -373,7 +387,8 @@ ${buildComponentDetails(component, {
     if (
       subdir === OUTPUT_SUBDIRS.DATA ||
       subdir === OUTPUT_SUBDIRS.GENIE ||
-      subdir === OUTPUT_SUBDIRS.FILES
+      subdir === OUTPUT_SUBDIRS.FILES ||
+      subdir === OUTPUT_SUBDIRS.CHAT
     ) {
       // For data components: show code only (no interactive preview)
       const sourceCode = fs.readFileSync(example.path, MARKDOWN.FILE_ENCODING);
@@ -584,6 +599,21 @@ function main() {
       }
     }
 
+    // Exclude non-component files from chat directory.
+    // Hooks (use-*.ts), the transport class, lib utilities, and barrel
+    // files are documented in the hand-written `chat/index.md` overview.
+    if (info.category === "chat") {
+      const basename = path.basename(filePath);
+      if (
+        basename === "index.ts" ||
+        basename === "utils.ts" ||
+        basename.startsWith("use-") ||
+        basename === "responses-api-transport.ts"
+      ) {
+        return false;
+      }
+    }
+
     return (
       Boolean(displayName) &&
       !excludeList.includes(displayName) &&
@@ -649,16 +679,26 @@ function main() {
   // Create output directory if it doesn't exist
   fs.mkdirSync(outputDir, { recursive: true });
 
-  // Delete only subdirectories (preserve root-level files)
-  // This preserves files like _index.md (category link) and styling.md (manual docs)
-  if (fs.existsSync(outputDir)) {
-    const entries = fs.readdirSync(outputDir, { withFileTypes: true });
-    for (const entry of entries) {
-      if (entry.isDirectory()) {
-        fs.rmSync(path.join(outputDir, entry.name), {
-          recursive: true,
-          force: true,
-        });
+  // Subdirectories owned by the generator. Inside each, only auto-generated
+  // artifacts (*.mdx and the auto-written _category_.json) are deleted on
+  // regen — hand-written files like `index.md` are preserved.
+  const generatedSubdirs = [
+    OUTPUT_SUBDIRS.DATA,
+    OUTPUT_SUBDIRS.UI,
+    OUTPUT_SUBDIRS.GENIE,
+    OUTPUT_SUBDIRS.FILES,
+    OUTPUT_SUBDIRS.CHAT,
+  ];
+  for (const sub of generatedSubdirs) {
+    const subPath = path.join(outputDir, sub);
+    if (!fs.existsSync(subPath)) continue;
+    const files = fs.readdirSync(subPath, { withFileTypes: true });
+    for (const f of files) {
+      if (
+        f.isFile() &&
+        (f.name.endsWith(".mdx") || f.name === FILE_EXTENSIONS.CATEGORY_CONFIG)
+      ) {
+        fs.rmSync(path.join(subPath, f.name), { force: true });
       }
     }
   }
@@ -668,10 +708,12 @@ function main() {
   const uiOutputDir = path.join(outputDir, OUTPUT_SUBDIRS.UI);
   const genieOutputDir = path.join(outputDir, OUTPUT_SUBDIRS.GENIE);
   const filesOutputDir = path.join(outputDir, OUTPUT_SUBDIRS.FILES);
+  const chatOutputDir = path.join(outputDir, OUTPUT_SUBDIRS.CHAT);
   fs.mkdirSync(dataOutputDir, { recursive: true });
   fs.mkdirSync(uiOutputDir, { recursive: true });
   fs.mkdirSync(genieOutputDir, { recursive: true });
   fs.mkdirSync(filesOutputDir, { recursive: true });
+  fs.mkdirSync(chatOutputDir, { recursive: true });
 
   // Create _category_.json files for proper sidebar labels
   fs.writeFileSync(
@@ -716,6 +758,18 @@ function main() {
       {
         label: "Files (UC) components",
         position: 6,
+      },
+      null,
+      2,
+    )}\n`,
+    MARKDOWN.FILE_ENCODING,
+  );
+  fs.writeFileSync(
+    path.join(chatOutputDir, FILE_EXTENSIONS.CATEGORY_CONFIG),
+    `${JSON.stringify(
+      {
+        label: "Chat primitives",
+        position: 7,
       },
       null,
       2,


### PR DESCRIPTION
Builds on top of the chat primitives from the previous PR to ship a fully-styled, batteries-included chat UI that works against an `agents()`-backed AppKit server with literally one line of JSX.

### What's new

A new `<ChatApp />` component in `@databricks/appkit-ui/react/chat`:

```tsx
import { ChatApp } from "@databricks/appkit-ui/react/chat";

export function MyChat() {
  return (
    <div className="h-svh">
      <ChatApp />
    </div>
  );
}
```

That's the whole thing. No props, no callbacks, no slots. It defaults `api` to `/api/agents/chat` (the AppKit `agents()` plugin's default mount path), handles approval cards end-to-end (including POSTing the decision to `/api/agents/approve`), and renders a polished UI: greeting/empty state, message bubbles, reasoning panel, tool-call cards, markdown rendering, and a composer.

### Demo

https://github.com/user-attachments/assets/48995631-8669-42d5-a281-3719ab914a1a

### Tool approval

<img width="1358" height="913" alt="approval-new" src="https://github.com/user-attachments/assets/5ff8b31f-6a4f-48c8-888b-89728f3ae019" />

### Reasoning

<img width="1340" height="453" alt="reasoning-ui" src="https://github.com/user-attachments/assets/03f8e116-381b-4ac2-8293-cfea08470b90" />

For people who outgrow the defaults, every section has a `render*` slot (`renderMessage`, `renderToolCall`, `renderComposer`) and you can override `api`, `approveUrl`, `placeholder`, etc.

### Why

The previous PR gave us the building blocks (headless `<Conversation>`, `<ChatInput>`, hooks, transport) for people who want full control. But "full control" is overkill for the 80% case where you just want a chat that works. `<ChatApp />` is the opinionated counterpart: zero-config for the default agents-plugin setup, with sensible escape hatches when you need them.

### Playground

A new `/agent-chat-full` route showcases the no-config path: literally one `<ChatApp />` tag in a sized container. Sits next to the existing `/agent` route (which stays as the build-your-own example).