### PR TITLE
docs: replace --skip-build with --skip-validation in app-management

### DIFF
--- a/docs/docs/app-management.mdx
+++ b/docs/docs/app-management.mdx
@@ -56,10 +56,10 @@ databricks apps deploy --help
     databricks apps deploy --var="warehouse_id=abc123"
     ```
 
-- Skip the build step for faster iteration:
+- Skip validation for faster iteration:
 
     ```bash
-    databricks apps deploy --skip-build
+    databricks apps deploy --skip-validation
     ```
 
 - Force deploy (override Git branch validation):


### PR DESCRIPTION
## Summary
- The `databricks apps deploy --skip-build` flag has been replaced with `--skip-validation`.
- Update the example and description in `docs/docs/app-management.mdx` to reflect the current CLI flag.

## Test plan
- [ ] `pnpm docs:build` renders the updated `app-management` page without errors.
- [ ] Verify the rendered docs show `databricks apps deploy --skip-validation` with the matching "Skip validation for faster iteration" description.