### PR TITLE
feat(appkit): executeTask, TypedTaskContext, SSE bridge, step

### DIFF
--- a/packages/appkit/src/context/execution-context.ts
+++ b/packages/appkit/src/context/execution-context.ts
@@ -83,11 +83,22 @@ export function getWorkspaceId(): Promise<string> {
 }
 
 /**
- * Check if currently running in a user context.
+ * Check if currently running in a user context. Sugar for
+ * `getCurrentUserContext() !== null` — prefer {@link getCurrentUserContext}
+ * when you also need the value.
  */
 export function isInUserContext(): boolean {
-  const ctx = executionContextStorage.getStore();
-  return ctx !== undefined;
+  return getCurrentUserContext() !== null;
+}
+
+/**
+ * Returns the active {@link UserContext} when inside a
+ * `runInUserContext` scope (set by `plugin.asUser(req).method(...)`),
+ * or `null`. Use to forward user identity to a downstream layer
+ * (e.g. spawning a durable task that should run as the caller).
+ */
+export function getCurrentUserContext(): UserContext | null {
+  return executionContextStorage.getStore() ?? null;
 }
 
 /**

--- a/packages/appkit/src/context/index.ts
+++ b/packages/appkit/src/context/index.ts
@@ -1,4 +1,5 @@
 export {
+  getCurrentUserContext,
   getCurrentUserId,
   getExecutionContext,
   getWarehouseId,

--- a/packages/appkit/src/index.ts
+++ b/packages/appkit/src/index.ts
@@ -108,8 +108,30 @@ export {
   ResourceRegistry,
   ResourceType,
 } from "./registry";
-export type { TaskConfig } from "./tasks";
-export { TaskManager } from "./tasks";
+// Durable execution. `TaskManager` is exported type-only: it's
+// constructed by `createApp` and addressed via `this.task` inside
+// plugins; internal statics must not leak to consumers.
+export {
+  type ExecuteTaskSettings,
+  type ResumeOptions,
+  type SseEvent,
+  type StopOptions,
+  type StreamEvent,
+  type SubmitOptions,
+  setupSseHeaders,
+  step,
+  TASK_IDEMPOTENCY_HEADER,
+  type Task,
+  type TaskConfig,
+  type TaskContext,
+  type TaskDefinition,
+  type TaskEvent,
+  type TaskHandle,
+  type TaskManager,
+  type TaskRef,
+  type TypedTaskContext,
+  writeSseFrame,
+} from "./tasks";
 // Telemetry (for advanced custom telemetry)
 export {
   type Counter,

--- a/packages/appkit/src/plugin/plugin.ts
+++ b/packages/appkit/src/plugin/plugin.ts
@@ -19,7 +19,12 @@ import type { PluginContext } from "../core/plugin-context";
 import { AppKitError, AuthenticationError } from "../errors";
 import { createLogger } from "../logging/logger";
 import { StreamManager } from "../stream";
-import { TaskManager } from "../tasks";
+import {
+  type ExecuteTaskSettings,
+  executeTask as executeTaskImpl,
+  TaskManager,
+  type TaskRef,
+} from "../tasks";
 import {
   type ITelemetry,
   normalizeTelemetryOptions,
@@ -112,11 +117,14 @@ function hasHttpStatusCode(
 
 /**
  * Methods that should not be proxied by asUser().
- * These are lifecycle/internal methods that don't make sense
- * to execute in a user context.
+ * Lifecycle/internal methods that don't make sense in a user context.
+ *
+ * Note: `executeTask` is deliberately NOT excluded — it MUST run inside
+ * the proxy's `runInUserContext` so `getCurrentUserContext()` forwards
+ * the OBO context to the engine. Excluding it would silently downgrade
+ * OBO calls to SP.
  */
 const EXCLUDED_FROM_PROXY = new Set([
-  // Lifecycle methods
   "setup",
   "shutdown",
   "attachContext",
@@ -125,9 +133,8 @@ const EXCLUDED_FROM_PROXY = new Set([
   "getSkipBodyParsingPaths",
   "abortActiveOperations",
   "clientConfig",
-  // asUser itself - prevent chaining like .asUser().asUser()
+  // Prevent chained .asUser().asUser().
   "asUser",
-  // Internal methods
   "constructor",
 ]);
 
@@ -588,6 +595,58 @@ export abstract class Plugin<
       asyncWrapperFn,
       streamConfig,
       effectiveUserKey,
+    );
+  }
+
+  /**
+   * Bridges a registered durable task to an SSE response.
+   *
+   * Submits via `this.task.start(...)`, subscribes, writes each event
+   * as `id: <seq>\nevent: <name>\ndata: <json>`. Supports
+   * `Last-Event-ID` reconnect from the WAL.
+   *
+   * Identity comes from the active `runInUserContext` scope. For OBO,
+   * call through the proxy: `this.asUser(req).executeTask(...)`.
+   *
+   * Unlike `execute()` / `executeStream()`, this does not accept
+   * `retry` / `cache` / `timeout` — the task engine handles them
+   * natively.
+   *
+   * @throws if the app was created without `task: true` or an explicit task config.
+   *
+   * @example
+   * ```ts
+   * // SP
+   * await this.executeTask(res, "agent-loop", req.body);
+   *
+   * // OBO, no cancel on reconnect
+   * await this.asUser(req).executeTask(res, "agent-loop", req.body, {
+   *   cancelOnDisconnect: false,
+   * });
+   * ```
+   */
+  protected async executeTask<
+    TInput = unknown,
+    TResult = unknown,
+    TEvents extends Record<string, unknown> = Record<string, unknown>,
+  >(
+    res: express.Response,
+    task: string | TaskRef<TInput, TResult, TEvents>,
+    input: TInput,
+    settings?: ExecuteTaskSettings,
+  ): Promise<void> {
+    if (!this.task) {
+      throw new Error(
+        "executeTask() requires durable execution. Enable it with createApp({ task: true }) or an explicit task config.",
+      );
+    }
+    const taskName = typeof task === "string" ? task : task.name;
+    return executeTaskImpl(
+      { manager: this.task, telemetry: this.telemetry, pluginName: this.name },
+      res,
+      taskName,
+      input,
+      settings,
     );
   }
 

