### PR TITLE
refactor(appkit): introduce ServiceManager for core service lifecycle

### DIFF
--- a/docs/docs/api/appkit/Class.Plugin.md
+++ b/docs/docs/api/appkit/Class.Plugin.md
@@ -257,23 +257,23 @@ AuthenticationError if user token is not available in request headers (productio
 ```ts
 attachContext(deps: {
   context?: unknown;
+  services?: {
+     get: T | null;
+  };
   telemetryConfig?: TelemetryOptions;
 }): void;
 ```
 
-Binds runtime dependencies (telemetry provider, cache, plugin context) to
-this plugin. Called by `AppKit._createApp` after construction and before
-`setup()`. Idempotent: safe to call if the constructor already bound them
-eagerly. Kept separate so factories can eagerly construct plugin instances
-without running this before `TelemetryManager.initialize()` /
-`CacheManager.getInstance()` have run.
+Binds runtime deps (context, core services). Called before `setup()`.
 
 #### Parameters
 
 | Parameter | Type |
 | ------ | ------ |
-| `deps` | \{ `context?`: `unknown`; `telemetryConfig?`: `TelemetryOptions`; \} |
+| `deps` | \{ `context?`: `unknown`; `services?`: \{ `get`: `T` \| `null`; \}; `telemetryConfig?`: `TelemetryOptions`; \} |
 | `deps.context?` | `unknown` |
+| `deps.services?` | \{ `get`: `T` \| `null`; \} |
+| `deps.services.get` |
 | `deps.telemetryConfig?` | `TelemetryOptions` |
 
 #### Returns

--- a/packages/appkit/src/cache/index.ts
+++ b/packages/appkit/src/cache/index.ts
@@ -134,6 +134,22 @@ export class CacheManager {
     return CacheManager.initPromise;
   }
 
+  /** @internal */
+  static async boot(
+    config?: CacheConfig,
+  ): Promise<{ instance: CacheManager; stop(): Promise<void> }> {
+    const mgr = await CacheManager.getInstance(config);
+    return { instance: mgr, stop: () => mgr.shutdown() };
+  }
+
+  /** @internal */
+  async shutdown(): Promise<void> {
+    await this.close();
+    this.inFlightRequests.clear();
+    CacheManager.instance = null;
+    CacheManager.initPromise = null;
+  }
+
   /**
    * Create a new cache manager instance
    *

--- a/packages/appkit/src/core/appkit.ts
+++ b/packages/appkit/src/core/appkit.ts
@@ -9,30 +9,28 @@ import type {
   PluginMap,
 } from "shared";
 import { version as productVersion } from "../../package.json";
-import { CacheManager } from "../cache";
 import { ServiceContext } from "../context";
 import {
   isInternalTelemetryEnabled,
   TelemetryReporter,
 } from "../internal-telemetry";
-import { createLogger } from "../logging/logger";
 import { isPlainObject } from "../plugin/plugin";
 import { ResourceRegistry, ResourceType } from "../registry";
 import type { TelemetryConfig } from "../telemetry";
-import { TelemetryManager } from "../telemetry";
 import { isToolProvider, PluginContext } from "./plugin-context";
-
-const logger = createLogger("appkit");
+import { type ServiceManager, startCoreServices } from "./service-manager";
 
 export class AppKit<TPlugins extends InputPluginMap> {
   #pluginInstances: Record<string, BasePlugin> = {};
   #setupPromises: Promise<void>[] = [];
   #context: PluginContext;
+  #services: ServiceManager;
 
-  private constructor(config: { plugins: TPlugins }) {
+  private constructor(config: { plugins: TPlugins }, services: ServiceManager) {
     const { plugins, ...globalConfig } = config;
 
     this.#context = new PluginContext();
+    this.#services = services;
 
     const pluginEntries = Object.entries(plugins);
 
@@ -90,6 +88,7 @@ export class AppKit<TPlugins extends InputPluginMap> {
     if (typeof pluginInstance.attachContext === "function") {
       pluginInstance.attachContext({
         context: this.#context,
+        services: this.#services,
         telemetryConfig: baseConfig.telemetry,
       });
     }
@@ -187,56 +186,59 @@ export class AppKit<TPlugins extends InputPluginMap> {
       disableInternalTelemetry?: boolean;
     } = {},
   ): Promise<PluginMap<T>> {
-    // Initialize core services
-    TelemetryManager.initialize(config?.telemetry);
-    await CacheManager.getInstance(config?.cache);
+    const services = await startCoreServices({
+      telemetry: config?.telemetry,
+      cache: config?.cache,
+    });
 
-    const rawPlugins = config.plugins as T;
+    try {
+      const rawPlugins = config.plugins as T;
 
-    // Collect manifest resources via registry
-    const registry = new ResourceRegistry();
-    registry.collectResources(rawPlugins);
+      const resourceRegistry = new ResourceRegistry();
+      resourceRegistry.collectResources(rawPlugins);
 
-    // Derive ServiceContext needs from what manifests declared
-    const needsWarehouse = registry
-      .getRequired()
-      .some((r) => r.type === ResourceType.SQL_WAREHOUSE);
-    await ServiceContext.initialize(
-      { warehouseId: needsWarehouse },
-      config?.client,
-    );
+      const needsWarehouse = resourceRegistry
+        .getRequired()
+        .some((r) => r.type === ResourceType.SQL_WAREHOUSE);
+      await ServiceContext.initialize(
+        { warehouseId: needsWarehouse },
+        config?.client,
+      );
 
-    // Validate env vars
-    registry.enforceValidation();
+      resourceRegistry.enforceValidation();
 
-    const preparedPlugins = AppKit.preparePlugins(rawPlugins);
-    const mergedConfig = {
-      plugins: preparedPlugins,
-    };
+      const preparedPlugins = AppKit.preparePlugins(rawPlugins);
+      const mergedConfig = {
+        plugins: preparedPlugins,
+      };
 
-    const instance = new AppKit(mergedConfig);
+      const instance = new AppKit(mergedConfig, services);
 
-    await Promise.all(instance.#setupPromises);
-    await instance.#context.emitLifecycle("setup:complete");
+      await Promise.all(instance.#setupPromises);
+      await instance.#context.emitLifecycle("setup:complete");
 
-    const handle = instance as unknown as PluginMap<T>;
+      const handle = instance as unknown as PluginMap<T>;
 
-    if (config.onPluginsReady) {
-      logger.debug("Running onPluginsReady hook");
-      await config.onPluginsReady(handle);
-      logger.debug("onPluginsReady hook completed");
+      if (config.onPluginsReady) {
+        await config.onPluginsReady(handle);
+      }
+
+      if (isInternalTelemetryEnabled(config)) {
+        AppKit.bootstrapInternalTelemetry();
+      }
+
+      const serverPlugin = instance.#pluginInstances.server;
+      if (serverPlugin && typeof (serverPlugin as any).start === "function") {
+        await (serverPlugin as any).start({
+          shutdownCoreServices: () => services.stop(),
+        });
+      }
+
+      return handle;
+    } catch (error) {
+      await services.stop();
+      throw error;
     }
-
-    if (isInternalTelemetryEnabled(config)) {
-      AppKit.bootstrapInternalTelemetry();
-    }
-
-    const serverPlugin = instance.#pluginInstances.server;
-    if (serverPlugin && typeof (serverPlugin as any).start === "function") {
-      await (serverPlugin as any).start();
-    }
-
-    return handle;
   }
 
   private static bootstrapInternalTelemetry(): void {

--- a/packages/appkit/src/core/service-manager.ts
+++ b/packages/appkit/src/core/service-manager.ts
@@ -1,0 +1,68 @@
+import type { CacheConfig } from "shared";
+import { CacheManager } from "../cache";
+import { createLogger } from "../logging";
+import { type TelemetryConfig, TelemetryManager } from "../telemetry";
+
+const logger = createLogger("services");
+
+interface ServiceEntry {
+  readonly name: string;
+  readonly instance: unknown;
+  stop(): Promise<void>;
+}
+
+/** Holds booted core services and resolves them by name. */
+export class ServiceManager {
+  #services: ServiceEntry[] = [];
+
+  /** Adds a service. `null` is ignored so callers can pass an opt-out result. */
+  add(
+    name: string,
+    service: { instance: unknown; stop(): Promise<void> } | null,
+  ): void {
+    if (!service) return;
+    this.#services.push({ name, ...service });
+    logger.debug("Started: %s", name);
+  }
+
+  get<T>(name: string): T | null {
+    for (const s of this.#services) {
+      if (s.name === name) return s.instance as T;
+    }
+    return null;
+  }
+
+  /** Stops services in reverse start order. Per-service failures are logged. */
+  async stop(): Promise<void> {
+    while (this.#services.length > 0) {
+      const s = this.#services.pop();
+      if (!s) continue;
+      try {
+        await s.stop();
+        logger.debug("Stopped: %s", s.name);
+      } catch (error) {
+        logger.error("Stop failed for %s: %O", s.name, error);
+      }
+    }
+  }
+}
+
+/**
+ * Boots the core services AppKit ships with. Adding a new service touches
+ * only this function and the service module itself — the rest of the core
+ * stays free of concrete service imports.
+ */
+export async function startCoreServices(config: {
+  telemetry?: TelemetryConfig;
+  cache?: CacheConfig;
+}): Promise<ServiceManager> {
+  const services = new ServiceManager();
+  try {
+    services.add("telemetry", await TelemetryManager.boot(config.telemetry));
+    services.add("cache", await CacheManager.boot(config.cache));
+    return services;
+  } catch (error) {
+    await services.stop();
+    throw error;
+  }
+}

--- a/packages/appkit/src/core/tests/appkit-as-user-exports.test.ts
+++ b/packages/appkit/src/core/tests/appkit-as-user-exports.test.ts
@@ -14,6 +14,21 @@ import type { UserContext } from "../../context/user-context";
 
 vi.mock("../../cache", () => ({
   CacheManager: {
+    boot: vi.fn(async () => ({
+      instance: {
+        get: vi.fn(),
+        set: vi.fn(),
+        delete: vi.fn(),
+        getOrExecute: vi.fn(
+          async (
+            _k: unknown[],
+            fn: (signal?: AbortSignal) => Promise<unknown>,
+          ) => fn(),
+        ),
+        generateKey: vi.fn(() => "test-key"),
+      },
+      stop: vi.fn(),
+    })),
     getInstance: vi.fn(async () => ({
       get: vi.fn(),
       set: vi.fn(),
@@ -43,6 +58,7 @@ vi.mock("../../telemetry", async () => {
   return {
     ...actual,
     TelemetryManager: {
+      boot: vi.fn(async () => null),
       initialize: vi.fn(),
       getProvider: () => ({
         getTracer: () => ({

--- a/packages/appkit/src/core/tests/service-manager.test.ts
+++ b/packages/appkit/src/core/tests/service-manager.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test, vi } from "vitest";
+import { ServiceManager } from "../service-manager";
+
+function mockService(name: string, calls: string[]) {
+  return {
+    instance: { name },
+    stop: vi.fn(async () => {
+      calls.push(`stop:${name}`);
+    }),
+  };
+}
+
+describe("ServiceManager", () => {
+  test("get<T> returns the registered instance", () => {
+    const sm = new ServiceManager();
+    const svc = { instance: { hello: "world" }, stop: vi.fn() };
+    sm.add("greeter", svc);
+
+    expect(sm.get<{ hello: string }>("greeter")).toEqual({ hello: "world" });
+  });
+
+  test("get<T> returns null for unknown service", () => {
+    const sm = new ServiceManager();
+    expect(sm.get("missing")).toBeNull();
+  });
+
+  test("add(null) is a no-op (opt-out pattern)", async () => {
+    const sm = new ServiceManager();
+    sm.add("absent", null);
+
+    expect(sm.get("absent")).toBeNull();
+    await expect(sm.stop()).resolves.toBeUndefined();
+  });
+
+  test("stop() invokes services in reverse add order", async () => {
+    const calls: string[] = [];
+    const sm = new ServiceManager();
+    sm.add("a", mockService("a", calls));
+    sm.add("b", mockService("b", calls));
+    sm.add("c", mockService("c", calls));
+
+    await sm.stop();
+
+    expect(calls).toEqual(["stop:c", "stop:b", "stop:a"]);
+  });
+
+  test("stop() continues when one service throws", async () => {
+    const calls: string[] = [];
+    const sm = new ServiceManager();
+    sm.add("a", mockService("a", calls));
+    sm.add("b", {
+      instance: {},
+      stop: vi.fn(async () => {
+        throw new Error("boom");
+      }),
+    });
+    sm.add("c", mockService("c", calls));
+
+    await expect(sm.stop()).resolves.toBeUndefined();
+    expect(calls).toEqual(["stop:c", "stop:a"]);
+  });
+
+  test("stop() drains the registry (idempotent on second call)", async () => {
+    const calls: string[] = [];
+    const sm = new ServiceManager();
+    sm.add("a", mockService("a", calls));
+
+    await sm.stop();
+    await sm.stop();
+
+    expect(calls).toEqual(["stop:a"]);
+    expect(sm.get("a")).toBeNull();
+  });
+});

--- a/packages/appkit/src/plugin/plugin.ts
+++ b/packages/appkit/src/plugin/plugin.ts
@@ -256,14 +256,10 @@ export abstract class Plugin<
       | PluginContext
       | undefined;
 
-    // Eagerly bind telemetry + cache if the core services have already been
-    // initialized (normal createApp path, or tests that mock CacheManager).
-    // If they haven't, we leave these undefined and rely on `attachContext`
-    // being called later — this lets factories eagerly construct plugin
-    // instances at module top-level before `createApp` has run.
     this.tryAttachContext();
   }
 
+  // Fallback for plugins instantiated outside `_createApp` (test path).
   private tryAttachContext(): void {
     try {
       this.cache = CacheManager.getInstanceSync();
@@ -277,23 +273,17 @@ export abstract class Plugin<
     this.isReady = true;
   }
 
-  /**
-   * Binds runtime dependencies (telemetry provider, cache, plugin context) to
-   * this plugin. Called by `AppKit._createApp` after construction and before
-   * `setup()`. Idempotent: safe to call if the constructor already bound them
-   * eagerly. Kept separate so factories can eagerly construct plugin instances
-   * without running this before `TelemetryManager.initialize()` /
-   * `CacheManager.getInstance()` have run.
-   */
   attachContext(
     deps: {
       context?: unknown;
+      services?: { get<T>(name: string): T | null };
       telemetryConfig?: BasePluginConfig["telemetry"];
     } = {},
   ): void {
-    if (!this.cache) {
-      this.cache = CacheManager.getInstanceSync();
-    }
+    this.cache =
+      deps.services?.get<CacheManager>("cache") ??
+      this.cache ??
+      CacheManager.getInstanceSync();
     this.telemetry = TelemetryManager.getProvider(
       this.name,
       deps.telemetryConfig ?? this.config.telemetry,
@@ -751,10 +741,12 @@ export abstract class Plugin<
   }
 
   private _checkIfGenerator(
-    result: any,
-  ): result is AsyncGenerator<any, void, unknown> {
+    result: unknown,
+  ): result is AsyncGenerator<unknown, void, unknown> {
     return (
-      result && typeof result === "object" && Symbol.asyncIterator in result
+      typeof result === "object" &&
+      result !== null &&
+      Symbol.asyncIterator in result
     );
   }
 }

--- a/packages/appkit/src/plugins/files/tests/plugin.test.ts
+++ b/packages/appkit/src/plugins/files/tests/plugin.test.ts
@@ -70,6 +70,10 @@ vi.mock("../../../context", async (importOriginal) => {
 
 vi.mock("../../../cache", () => ({
   CacheManager: {
+    boot: vi.fn(async () => ({
+      instance: mockCacheInstance,
+      stop: vi.fn(),
+    })),
     getInstanceSync: vi.fn(() => mockCacheInstance),
     getInstance: vi.fn(async () => mockCacheInstance),
   },

--- a/packages/appkit/src/telemetry/telemetry-manager.ts
+++ b/packages/appkit/src/telemetry/telemetry-manager.ts
@@ -95,11 +95,25 @@ export class TelemetryManager {
       });
 
       this.sdk.start();
-      this.registerShutdown();
       logger.debug("Initialized successfully");
     } catch (error) {
       logger.error("Failed to initialize: %O", error);
     }
+  }
+
+  /** True once the underlying NodeSDK has started. */
+  isActive(): boolean {
+    return this.sdk !== undefined;
+  }
+
+  /** Returns `null` when no OTLP endpoint is configured (telemetry opt-out). */
+  static async boot(
+    config?: TelemetryConfig,
+  ): Promise<{ instance: TelemetryManager; stop(): Promise<void> } | null> {
+    TelemetryManager.initialize(config);
+    const instance = TelemetryManager.getInstance();
+    if (!instance.isActive()) return null;
+    return { instance, stop: () => instance.shutdown() };
   }
 
   /**
@@ -158,15 +172,12 @@ export class TelemetryManager {
     ];
   }
 
-  private registerShutdown() {
-    const shutdownFn = async () => {
-      await TelemetryManager.getInstance().shutdown();
-    };
-    process.once("SIGTERM", shutdownFn);
-    process.once("SIGINT", shutdownFn);
-  }
-
-  private async shutdown(): Promise<void> {
+  /**
+   * Drains pending spans/metrics/logs and shuts down the NodeSDK.
+   * Idempotent.
+   * @internal
+   */
+  async shutdown(): Promise<void> {
     if (!this.sdk) {
       return;
     }

--- a/packages/appkit/src/telemetry/tests/telemetry-manager.test.ts
+++ b/packages/appkit/src/telemetry/tests/telemetry-manager.test.ts
@@ -54,8 +54,6 @@ describe("TelemetryManager", () => {
     vi.clearAllMocks();
     // @ts-expect-error - accessing private static property for testing
     TelemetryManager.instance = undefined;
-    // @ts-expect-error - accessing private static property for testing
-    TelemetryManager.shutdownRegistered = false;
   });
 
   afterEach(() => {

--- a/packages/shared/src/plugin.ts
+++ b/packages/shared/src/plugin.ts
@@ -30,12 +30,10 @@ export interface BasePlugin {
 
   clientConfig?(): Record<string, unknown>;
 
-  /**
-   * Binds runtime dependencies (telemetry, cache, plugin context) after the
-   * plugin has been constructed. Called by the AppKit core before `setup()`.
-   */
+  /** Binds runtime deps (context, core services). Called before `setup()`. */
   attachContext?(deps: {
     context?: unknown;
+    services?: { get<T>(name: string): T | null };
     telemetryConfig?: TelemetryOptions;
   }): void;
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/databricks/appkit/pull/374/files) to review incremental changes.
- [**stack/taskflow/service-registry**](https://github.com/databricks/appkit/pull/374) [[Files changed](https://github.com/databricks/appkit/pull/374/files)]
  - [stack/taskflow/sql-warehouse-split](https://github.com/databricks/appkit/pull/375) [[Files changed](https://github.com/databricks/appkit/pull/375/files/079260ef5d6fa4dab69b2ca3e0ccc403812f385f..450d962002bb382a4018ba77fa570e1722ffa2bc)]
    - [stack/taskflow/taskflow-service](https://github.com/databricks/appkit/pull/376) [[Files changed](https://github.com/databricks/appkit/pull/376/files/450d962002bb382a4018ba77fa570e1722ffa2bc..e3956a8116e0f1950946c6bf46e158cef30c4523)]
      - [stack/taskflow/execute-task](https://github.com/databricks/appkit/pull/378) [[Files changed](https://github.com/databricks/appkit/pull/378/files/e3956a8116e0f1950946c6bf46e158cef30c4523..0b9ea8f515b0f67e82be422f4d8ccf99337c6ba4)]
        - [stack/taskflow/analytics-migration](https://github.com/databricks/appkit/pull/379) [[Files changed](https://github.com/databricks/appkit/pull/379/files/0b9ea8f515b0f67e82be422f4d8ccf99337c6ba4..4fd72ec3f32022118bb8ad17a5e42c41081b1157)]
          - [stack/taskflow/durable-task-demo](https://github.com/databricks/appkit/pull/380) [[Files changed](https://github.com/databricks/appkit/pull/380/files/4fd72ec3f32022118bb8ad17a5e42c41081b1157..97669ffc222015216e1f3ccd61103b0374d8878a)]
            - [stack/taskflow/production-hardening](https://github.com/databricks/appkit/pull/381) [[Files changed](https://github.com/databricks/appkit/pull/381/files/97669ffc222015216e1f3ccd61103b0374d8878a..e8a428102e9bd9a6af212d812ad7b8bf348226b4)]

---------
AppKit's core previously ran a hardcoded boot sequence for cache + telemetry. This refactor introduces a generic service container so the core no longer names concrete services in its bootstrap path:

- `ServiceManager` — holds booted core services, resolves them by name via `get<T>(name)`, and stops them in reverse start order. `add(name, null)` is a no-op so callers can pass opt-out results directly.
- `startCoreServices(config)` — builds the `ServiceManager` AppKit ships with; lives next to the concrete service modules so `core/appkit.ts` stays free of concrete-class imports.

Cache and Telemetry expose a `static boot(config)` returning `{ instance, stop } | null`. Telemetry returns `null` when no OTLP endpoint is configured (preserves the existing opt-out semantics).

Plugins receive a typed `services` locator through `attachContext`. The shape is inlined in `BasePlugin` so the `shared` package does not gain a new exported interface. Plugins resolve services via `services.get<MyService>("my-service")` when the base class doesn't surface them as properties.

Groundwork only — no behaviour change, no public-API removal. The goal is to make room for a third core service (TaskFlow) without re-threading the cross-package `attachContext` contract: adding a new service touches only the service module and `startCoreServices`. TaskFlow itself is intentionally NOT in this PR.

Verified: \`pnpm -r typecheck\`, \`pnpm build\`, full vitest run (123 files, 2261 tests) all green.

Signed-off-by: ditadi <victordperd@gmail.com>