### PR TITLE
fix: add name field to genie manifest for non-interactive --set support

### DIFF
--- a/packages/appkit/src/plugins/genie/manifest.json
+++ b/packages/appkit/src/plugins/genie/manifest.json
@@ -14,6 +14,9 @@
           "id": {
             "env": "DATABRICKS_GENIE_SPACE_ID",
             "description": "Default Genie Space ID"
+          },
+          "name": {
+            "description": "Genie Space display name"
           }
         }
       }

--- a/template/appkit.plugins.json
+++ b/template/appkit.plugins.json
@@ -92,6 +92,9 @@
               "id": {
                 "env": "DATABRICKS_GENIE_SPACE_ID",
                 "description": "Default Genie Space ID"
+              },
+              "name": {
+                "description": "Genie Space display name"
               }
             }
           }


### PR DESCRIPTION
## Summary

- Adds `name` field to the genie plugin manifest (`fields` object) alongside the existing `id` field
- Updates both the per-plugin manifest and the template `appkit.plugins.json`

## Problem

`databricks apps init --set 'genie.genie-space.name=<value>'` fails with:

```
Error: plugin "genie" has no resource with key "genie-space" and field "name"
```

The CLI's `--set` validation checks fields against the AppKit manifest, which only declared `id` for genie spaces. However, the CLI generator needs both `id` and `name` to produce valid DABs `genie_space` YAML.

Every other multi-field plugin (lakebase/postgres, secret, database) already declares all its fields in the manifest. Genie was the only one missing a field.

## Testing

### Before (reproduce the bug on `main`)

```bash
# Non-interactive: fails with "has no resource with key "genie-space" and field "name""
dbx apps init --name test-app --features genie \
  --set 'genie.genie-space.id=SPACE123' \
  --set 'genie.genie-space.name=My Space' \
  --run none --deploy=false
```

### After (verify with this branch)

```bash
# Non-interactive with both fields: should succeed
dbx apps init --name test-app --features genie \
  --template /path/to/this/branch/template \
  --set 'genie.genie-space.id=SPACE123' \
  --set 'genie.genie-space.name=My Space' \
  --run none --deploy=false

# Non-interactive with only id: should error with "incomplete resource"
dbx apps init --name test-app --features genie \
  --template /path/to/this/branch/template \
  --set 'genie.genie-space.id=SPACE123' \
  --run none --deploy=false

# Interactive: should show Genie Space picker and complete normally
dbx apps init --features genie \
  --template /path/to/this/branch/template
```

This pull request and its description were written by Isaac.