--- a/packages/appkit/src/tasks/execute-task.ts
+++ b/packages/appkit/src/tasks/execute-task.ts
@@ -1,0 +1,397 @@
+/**
+ * `executeTask` — durable POST + SSE bridge in one call.
+ *
+ * Wire shape: each `ctx.emit(name, payload)` becomes
+ * `event: <name>` / `data: <JSON.stringify(payload)>`. Bridge-handled:
+ * `heartbeat` → SSE comment, `custom:step:*` → dropped (WAL-only),
+ * `completed`/`failed`/`cancelled` → forwarded, then loop exits.
+ *
+ * Identity comes from the active `runInUserContext` scope set by the
+ * `asUser(req)` proxy — never from headers or settings.
+ */
+
+import { SpanStatusCode } from "@opentelemetry/api";
+import type express from "express";
+import { getCurrentUserContext } from "../context";
+import { createLogger } from "../logging/logger";
+import type { ITelemetry } from "../telemetry";
+import type { TaskManager } from "./manager";
+import {
+  RESERVED_BRIDGE_EVENT_NAMES,
+  setupSseHeaders,
+  writeSseComment,
+  writeSseFrame,
+} from "./sse";
+import type { ActiveBridge } from "./types";
+
+/**
+ * Response header carrying the engine-derived idempotency key
+ * (`sha256(name || canon(input) || userId)`) so clients can issue
+ * follow-up `/resume/:ik` / `/stop/:ik` without rebuilding the input.
+ * Mirrored as the first SSE event (`event: ready`) for cross-origin
+ * clients that can't read response headers.
+ *
+ * @public
+ */
+export const TASK_IDEMPOTENCY_HEADER = "X-AppKit-Task-Idempotency-Key";
+
+const logger = createLogger("tasks:execute");
+
+/** Process-scoped to log the OBO+autoRecover warning once per (plugin, task). @internal */
+const oboAutoRecoverWarned = new Set<string>();
+
+export async function executeTask<TInput>(
+  deps: {
+    manager: TaskManager;
+    telemetry: ITelemetry;
+    pluginName: string;
+  },
+  res: express.Response,
+  taskName: string,
+  input: TInput,
+  settings: ExecuteTaskSettings = {},
+): Promise<void> {
+  const { manager, telemetry, pluginName } = deps;
+
+  // Identity comes only from the active `runInUserContext` scope. A
+  // settings-based `userId` override would let any caller forge
+  // ownership of `manager.stop()` / `resume()` for another user's IK.
+  const userCtx = getCurrentUserContext();
+  const userId = userCtx?.userId;
+  const isObo = userCtx !== null;
+
+  // OBO + autoRecover is incompatible: the recovery worker has no
+  // UserContext, so post-restart OBO calls fail. Warn once per
+  // (plugin, task) so a high-traffic misconfigured task doesn't flood.
+  if (isObo) {
+    const reg = manager.getRegistration(taskName);
+    const warningKey = `${pluginName}:${taskName}`;
+    if (reg?.autoRecover && !oboAutoRecoverWarned.has(warningKey)) {
+      oboAutoRecoverWarned.add(warningKey);
+      logger.warn(
+        `Plugin "${pluginName}" registered OBO task "${taskName}" with autoRecover=true. ` +
+          "After restart, recovery runs without the original UserContext and OBO calls " +
+          "will fail. Register with `autoRecover: false` and call `task.resume()` " +
+          "from a fresh authenticated request.",
+      );
+    }
+  }
+
+  const wantTraces = settings.telemetry?.traces ?? true;
+  // Spans: `tasks.<plugin>.<task>` (parent, submit + subscribe) and
+  // `tasks.start` (submit only). Subscribe stays under the parent —
+  // a per-event child span would be expensive for no extra signal.
+  const tracer = wantTraces ? telemetry.getTracer() : null;
+  const span = tracer?.startSpan(`tasks.${pluginName}.${taskName}`, {
+    attributes: {
+      "task.name": taskName,
+      "task.plugin_name": pluginName,
+      "task.obo": isObo,
+      "task.execute_mode": settings.executeMode ?? "at_least_once",
+    },
+  });
+
+  let idempotencyKey: string;
+  // Hoisted so the outer `finally` can release the bridge regardless
+  // of which branch unwinds.
+  let unregisterBridge: (() => void) | null = null;
+  try {
+    // `context` is the live executor sidecar — never serialised, never
+    // seen by recovery. Lets the task body re-enter `runInUserContext`
+    // without re-parsing headers.
+    const startSpan = tracer?.startSpan("tasks.start", {
+      attributes: {
+        "task.name": taskName,
+        "task.execute_mode": settings.executeMode ?? "at_least_once",
+      },
+    });
+    try {
+      const handle = await manager.start(taskName, input, {
+        userId,
+        context: userCtx ?? undefined,
+        executeMode: settings.executeMode,
+      });
+      idempotencyKey = handle.idempotencyKey;
+      startSpan?.setAttribute("task.idempotency_key", idempotencyKey);
+      startSpan?.setStatus({ code: SpanStatusCode.OK });
+    } catch (err) {
+      const message =
+        (err as { message?: string } | undefined)?.message ??
+        "task start failed";
+      startSpan?.setStatus({ code: SpanStatusCode.ERROR, message });
+      span?.setStatus({ code: SpanStatusCode.ERROR, message });
+      throw err;
+    } finally {
+      startSpan?.end();
+    }
+
+    span?.setAttribute("task.idempotency_key", idempotencyKey);
+
+    const sseRequest = res.req as express.Request | undefined;
+    const lastEventId = parseLastEventId(sseRequest);
+
+    if (!res.headersSent) {
+      // Dual surface: header for same-origin fetch, `ready` event for
+      // cross-origin EventSource (which can't read headers).
+      res.setHeader(TASK_IDEMPOTENCY_HEADER, idempotencyKey);
+      setupSseHeaders(res);
+      writeSseFrame(res, {
+        event: "ready",
+        data: JSON.stringify({ idempotencyKey }),
+      });
+    }
+
+    const cancelOnDisconnect = settings.cancelOnDisconnect ?? true;
+    const disconnectGraceMs = Math.max(0, settings.disconnectGraceMs ?? 5000);
+    let clientClosed = false;
+    sseRequest?.once?.("close", () => {
+      clientClosed = true;
+      if (!cancelOnDisconnect) return;
+      // Grace window so a "wifi blipped for 2 s" reconnect doesn't
+      // durably suspend the task.
+      setTimeout(() => {
+        manager
+          .stop(idempotencyKey, {
+            reason: "client_disconnected",
+            userId,
+          })
+          .catch((err: unknown) => {
+            logger.debug(
+              `task.stop after client disconnect failed for ${idempotencyKey}: %O`,
+              err,
+            );
+          });
+      }, disconnectGraceMs).unref?.();
+    });
+
+    // Register so the service can write a final `event: error` frame
+    // on shutdown before the engine closes the iterator.
+    const bridge: ActiveBridge = {
+      idempotencyKey,
+      drain: (reason) => {
+        clientClosed = true;
+        if (res.writableEnded) return;
+        try {
+          writeSseFrame(res, {
+            event: "error",
+            data: JSON.stringify({ message: reason }),
+          });
+        } catch {
+          // Response may already be in a bad state.
+        }
+        if (!res.writableEnded) res.end();
+      },
+    };
+    unregisterBridge = manager._registerBridge(bridge);
+
+    for await (const streamEvent of manager.subscribe(
+      idempotencyKey,
+      lastEventId,
+    )) {
+      if (clientClosed || res.writableEnded) break;
+
+      const rawType = streamEvent.event.eventType;
+
+      // Heartbeats are wire-level keep-alives — emit as SSE comment so
+      // proxies don't drop idle sockets without leaking to the client.
+      if (rawType === "heartbeat") {
+        writeSseComment(res, "hb");
+        continue;
+      }
+
+      // `step:*` checkpoints are WAL-only (consumed by `step()` on
+      // recovery). The `step:` prefix is reserved — a plugin emitting
+      // `ctx.emit("step:foo", ...)` will be filtered here too.
+      if (typeof rawType === "string" && rawType.startsWith("custom:step:")) {
+        continue;
+      }
+
+      // Engine prefixes user events with `custom:`; strip for the wire.
+      const isCustom =
+        typeof rawType === "string" && rawType.startsWith("custom:");
+      const strippedName = isCustom
+        ? rawType.slice("custom:".length)
+        : (rawType ?? "message");
+
+      // Reserved-name guard: a plugin emitting `completed` would close
+      // the EventSource on the client while the engine keeps publishing.
+      // Engine-emitted reserved events (`isCustom === false`) pass.
+      if (isCustom && RESERVED_BRIDGE_EVENT_NAMES.has(strippedName)) {
+        logger.warn(
+          `Plugin "${pluginName}" task "${taskName}" emitted reserved event ` +
+            `name "${strippedName}" — refusing to forward.`,
+        );
+        continue;
+      }
+      const eventName = strippedName;
+
+      let data: string;
+      try {
+        // `bigintReplacer`: warehouse `LONG`/`BIGINT` columns surface as
+        // JS `BigInt`, which `JSON.stringify` rejects with `TypeError`.
+        data = JSON.stringify(streamEvent.event.payload ?? {}, bigintReplacer);
+      } catch (err) {
+        logger.warn(
+          `Failed to serialise event payload for "${taskName}" (event=${rawType}): %O`,
+          err,
+        );
+        data = "{}";
+      }
+
+      try {
+        // `streamSeq` as SSE `id:` so `Last-Event-ID` reconnects resume
+        // from the WAL via `manager.subscribe(ik, lastSeq)`.
+        writeSseFrame(res, {
+          id: streamEvent.streamSeq,
+          event: eventName,
+          data,
+        });
+      } catch (err) {
+        logger.debug("SSE write failed; closing stream", err);
+        break;
+      }
+
+      if (
+        rawType === "completed" ||
+        rawType === "failed" ||
+        rawType === "cancelled"
+      ) {
+        break;
+      }
+    }
+
+    if (!res.writableEnded) res.end();
+    span?.setStatus({ code: SpanStatusCode.OK });
+  } catch (err) {
+    span?.setStatus({
+      code: SpanStatusCode.ERROR,
+      message:
+        (err as { message?: string } | undefined)?.message ??
+        "executeTask failed",
+    });
+    if (!res.headersSent) {
+      const isProd = process.env.NODE_ENV === "production";
+      const message = isProd
+        ? "Server error"
+        : ((err as { message?: string } | undefined)?.message ??
+          "executeTask failed");
+      res.status(500).json({ error: message });
+    } else if (!res.writableEnded) {
+      // In-band SSE error. Redact the message in production so handler
+      // exceptions (stacks, paths, secrets) don't reach the wire.
+      try {
+        const isProd = process.env.NODE_ENV === "production";
+        const message = isProd
+          ? "Server error"
+          : ((err as { message?: string } | undefined)?.message ?? "");
+        writeSseFrame(res, {
+          event: "error",
+          data: JSON.stringify({ message }),
+        });
+      } catch {
+        // Ignore.
+      }
+      res.end();
+    }
+    logger.error(
+      `executeTask("${taskName}") failed for plugin "${pluginName}": %O`,
+      err,
+    );
+    throw err;
+  } finally {
+    unregisterBridge?.();
+    span?.end();
+  }
+}
+
+function parseLastEventId(
+  req: express.Request | undefined,
+): number | undefined {
+  const raw = req?.header?.("last-event-id") ?? req?.header?.("Last-Event-ID");
+  if (!raw) return undefined;
+  const parsed = parseInt(String(raw), 10);
+  if (!Number.isFinite(parsed)) return undefined;
+  // Clamp: negative values rewind past the WAL retention prefix
+  // (used to infinite-loop on subscribe), and engine seq comparisons
+  // lose precision past 2^53. Engine still validates against its own
+  // retention window — this just stops the obvious abuse at the FFI.
+  if (parsed < 0 || parsed > Number.MAX_SAFE_INTEGER) return undefined;
+  return parsed;
+}
+
+/** Serialises `BigInt` as string. Warehouse `LONG`/`BIGINT` columns. */
+function bigintReplacer(_key: string, value: unknown): unknown {
+  return typeof value === "bigint" ? value.toString() : value;
+}
+
+/**
+ * Settings for `Plugin.executeTask`. Deliberately disjoint from
+ * `PluginExecutionSettings`: the task engine handles retry / dedup /
+ * timeout natively, so those knobs are typed `never` to fail at
+ * compile time.
+ *
+ * @example
+ * ```ts
+ * await this.executeTask(res, "agent-loop", req.body, {
+ *   cancelOnDisconnect: false, // long-running OBO tasks survive reconnect
+ * });
+ * ```
+ *
+ * @public
+ */
+export interface ExecuteTaskSettings {
+  /**
+   * Issue cooperative `task.stop()` when the SSE client disconnects.
+   * Default `true`. Set `false` for OBO tasks the user reconnects to
+   * (engine keeps writing the WAL; reconnects replay via `Last-Event-ID`).
+   *
+   * Note: OBO tokens expire in 1 hour. For longer runs, register with
+   * `autoRecover: false` and resume from a fresh authenticated request.
+   */
+  cancelOnDisconnect?: boolean;
+  /**
+   * Grace window before `task.stop()` after client close. Default
+   * `5000`. Bridges the "wifi blipped for 2 s" reconnect case. Set `0`
+   * for cancel-immediately.
+   */
+  disconnectGraceMs?: number;
+  /**
+   * Idempotency strictness for `engine.submit`.
+   *
+   * - `at_least_once` (default): cache-backed dedup, fast path. Two
+   *   pods may both submit within the cache window — fine for
+   *   idempotent reads.
+   * - `at_most_once`: queries storage before creating the task, so
+   *   cross-pod uniqueness holds. Use for non-idempotent side effects
+   *   (DML, external writes, billing). Costs single-digit ms on submit.
+   *
+   * Cross-pod uniqueness requires a shared storage backend
+   * (`storage.backend: "lakebase"`) — default per-pod SQLite cannot
+   * coordinate.
+   */
+  executeMode?: "at_least_once" | "at_most_once";
+  telemetry?: {
+    /** Default: true. */
+    traces?: boolean;
+    /** Default: true. */
+    metrics?: boolean;
+  };
+
+  // Typed `never`: rejected at compile time so a settings object copied
+  // from `execute()` / `executeStream()` errors clearly.
+
+  /** Forbidden: the task engine handles retry via `recover` on `TaskDefinition`. */
+  retry?: never;
+  /** Forbidden: the task engine dedupes by idempotency key. */
+  cache?: never;
+  /** Forbidden: the task engine uses cooperative `stop()` + `staleThresholdMs`. */
+  timeout?: never;
+  /** Forbidden: wire shape is fixed by what the handler emits. */
+  stream?: never;
+  /**
+   * Forbidden: identity comes from the active `runInUserContext` scope
+   * (`asUser(req)` proxy). Accepting a raw `userId` would let callers
+   * forge ownership for `stop()` / `resume()`.
+   */
+  userId?: never;
+}

--- a/packages/appkit/src/tasks/index.ts
+++ b/packages/appkit/src/tasks/index.ts
@@ -1,2 +1,26 @@
+/**
+ * @public
+ * Durable execution. Enabled by passing `task: true` or an explicit task
+ * config to `createApp`; exposed to plugins as `this.task`.
+ */
+
+export type {
+  ResumeOptions,
+  StopOptions,
+  StreamEvent,
+  SubmitOptions,
+  Task,
+  TaskContext,
+  TaskEvent,
+  TaskHandle,
+} from "../../vendor/taskflow/taskflow.js";
 export type { TaskConfig, TaskOption } from "./defaults";
+export {
+  type ExecuteTaskSettings,
+  executeTask,
+  TASK_IDEMPOTENCY_HEADER,
+} from "./execute-task";
 export { TaskManager } from "./manager";
+export { type SseEvent, setupSseHeaders, writeSseFrame } from "./sse";
+export { step } from "./step";
+export type { TaskDefinition, TaskRef, TypedTaskContext } from "./types";

--- a/packages/appkit/src/tasks/manager.ts
+++ b/packages/appkit/src/tasks/manager.ts
@@ -13,6 +13,7 @@ import type {
   StreamEvent,
   SubmitOptions,
   Task,
+  TaskContext,
   Engine as TaskflowEngine,
   TaskHandle,
 } from "../../vendor/taskflow/taskflow.js";
@@ -24,9 +25,48 @@ import {
   type TelemetryProvider,
 } from "../telemetry";
 import { mergeTaskDefaults, type TaskOption } from "./defaults";
+import type {
+  ActiveBridge,
+  TaskDefinition,
+  TaskHandleRef,
+  TaskRegistrationRecord,
+} from "./types";
 import { loadVendorModule } from "./vendor-loader";
 
 const logger = createLogger("tasks");
+
+/**
+ * Build the registration options object passed to the vendor engine's
+ * `registerTask`. Validates `recoveryMaxAgeMs` so a bad value surfaces
+ * at registration time rather than as an opaque native error.
+ */
+function buildRegisterOpts(definition: {
+  name: string;
+  autoRecover?: boolean;
+  recoveryMaxAgeMs?: number;
+}): { autoRecover?: boolean; recoveryMaxAgeMs?: number } | null {
+  const opts: { autoRecover?: boolean; recoveryMaxAgeMs?: number } = {};
+  if (definition.autoRecover !== undefined) {
+    opts.autoRecover = definition.autoRecover;
+  }
+  if (definition.recoveryMaxAgeMs !== undefined) {
+    const v = definition.recoveryMaxAgeMs;
+    if (
+      typeof v !== "number" ||
+      !Number.isFinite(v) ||
+      !Number.isInteger(v) ||
+      v < 0
+    ) {
+      throw new Error(
+        `task '${definition.name}': recoveryMaxAgeMs must be a non-negative integer (got ${String(
+          v,
+        )})`,
+      );
+    }
+    opts.recoveryMaxAgeMs = v;
+  }
+  return Object.keys(opts).length === 0 ? null : opts;
+}
 
 interface TaskCounters {
   starts: Counter;
@@ -49,6 +89,8 @@ export class TaskManager {
 
   private readonly telemetry: TelemetryProvider;
   private readonly metrics: TaskCounters;
+  private readonly registrations = new Map<string, TaskRegistrationRecord>();
+  private readonly activeBridges = new Set<ActiveBridge>();
   private hasShutdown = false;
 
   private constructor(engine: TaskflowEngine) {
@@ -114,6 +156,109 @@ export class TaskManager {
   /** Returns the live instance or `null` when tasks are not enabled. */
   static getInstanceSync(): TaskManager | null {
     return TaskManager._instance;
+  }
+
+  /**
+   * Registers a durable task. Call from the plugin's `setup()` hook
+   * with handlers bound to the plugin instance. `TEvents` constrains
+   * `ctx.emit(name, payload)`, which is also the SSE wire shape.
+   *
+   * @example
+   * ```ts
+   * type AgentEvents = { turn_done: { turn: number; result: string } };
+   *
+   * this.task.task<AgentInput, AgentOutput, AgentEvents>({
+   *   name: "agent-loop",
+   *   execute: async (input, ctx) => {
+   *     await ctx.emit("turn_done", { turn: 1, result: "ok" });
+   *   },
+   *   autoRecover: false,
+   * });
+   * ```
+   */
+  task<
+    TInput = unknown,
+    TResult = unknown,
+    TEvents extends Record<string, unknown> = Record<string, unknown>,
+  >(
+    definition: TaskDefinition<TInput, TResult, TEvents>,
+  ): TaskHandleRef<TInput, TResult, TEvents> {
+    this.assertAlive();
+    if (this.registrations.has(definition.name)) {
+      // Throw in prod so a duplicate doesn't silently shadow the first
+      // handler (recovery worker would route in-flight tasks to a stale
+      // closure). Warn-only in dev so HMR loops keep working.
+      const message = `Task "${definition.name}" is already registered.`;
+      if (process.env.NODE_ENV === "production") {
+        throw new Error(message);
+      }
+      logger.warn(`${message} (allowed in non-production)`);
+    }
+    // TODO(taskflow#engine-binding-reconciliation): vendored
+    // `registerTask` is positional at runtime even though the .d.ts
+    // documents the object form. `TypedTaskContext` is compile-time
+    // only — at runtime emit is unconstrained `(string, any)`.
+    const recoverFn = definition.recover ?? null;
+    const registerOpts = buildRegisterOpts(definition);
+    (
+      this.engine as unknown as {
+        registerTask(
+          n: string,
+          exec: (input: unknown, ctx: TaskContext) => Promise<unknown>,
+          recover:
+            | ((input: unknown, ctx: TaskContext) => Promise<unknown>)
+            | null,
+          opts: { autoRecover?: boolean; recoveryMaxAgeMs?: number } | null,
+        ): void;
+      }
+    ).registerTask(
+      definition.name,
+      definition.execute as unknown as (
+        input: unknown,
+        ctx: TaskContext,
+      ) => Promise<unknown>,
+      recoverFn as unknown as
+        | ((input: unknown, ctx: TaskContext) => Promise<unknown>)
+        | null,
+      registerOpts,
+    );
+    this.registrations.set(definition.name, {
+      autoRecover: definition.autoRecover ?? true,
+      hasRecover: typeof definition.recover === "function",
+      recoveryMaxAgeMs: definition.recoveryMaxAgeMs,
+    });
+    return { name: definition.name } as TaskHandleRef<TInput, TResult, TEvents>;
+  }
+
+  /** Process-local lookup; not cross-pod. */
+  hasTask(name: string): boolean {
+    return this.registrations.has(name);
+  }
+
+  /** Used by `executeTask` to surface OBO misconfigurations. @internal */
+  getRegistration(name: string): TaskRegistrationRecord | undefined {
+    return this.registrations.get(name);
+  }
+
+  /**
+   * Registers an SSE bridge so shutdown can drain it with a graceful
+   * `event: error` / `server_shutting_down` frame before the engine
+   * closes the subscription. Returns an unregister callback.
+   * @internal
+   */
+  _registerBridge(bridge: ActiveBridge): () => void {
+    if (this.hasShutdown) {
+      try {
+        bridge.drain("server_shutting_down");
+      } catch (err) {
+        logger.debug("Bridge drain after shutdown threw: %O", err);
+      }
+      return () => {};
+    }
+    this.activeBridges.add(bridge);
+    return () => {
+      this.activeBridges.delete(bridge);
+    };
   }
 
   /**
@@ -233,6 +378,24 @@ export class TaskManager {
     if (this.hasShutdown) return;
     this.hasShutdown = true;
     logger.info("Shutting down task engine");
+    // Drain bridges before the engine — otherwise iterators close and
+    // clients see a silent EOF instead of an actionable error frame.
+    if (this.activeBridges.size > 0) {
+      logger.debug(
+        `Draining ${this.activeBridges.size} active SSE bridge(s) before engine shutdown`,
+      );
+      for (const bridge of this.activeBridges) {
+        try {
+          bridge.drain("server_shutting_down");
+        } catch (err) {
+          logger.debug(
+            `Bridge drain failed for IK ${bridge.idempotencyKey}: %O`,
+            err,
+          );
+        }
+      }
+      this.activeBridges.clear();
+    }
     await this.engine.shutdown();
     if (TaskManager._instance === this) {
       TaskManager._instance = null;

--- a/packages/appkit/src/tasks/sse.ts
+++ b/packages/appkit/src/tasks/sse.ts
@@ -1,0 +1,126 @@
+/**
+ * SSE wire format for the task bridge. Uses the engine `streamSeq` as
+ * the SSE `id:` so client `Last-Event-ID` reconnects resume from the WAL.
+ */
+import type { Response } from "express";
+
+/**
+ * Event names the bridge writes itself, or that collide with engine
+ * terminal frames. Plugin code must NOT emit these via `ctx.emit` —
+ * `event: completed` would close the EventSource on the client.
+ * @internal
+ */
+export const RESERVED_BRIDGE_EVENT_NAMES = new Set<string>([
+  // Bridge-internal frames.
+  "ready",
+  "error",
+  // Engine wire vocabulary.
+  "heartbeat",
+  "completed",
+  "failed",
+  "cancelled",
+  "suspended",
+]);
+
+/**
+ * SSE frame. `data` is pre-serialised so callers can emit JSON, plain
+ * text, or anything else without the writer touching the payload.
+ * @public
+ */
+export interface SseEvent {
+  /** SSE `event:` field name (e.g. "tick", "completed", "data"). */
+  event: string;
+  /** Pre-serialised payload for the SSE `data:` field. */
+  data: string;
+  /**
+   * Optional SSE `id:` echoed back via `Last-Event-ID` on reconnect.
+   * The bridge sets it to the engine `streamSeq`.
+   */
+  id?: string | number;
+}
+
+/**
+ * SSE injection guard: event names live on a single line, so embedded
+ * CR/LF would let an attacker close one event and start another. Refuse
+ * rather than strip — caller has a bug to fix.
+ * @internal
+ */
+function assertSafeEventName(name: string): void {
+  if (/[\r\n]/.test(name)) {
+    throw new Error(
+      `SSE event name must not contain CR/LF: ${JSON.stringify(name)}`,
+    );
+  }
+}
+
+/** Same rationale as {@link assertSafeEventName}. @internal */
+function assertSafeId(id: string | number): void {
+  if (typeof id === "number") return;
+  if (/[\r\n]/.test(id)) {
+    throw new Error(`SSE id must not contain CR/LF: ${JSON.stringify(id)}`);
+  }
+}
+
+/**
+ * Re-encode `data` as one or more `data:` lines per the SSE spec.
+ * EventSource joins them with `\n`, so multi-line payloads round-trip
+ * losslessly while every wire line still starts with `data:` (denies
+ * the "embedded CRLF dispatches a synthetic event" attack).
+ * @internal
+ */
+function formatDataField(data: string): string {
+  return data
+    .replace(/\r\n?/g, "\n")
+    .split("\n")
+    .map((line) => `data: ${line}`)
+    .join("\n");
+}
+
+/**
+ * Writes the SSE handshake (200 + content type + cache controls).
+ * `flushHeaders()` so intermediaries see the response start before the
+ * first event lands. `Vary: Origin` so a CDN that caches an SSE
+ * response (despite `no-cache`) cannot serve it cross-origin.
+ * @public
+ */
+export function setupSseHeaders(res: Response): void {
+  if (res.headersSent) return;
+  res.statusCode = 200;
+  res.setHeader("Content-Type", "text/event-stream; charset=utf-8");
+  res.setHeader("Cache-Control", "no-cache, no-transform");
+  // Disables nginx-style proxy buffering used by Cloudflare / AWS / GCP.
+  res.setHeader("X-Accel-Buffering", "no");
+  res.setHeader("Vary", "Origin");
+  res.flushHeaders?.();
+}
+
+/**
+ * Writes one SSE frame. Returns `false` once the response has ended so
+ * callers can break out of the subscribe loop. Throws on CR/LF in
+ * `event` / `id` (header-injection style).
+ * @public
+ */
+export function writeSseFrame(res: Response, frame: SseEvent): boolean {
+  if (res.writableEnded) return false;
+  assertSafeEventName(frame.event);
+  if (frame.id !== undefined && frame.id !== null) {
+    assertSafeId(frame.id);
+    res.write(`id: ${frame.id}\n`);
+  }
+  res.write(`event: ${frame.event}\n`);
+  res.write(`${formatDataField(frame.data)}\n\n`);
+  return true;
+}
+
+/**
+ * Writes an SSE comment (`: <text>\n\n`). Ignored by EventSource but
+ * keeps the connection alive through proxies that drop idle sockets.
+ * Used by the bridge to translate engine `heartbeat` into wire
+ * keep-alives without surfacing them as application events.
+ * @internal
+ */
+export function writeSseComment(res: Response, text: string): boolean {
+  if (res.writableEnded) return false;
+  res.write(`: ${text}\n\n`);
+  return true;
+}

--- a/packages/appkit/src/tasks/step.ts
+++ b/packages/appkit/src/tasks/step.ts
@@ -1,0 +1,85 @@
+import type { TaskContext } from "../../vendor/taskflow/taskflow.js";
+import { InitializationError } from "../errors";
+import { getCachedVendorSync } from "./vendor-loader";
+
+/**
+ * Wraps an async function as an idempotent WAL-keyed checkpoint inside
+ * a durable task. On recovery, completed steps short-circuit to the
+ * cached result instead of re-executing — use this for expensive /
+ * unsafe-to-replay stages (LLM calls, large queries, external I/O).
+ *
+ * **Naming matters**: the WAL key is `Function.name`, so anonymous
+ * arrows all collide on `""`. `step(fn)` requires a non-empty `.name`
+ * (named declaration or `const x = step(...)` assignment);
+ * `step("name", fn)` overrides it explicitly.
+ *
+ * Lazily resolves the engine primitive on first invocation so module-
+ * scope `const x = step(...)` works before `createApp` has booted.
+ *
+ * @example
+ * ```ts
+ * const fetchInvoices = step("fetch-invoices", async (ctx, id: string) =>
+ *   invoiceClient.list({ accountId: id }),
+ * );
+ * ```
+ *
+ * @public
+ */
+export function step<TArgs extends unknown[], TResult>(
+  name: string,
+  fn: (ctx: TaskContext, ...args: TArgs) => Promise<TResult>,
+): (ctx: TaskContext, ...args: TArgs) => Promise<TResult>;
+export function step<TArgs extends unknown[], TResult>(
+  fn: (ctx: TaskContext, ...args: TArgs) => Promise<TResult>,
+): (ctx: TaskContext, ...args: TArgs) => Promise<TResult>;
+export function step<TArgs extends unknown[], TResult>(
+  nameOrFn: string | ((ctx: TaskContext, ...args: TArgs) => Promise<TResult>),
+  maybeFn?: (ctx: TaskContext, ...args: TArgs) => Promise<TResult>,
+): (ctx: TaskContext, ...args: TArgs) => Promise<TResult> {
+  let stepName: string;
+  let target: (ctx: TaskContext, ...args: TArgs) => Promise<TResult>;
+  if (typeof nameOrFn === "string") {
+    if (!nameOrFn) {
+      throw new Error("step(name, fn): name must be non-empty.");
+    }
+    if (typeof maybeFn !== "function") {
+      throw new Error("step(name, fn): missing function argument.");
+    }
+    stepName = nameOrFn;
+    const renamed = (...args: Parameters<typeof maybeFn>) => maybeFn(...args);
+    Object.defineProperty(renamed, "name", { value: stepName });
+    target = renamed as typeof maybeFn;
+  } else {
+    if (!nameOrFn.name) {
+      throw new Error(
+        'step(fn): wrapped function has empty `.name` — would collide with other anonymous steps in the WAL. Use `const x = step(...)` or pass an explicit name via `step("my-step", fn)`.',
+      );
+    }
+    stepName = nameOrFn.name;
+    target = nameOrFn;
+  }
+
+  let memoized:
+    | ((ctx: TaskContext, ...args: TArgs) => Promise<TResult>)
+    | null = null;
+  const trampoline = (ctx: TaskContext, ...args: TArgs): Promise<TResult> => {
+    if (!memoized) {
+      const vendor = getCachedVendorSync();
+      if (!vendor) {
+        throw InitializationError.notInitialized(
+          "TaskManager",
+          `step("${stepName}") ran before the task engine initialised — call it inside a registered task body.`,
+        );
+      }
+      memoized = vendor.workflow.step(
+        target as unknown as (
+          ctx: TaskContext,
+          ...args: unknown[]
+        ) => Promise<unknown>,
+      ) as unknown as (ctx: TaskContext, ...args: TArgs) => Promise<TResult>;
+    }
+    return memoized(ctx, ...args);
+  };
+  Object.defineProperty(trampoline, "name", { value: stepName });
+  return trampoline;
+}

--- a/packages/appkit/src/tasks/types.ts
+++ b/packages/appkit/src/tasks/types.ts
@@ -1,0 +1,100 @@
+import type { TaskContext, TaskEvent } from "../../vendor/taskflow/taskflow.js";
+
+/**
+ * `TaskContext` whose `emit` is narrowed to a declared event-name →
+ * payload-shape map. Plugins opt in via the `TEvents` parameter on
+ * {@link TaskDefinition}; the default keeps the engine's looser
+ * `(string, any)` shape.
+ *
+ * @public
+ */
+export interface TypedTaskContext<TEvents extends Record<string, unknown>>
+  extends Omit<TaskContext, "emit"> {
+  emit<K extends keyof TEvents & string>(
+    name: K,
+    payload: TEvents[K],
+  ): Promise<void>;
+}
+
+/**
+ * Durable task registration accepted by {@link TaskManager.task}.
+ * `TEvents` ties `ctx.emit(name, payload)` to a typed map — those names
+ * and shapes are exactly the SSE wire frames the client sees.
+ *
+ * @public
+ */
+export interface TaskDefinition<
+  TInput = unknown,
+  TResult = unknown,
+  TEvents extends Record<string, unknown> = Record<string, unknown>,
+> {
+  name: string;
+  execute(input: TInput, ctx: TypedTaskContext<TEvents>): Promise<TResult>;
+  recover?(input: TInput, ctx: TypedTaskContext<TEvents>): Promise<TResult>;
+  autoRecover?: boolean;
+  /**
+   * Registration-time override for `engine.recoveryMaxAgeMs` scoped to
+   * this task. Tasks whose age exceeds this deadline are atomically
+   * failed by TaskFlow before any recovery or auto-resume attempt; on
+   * the submit path TaskFlow then admits a fresh task under the same
+   * content-addressed idempotency key. `0` disables recovery for this
+   * task type (always fail-and-readmit). Omit to defer to the engine
+   * default.
+   *
+   * Runtime policy only — never participates in the idempotency key.
+   */
+  recoveryMaxAgeMs?: number;
+}
+
+/**
+ * Branded handle returned by {@link TaskManager.task}. Carries the
+ * registered name plus phantom type parameters so callers that take
+ * `TaskRef | string` can infer input and event shapes without a
+ * redundant generic.
+ *
+ * @public
+ */
+export interface TaskHandleRef<
+  TInput = unknown,
+  TResult = unknown,
+  TEvents extends Record<string, unknown> = Record<string, unknown>,
+> {
+  readonly name: string;
+  /** Phantom marker dragging `TInput`/`TResult`/`TEvents` into the type. Never read at runtime. @internal */
+  readonly __taskTypes?: {
+    input: TInput;
+    result: TResult;
+    events: TEvents;
+  };
+}
+
+/** Convenience alias for {@link TaskHandleRef}. @public */
+export type TaskRef<
+  TInput = unknown,
+  TResult = unknown,
+  TEvents extends Record<string, unknown> = Record<string, unknown>,
+> = TaskHandleRef<TInput, TResult, TEvents>;
+
+/** Captured per-registration so we can surface diagnostics (OBO + autoRecover). @internal */
+export interface TaskRegistrationRecord {
+  autoRecover: boolean;
+  hasRecover: boolean;
+  /** Resolved registration-time recovery-TTL override, if any. @internal */
+  recoveryMaxAgeMs?: number;
+}
+
+/**
+ * Active SSE bridge handle. The service keeps a set of these so it can
+ * drain in-flight bridges (write a final `event: error` frame) before
+ * the engine closes their iterators on shutdown.
+ * @internal
+ */
+export interface ActiveBridge {
+  /** For log context only — never used for ownership. */
+  idempotencyKey: string;
+  /** Best-effort: write SSE error frame, stop subscribing. Errors are swallowed. */
+  drain(reason: string): void;
+}
+
+/** Re-exported for callers that work with raw engine events. @public */
+export type { TaskEvent };

--- a/packages/appkit/src/tasks/vendor-loader.ts
+++ b/packages/appkit/src/tasks/vendor-loader.ts
@@ -9,6 +9,16 @@ type VendorModule = typeof import("../../vendor/taskflow/taskflow.js");
 
 let cachedVendor: VendorModule | null = null;
 
+/**
+ * Returns the loaded vendor module without awaiting — `null` until
+ * {@link loadVendorModule} has resolved at least once. Callers must
+ * already be inside a task body (where the engine has booted).
+ * @internal
+ */
+export function getCachedVendorSync(): VendorModule | null {
+  return cachedVendor;
+}
+
 interface VendorManifest {
   name?: string;
   version?: string;

--- a/tools/test-helpers.ts
+++ b/tools/test-helpers.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type { Span, SpanOptions } from "@opentelemetry/api";
 import type { IAppRouter } from "shared";
 import { vi } from "vitest";
@@ -314,32 +315,50 @@ export async function runWithRequestContext<T>(
 }
 
 /**
- * Parses SSE response. Format: "event: result\ndata: {...}\n\n"
+ * Parses an SSE response body and returns one frame's data merged with
+ * `{ eventType }`. Handles multi-line `data:` payloads, CRLF, and SSE
+ * comments. Pass `eventType` to pick a specific frame; without it, the
+ * last frame wins.
  */
-export async function parseSSEResponse(response: Response): Promise<any> {
-  const text = await response.text();
-  const lines = text.split("\n");
+export async function parseSSEResponse(
+  response: Response,
+  options: { eventType?: string } = {},
+): Promise<any> {
+  const text = (await response.text()).replace(/\r\n?/g, "\n");
+  const target = options.eventType;
 
-  let eventType: string | null = null;
-  let dataLine: string | null = null;
+  let chosenEventType: string | null = null;
+  let chosenDataLines: string[] | null = null;
+  let lastEventType: string | null = null;
+  let lastDataLines: string[] | null = null;
 
-  for (const line of lines) {
-    if (line.startsWith("event: ")) {
-      eventType = line.substring(7).trim();
-    } else if (line.startsWith("data: ")) {
-      dataLine = line.substring(6);
+  for (const frame of text.split("\n\n")) {
+    let eventType: string | null = null;
+    const dataLines: string[] = [];
+    for (const line of frame.split("\n")) {
+      if (line.startsWith(":")) continue;
+      if (line.startsWith("event: ")) eventType = line.substring(7).trim();
+      else if (line.startsWith("data: ")) dataLines.push(line.substring(6));
+    }
+    if (dataLines.length === 0) continue;
+    lastEventType = eventType;
+    lastDataLines = dataLines;
+    if (target && eventType === target) {
+      chosenEventType = eventType;
+      chosenDataLines = dataLines;
     }
   }
 
-  if (!dataLine) {
-    throw new Error(`No data found in SSE response: ${text}`);
+  const eventType = target ? chosenEventType : lastEventType;
+  const dataLines = target ? chosenDataLines : lastDataLines;
+
+  if (!dataLines || dataLines.length === 0) {
+    throw new Error(
+      `No ${target ? `${target} ` : ""}data found in SSE response: ${text}`,
+    );
   }
 
-  const parsed = JSON.parse(dataLine);
-  return {
-    eventType,
-    ...parsed,
-  };
+  return { eventType, ...JSON.parse(dataLines.join("\n")) };
 }
 
 export function createConfigurableMockWorkspaceClient() {
@@ -393,4 +412,213 @@ export function createFailedSQLResponse(errorMessage: string) {
     },
     statement_id: `stmt-${Date.now()}`,
   };
+}
+
+/**
+ * In-process stand-in for `TaskManager` that runs the handler directly
+ * inside `subscribe()` instead of through the vendored Rust engine.
+ * Use for unit tests where the real engine (SQLite WAL, recovery
+ * worker, FFI sidecar) is overkill.
+ *
+ * - `start()` keys runs by an engine-shaped IK
+ *   (`sha256(name || canon(input) || userId)`).
+ * - `subscribe()` yields every `ctx.emit(name, payload)` as
+ *   `custom:<name>` then a single `completed` / `failed` terminal.
+ * - `_emitHeartbeat` / `_emitStepCheckpoint` exercise the bridge
+ *   filters without booting the engine.
+ *
+ * Skips real recovery, storage dedup, and IK-cache eviction — for
+ * those, run against `createApp(...)`.
+ */
+export function createStubTaskManager() {
+  type TaskDef = {
+    name: string;
+    execute: (input: unknown, ctx: any) => Promise<unknown>;
+    recover?: (input: unknown, ctx: any) => Promise<unknown>;
+    autoRecover?: boolean;
+  };
+
+  const tasks = new Map<string, TaskDef>();
+  const stashedRuns = new Map<
+    string,
+    {
+      name: string;
+      input: unknown;
+      opts: { userId?: string; context?: unknown };
+    }
+  >();
+  /** Pre-injected events keyed by IK; yielded ahead of handler events. */
+  const injectedEvents = new Map<
+    string,
+    Array<{ event: any; streamSeq: number }>
+  >();
+  let seq = 0;
+
+  // Mirrors the engine IK shape (sha256 hex; the engine emits base64
+  // but tests only need stable equality, not byte-for-byte parity).
+  const canonicalize = (value: unknown): string => {
+    if (value === null || value === undefined) return "null";
+    if (typeof value !== "object") return JSON.stringify(value);
+    if (Array.isArray(value)) {
+      return `[${value.map(canonicalize).join(",")}]`;
+    }
+    const keys = Object.keys(value as Record<string, unknown>).sort();
+    const parts = keys.map(
+      (k) =>
+        `${JSON.stringify(k)}:${canonicalize((value as Record<string, unknown>)[k])}`,
+    );
+    return `{${parts.join(",")}}`;
+  };
+  const computeIK = (name: string, input: unknown, userId?: string) => {
+    const payload = `${name}|${canonicalize(input)}|${userId ?? ""}`;
+    return createHash("sha256").update(payload).digest("hex");
+  };
+
+  const stub = {
+    task: vi.fn((def: TaskDef) => {
+      tasks.set(def.name, def);
+    }),
+
+    start: vi.fn(
+      async (
+        name: string,
+        input: unknown,
+        opts: { userId?: string; context?: unknown } = {},
+      ) => {
+        const ik = computeIK(name, input, opts.userId);
+        stashedRuns.set(ik, { name, input, opts });
+        return { taskId: ik, idempotencyKey: ik };
+      },
+    ),
+
+    subscribe: vi.fn((ik: string) => {
+      const run = stashedRuns.get(ik);
+      const def = run ? tasks.get(run.name) : undefined;
+
+      return (async function* () {
+        if (!run || !def) return;
+
+        // Pre-injected events first (exercises bridge filters).
+        const pre = injectedEvents.get(ik);
+        if (pre) {
+          for (const e of pre) yield e;
+        }
+
+        const events: Array<{ event: any; streamSeq: number }> = [];
+        const ctx = {
+          taskId: ik,
+          idempotencyKey: ik,
+          userId: run.opts.userId ?? null,
+          attempt: 1,
+          previousEvents: [],
+          isRecovery: false,
+          context: run.opts.context ?? null,
+          emit: async (eventType: string, payload?: unknown) => {
+            events.push({
+              event: {
+                id: "",
+                taskId: ik,
+                idempotencyKey: ik,
+                seq: ++seq,
+                eventType: `custom:${eventType}`,
+                timestampMs: Date.now(),
+                payload,
+              },
+              streamSeq: seq,
+            });
+          },
+          heartbeat: async () => {},
+        };
+
+        try {
+          const result = await def.execute(run.input, ctx);
+          events.push({
+            event: {
+              id: "",
+              taskId: ik,
+              idempotencyKey: ik,
+              seq: ++seq,
+              eventType: "completed",
+              timestampMs: Date.now(),
+              payload: { result },
+            },
+            streamSeq: seq,
+          });
+        } catch (err) {
+          events.push({
+            event: {
+              id: "",
+              taskId: ik,
+              idempotencyKey: ik,
+              seq: ++seq,
+              eventType: "failed",
+              timestampMs: Date.now(),
+              payload: {
+                error: err instanceof Error ? err.message : String(err),
+              },
+            },
+            streamSeq: seq,
+          });
+        }
+
+        for (const e of events) yield e;
+      })();
+    }),
+
+    stop: vi.fn(async (ik: string) => ({ taskId: ik, idempotencyKey: ik })),
+    resume: vi.fn(async () => null),
+    reconnect: vi.fn(async () => null),
+    simulateCrash: vi.fn(),
+
+    hasTask: vi.fn((name: string) => tasks.has(name)),
+    getRegistration: vi.fn((name: string) => {
+      const t = tasks.get(name);
+      return t
+        ? { autoRecover: t.autoRecover ?? true, hasRecover: !!t.recover }
+        : undefined;
+    }),
+
+    // No-op: tests don't simulate shutdown drainage.
+    _registerBridge: vi.fn(() => () => {}),
+
+    /** Queue a `heartbeat` engine event ahead of handler events. */
+    _emitHeartbeat: (ik: string) => {
+      const list = injectedEvents.get(ik) ?? [];
+      list.push({
+        event: {
+          id: "",
+          taskId: ik,
+          idempotencyKey: ik,
+          seq: ++seq,
+          eventType: "heartbeat",
+          timestampMs: Date.now(),
+          payload: null,
+        },
+        streamSeq: seq,
+      });
+      injectedEvents.set(ik, list);
+    },
+
+    /** Queue a `custom:step:*` checkpoint event (WAL-only, dropped on the wire). */
+    _emitStepCheckpoint: (ik: string, name: string, value?: unknown) => {
+      const list = injectedEvents.get(ik) ?? [];
+      list.push({
+        event: {
+          id: "",
+          taskId: ik,
+          idempotencyKey: ik,
+          seq: ++seq,
+          eventType: `custom:step:${name}`,
+          timestampMs: Date.now(),
+          payload: value,
+        },
+        streamSeq: seq,
+      });
+      injectedEvents.set(ik, list);
+    },
+
+    shutdown: vi.fn(async () => {}),
+  };
+
+  return stub;
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/databricks/appkit/pull/378/files/e3956a8116e0f1950946c6bf46e158cef30c4523..0b9ea8f515b0f67e82be422f4d8ccf99337c6ba4) to review incremental changes.
- [stack/taskflow/service-registry](https://github.com/databricks/appkit/pull/374) [[Files changed](https://github.com/databricks/appkit/pull/374/files)]
  - [stack/taskflow/sql-warehouse-split](https://github.com/databricks/appkit/pull/375) [[Files changed](https://github.com/databricks/appkit/pull/375/files/079260ef5d6fa4dab69b2ca3e0ccc403812f385f..450d962002bb382a4018ba77fa570e1722ffa2bc)]
    - [stack/taskflow/taskflow-service](https://github.com/databricks/appkit/pull/376) [[Files changed](https://github.com/databricks/appkit/pull/376/files/450d962002bb382a4018ba77fa570e1722ffa2bc..e3956a8116e0f1950946c6bf46e158cef30c4523)]
      - [**stack/taskflow/execute-task**](https://github.com/databricks/appkit/pull/378) [[Files changed](https://github.com/databricks/appkit/pull/378/files/e3956a8116e0f1950946c6bf46e158cef30c4523..0b9ea8f515b0f67e82be422f4d8ccf99337c6ba4)]
        - [stack/taskflow/analytics-migration](https://github.com/databricks/appkit/pull/379) [[Files changed](https://github.com/databricks/appkit/pull/379/files/0b9ea8f515b0f67e82be422f4d8ccf99337c6ba4..4fd72ec3f32022118bb8ad17a5e42c41081b1157)]
          - [stack/taskflow/durable-task-demo](https://github.com/databricks/appkit/pull/380) [[Files changed](https://github.com/databricks/appkit/pull/380/files/4fd72ec3f32022118bb8ad17a5e42c41081b1157..97669ffc222015216e1f3ccd61103b0374d8878a)]
            - [stack/taskflow/production-hardening](https://github.com/databricks/appkit/pull/381) [[Files changed](https://github.com/databricks/appkit/pull/381/files/97669ffc222015216e1f3ccd61103b0374d8878a..e8a428102e9bd9a6af212d812ad7b8bf348226b4)]

---------
The public AppKit-side surface for TaskFlow durable execution. Plugin
authors can now register typed durable tasks
(`TaskDefinition<TInput, TOutput, TEvents>`), bridge them to SSE via
`this.executeTask(res, name, input, settings?)`, use `step()` for
replay-safe checkpoints, and route OBO identity automatically through
`runInUserContext` + `getCurrentUserContext`.

Public surface added under `packages/appkit/src/taskflow/`:

- `TypedTaskContext<TEvents>` — narrows `ctx.emit(name, payload)` to a
  declared event-name → payload-shape map so the SSE wire shape is
  typed end-to-end.
- `TaskDefinition<TInput, TResult, TEvents>` and
  `TaskHandleRef`/`TaskRef` — the registration object accepted by
  `taskflow.task(...)` and the branded handle it returns. Phantom
  generic parameters propagate to `executeTask` so input / event maps
  flow without redundant generics.
- `ExecuteTaskSettings` — strictly disjoint from `PluginExecutionSettings`.
  `retry`, `cache`, `timeout`, `stream`, and `userId` are typed as
  `never` so any caller copying a settings object from `execute()` /
  `executeStream()` gets a clear compile-time error. TaskFlow handles
  those concerns natively (smart recovery, IK dedup, cooperative
  `stop()`).
- `step(fn)` / `step("name", fn)` — workflow primitive with deferred
  binding (resolves the engine wrapper on first invocation so plugin
  authors can declare `const x = step(...)` at module scope) and an
  explicit guard against anonymous-arrow WAL key collisions.
- `setupSseHeaders`, `writeSseFrame`, `writeSseComment`,
  `RESERVED_BRIDGE_EVENT_NAMES`, `TASKFLOW_IK_HEADER` — SSE wire
  helpers with a CRLF guard on event names, multi-line \`data:\`
  framing, and \`Vary: Origin\` for cache safety.
- `userContextFromTaskCtx(ctx)` — reads the OBO `UserContext` from
  the FFI sidecar in `ctx.context`, with a discriminator check
  (`isUserContext`) so a stale or wrong-shape payload returns null
  instead of being trusted.

`executeTask` (lives in `taskflow/execute-task.ts`) implements the
durable bridge:

- Derives identity from `getCurrentUserContext()` only (never from
  request headers or settings) — `this.asUser(req).executeTask(...)`
  yields OBO, the bare call yields SP.
- Submits via `taskflow.start(...)` with the engine sidecar carrying
  the OBO `UserContext`, then bridges the WAL stream to SSE with
  `Last-Event-ID` replay support clamped to
  `[0, MAX_SAFE_INTEGER]`.
- Drops `custom:step:*` events (WAL-only checkpoints), translates
  `heartbeat` to SSE comments, and routes terminal events
  (`completed` / `failed` / `cancelled`) before closing.
- Reserved-name guard: plugin emissions whose name collides with the
  bridge wire vocabulary (`ready`, `completed`, `failed`, `error`,
  …) are dropped with `logger.warn`, never closing the stream.
- BigInt-safe JSON replacer (warehouse payloads round-trip cleanly).
- `cancelOnDisconnect` (default `true`) + `disconnectGraceMs`
  (default 5 s) — short reconnects don't kill the durable run.
- Production-safe error path: post-headers errors mask the message
  when `NODE_ENV=production`.

`TaskflowService` extensions in `taskflow/index.ts`:

- `task<TInput, TResult, TEvents>(def)` — typed registration with
  a hard-error on duplicate registration in production (silent
  shadowing was the prior failure mode); HMR warning in dev.
- `hasTask(name)` / `getRegistration(name)` — used by `executeTask`
  to surface OBO-misconfiguration diagnostics.
- `_registerBridge(bridge)` — bookkeeping for active SSE bridges so
  `shutdown()` can drain them with an explicit
  `event: error` / `server_shutting_down` frame *before* the engine
  closes iterators (otherwise the client sees mid-stream EOF).

Context layer:

- `getCurrentUserContext()` — public accessor for the active OBO
  `UserContext` (sugar for the same AsyncLocalStorage slot
  `isInUserContext()` already reads).

Plugin layer:

- `Plugin.executeTask(res, task, input, settings?)` — typed entry
  point. `task` accepts either a registered name (`string`) or a
  branded `TaskRef`. The method is deliberately NOT in
  `EXCLUDED_FROM_PROXY` so OBO routing via the `asUser` proxy works
  uniformly with `execute` / `executeStream`.

Tests scaffolding:

- `tools/test-helpers.ts` — `createStubTaskflowService` (in-process
  fake of the TaskFlow surface for unit tests; consumed by PR 5's
  analytics tests) and a robust `parseSSEResponse` upgrade (multi-line
  `data:` joining per the SSE spec, CRLF normalisation, comment
  skipping, `eventType` filtering).

Verify:

- `pnpm -r typecheck`, `pnpm build`, `pnpm test` (122 files, 2279
  tests) all green.
- `pnpm exec knip` clean (no unused exports or types).
- `pnpm exec biome check` clean on touched files.

Not in this PR. No plugin uses `executeTask` yet — analytics migration
is PR 5. No demo plugin — that's PR 6. No docs rewrite — that's PR 7.

Stacked on: stack/taskflow/taskflow-service (#376).

Signed-off-by: Victor Ditadi <victor.ditadi@databricks.com>
Signed-off-by: ditadi <victordperd@gmail.com>

