### PR TITLE
feat(appkit): default analytics format to ARROW_STREAM (BREAKING)

### DIFF
--- a/apps/dev-playground/client/src/features/smart-dashboard/hooks/use-dashboard-data.ts
+++ b/apps/dev-playground/client/src/features/smart-dashboard/hooks/use-dashboard-data.ts
@@ -80,7 +80,7 @@ export function useDashboardData(filters: DashboardFilters) {
     data: kpisRaw,
     loading: kpisLoading,
     error: kpisError,
-  } = useAnalyticsQuery("dashboard_kpis", params) as {
+  } = useAnalyticsQuery("dashboard_kpis", params, { format: "JSON_ARRAY" }) as {
     data: KPIRawRow[] | null;
     loading: boolean;
     error: string | null;
@@ -90,7 +90,9 @@ export function useDashboardData(filters: DashboardFilters) {
     data: topZoneRaw,
     loading: topZoneLoading,
     error: topZoneError,
-  } = useAnalyticsQuery("dashboard_top_zone", params) as {
+  } = useAnalyticsQuery("dashboard_top_zone", params, {
+    format: "JSON_ARRAY",
+  }) as {
     data: TopZoneData[] | null;
     loading: boolean;
     error: string | null;
@@ -109,7 +111,9 @@ export function useDashboardData(filters: DashboardFilters) {
     data: tripsOverTime,
     loading: tripsLoading,
     error: tripsError,
-  } = useAnalyticsQuery("dashboard_trips_over_time", tripsParams) as {
+  } = useAnalyticsQuery("dashboard_trips_over_time", tripsParams, {
+    format: "JSON_ARRAY",
+  }) as {
     data: TripOverTime[] | null;
     loading: boolean;
     error: string | null;
@@ -119,7 +123,9 @@ export function useDashboardData(filters: DashboardFilters) {
     data: fareDistribution,
     loading: fareLoading,
     error: fareError,
-  } = useAnalyticsQuery("dashboard_fare_distribution", tripsParams) as {
+  } = useAnalyticsQuery("dashboard_fare_distribution", tripsParams, {
+    format: "JSON_ARRAY",
+  }) as {
     data: FareBucket[] | null;
     loading: boolean;
     error: string | null;
@@ -129,7 +135,9 @@ export function useDashboardData(filters: DashboardFilters) {
     data: heatmap,
     loading: heatmapLoading,
     error: heatmapError,
-  } = useAnalyticsQuery("dashboard_hourly_heatmap", params) as {
+  } = useAnalyticsQuery("dashboard_hourly_heatmap", params, {
+    format: "JSON_ARRAY",
+  }) as {
     data: HeatmapCell[] | null;
     loading: boolean;
     error: string | null;
@@ -139,7 +147,9 @@ export function useDashboardData(filters: DashboardFilters) {
     data: topZones,
     loading: topZonesLoading,
     error: topZonesError,
-  } = useAnalyticsQuery("dashboard_top_zones", params) as {
+  } = useAnalyticsQuery("dashboard_top_zones", params, {
+    format: "JSON_ARRAY",
+  }) as {
     data: TopZoneRow[] | null;
     loading: boolean;
     error: string | null;
@@ -149,7 +159,9 @@ export function useDashboardData(filters: DashboardFilters) {
     data: sparklines,
     loading: sparklinesLoading,
     error: sparklinesError,
-  } = useAnalyticsQuery("dashboard_kpi_sparklines", params) as {
+  } = useAnalyticsQuery("dashboard_kpi_sparklines", params, {
+    format: "JSON_ARRAY",
+  }) as {
     data: SparklineRow[] | null;
     loading: boolean;
     error: string | null;

--- a/apps/dev-playground/client/src/routes/analytics.route.tsx
+++ b/apps/dev-playground/client/src/routes/analytics.route.tsx
@@ -53,9 +53,15 @@ function AnalyticsRoute() {
     data: summaryDataRaw,
     loading: summaryLoading,
     error: summaryError,
-  } = useAnalyticsQuery("spend_summary", summaryParams);
+  } = useAnalyticsQuery("spend_summary", summaryParams, {
+    format: "JSON_ARRAY",
+  });
 
-  const { data: appsListData } = useAnalyticsQuery("apps_list", {});
+  const { data: appsListData } = useAnalyticsQuery(
+    "apps_list",
+    {},
+    { format: "JSON_ARRAY" },
+  );
 
   const untaggedAppsParams = useMemo(() => {
     return {
@@ -69,7 +75,9 @@ function AnalyticsRoute() {
     data: untaggedAppsData,
     loading: untaggedAppsLoading,
     error: untaggedAppsError,
-  } = useAnalyticsQuery("untagged_apps", untaggedAppsParams);
+  } = useAnalyticsQuery("untagged_apps", untaggedAppsParams, {
+    format: "JSON_ARRAY",
+  });
 
   const metrics = useMemo(() => {
     if (!summaryDataRaw || summaryDataRaw.length === 0) {

--- a/apps/dev-playground/client/src/routes/sql-helpers.route.tsx
+++ b/apps/dev-playground/client/src/routes/sql-helpers.route.tsx
@@ -230,6 +230,7 @@ function SqlHelpersRoute() {
   const { data, loading, error } = useAnalyticsQuery(
     "sql_helpers_test",
     queryParams ?? {},
+    { format: "JSON_ARRAY" },
   );
 
   // Helper to show the marker result

--- a/packages/appkit-ui/src/react/hooks/__tests__/use-chart-data.test.ts
+++ b/packages/appkit-ui/src/react/hooks/__tests__/use-chart-data.test.ts
@@ -205,7 +205,7 @@ describe("useChartData", () => {
       );
     });
 
-    test("auto-selects JSON_ARRAY by default when no heuristics match", () => {
+    test("auto-selects ARROW_STREAM by default when no heuristics match", () => {
       mockUseAnalyticsQuery.mockReturnValue({
         data: [],
         loading: false,
@@ -223,11 +223,11 @@ describe("useChartData", () => {
       expect(mockUseAnalyticsQuery).toHaveBeenCalledWith(
         "test",
         { limit: 100 },
-        expect.objectContaining({ format: "JSON_ARRAY" }),
+        expect.objectContaining({ format: "ARROW_STREAM" }),
       );
     });
 
-    test("defaults to auto format (JSON_ARRAY) when format is not specified", () => {
+    test("defaults to auto format (ARROW_STREAM) when format is not specified", () => {
       mockUseAnalyticsQuery.mockReturnValue({
         data: [],
         loading: false,
@@ -243,7 +243,7 @@ describe("useChartData", () => {
       expect(mockUseAnalyticsQuery).toHaveBeenCalledWith(
         "test",
         undefined,
-        expect.objectContaining({ format: "JSON_ARRAY" }),
+        expect.objectContaining({ format: "ARROW_STREAM" }),
       );
     });
   });

--- a/packages/appkit-ui/src/react/hooks/types.ts
+++ b/packages/appkit-ui/src/react/hooks/types.ts
@@ -45,9 +45,9 @@ export interface TypedArrowTable<
 
 /** Options for configuring an analytics SSE query */
 export interface UseAnalyticsQueryOptions<
-  F extends AnalyticsFormat = "JSON_ARRAY",
+  F extends AnalyticsFormat = "ARROW_STREAM",
 > {
-  /** Response format - "JSON_ARRAY" (default) returns typed arrays, "ARROW_STREAM" uses Arrow (inline or external links) */
+  /** Response format - "ARROW_STREAM" (default) returns a TypedArrowTable (compact binary wire, type-preserving). "JSON_ARRAY" returns typed row arrays. */
   format?: F;
 
   /** Maximum size of serialized parameters in bytes */

--- a/packages/appkit-ui/src/react/hooks/use-analytics-query.ts
+++ b/packages/appkit-ui/src/react/hooks/use-analytics-query.ts
@@ -77,8 +77,8 @@ function getArrowStreamUrl(id: string) {
  * Integration hook between client and analytics plugin.
  *
  * The return type is automatically inferred based on the format:
- * - `format: "JSON_ARRAY"` (default): Returns typed array from QueryRegistry
- * - `format: "ARROW_STREAM"`: Returns TypedArrowTable with row type preserved
+ * - `format: "ARROW_STREAM"` (default): Returns TypedArrowTable with row type preserved — works across all warehouse variants and avoids JSON serialization cost
+ * - `format: "JSON_ARRAY"`: Returns typed array from QueryRegistry
  *
  * Note: User context execution is determined by query file naming:
  * - `queryKey.obo.sql`: Executes as user (OBO = on-behalf-of / user delegation)
@@ -89,28 +89,28 @@ function getArrowStreamUrl(id: string) {
  * @param options - Analytics query settings including format
  * @returns Query result state with format-appropriate data type
  *
- * @example JSON_ARRAY format (default)
+ * @example ARROW_STREAM format (default)
  * ```typescript
  * const { data } = useAnalyticsQuery("spend_data", params);
- * // data: Array<{ group_key: string; cost_usd: number; ... }> | null
+ * // data: TypedArrowTable<{ group_key: string; cost_usd: number; ... }> | null
  * ```
  *
- * @example ARROW_STREAM format
+ * @example JSON_ARRAY format
  * ```typescript
- * const { data } = useAnalyticsQuery("spend_data", params, { format: "ARROW_STREAM" });
- * // data: TypedArrowTable<{ group_key: string; cost_usd: number; ... }> | null
+ * const { data } = useAnalyticsQuery("spend_data", params, { format: "JSON_ARRAY" });
+ * // data: Array<{ group_key: string; cost_usd: number; ... }> | null
  * ```
  */
 export function useAnalyticsQuery<
   T = unknown,
   K extends QueryKey = QueryKey,
-  F extends AnalyticsFormat = "JSON_ARRAY",
+  F extends AnalyticsFormat = "ARROW_STREAM",
 >(
   queryKey: K,
   parameters?: InferParams<K> | null,
   options: UseAnalyticsQueryOptions<F> = {} as UseAnalyticsQueryOptions<F>,
 ): UseAnalyticsQueryResult<InferResultByFormat<T, K, F>> {
-  const format = options?.format ?? "JSON_ARRAY";
+  const format = options?.format ?? "ARROW_STREAM";
   const maxParametersSize = options?.maxParametersSize ?? 100 * 1024;
   const autoStart = options?.autoStart ?? true;
 

--- a/packages/appkit-ui/src/react/hooks/use-chart-data.ts
+++ b/packages/appkit-ui/src/react/hooks/use-chart-data.ts
@@ -73,10 +73,10 @@ function resolveFormat(
       return "ARROW_STREAM";
     }
 
-    return "JSON_ARRAY";
+    return "ARROW_STREAM";
   }
 
-  return "JSON_ARRAY";
+  return "ARROW_STREAM";
 }
 
 // ============================================================================

--- a/packages/appkit-ui/src/react/table/table-wrapper.tsx
+++ b/packages/appkit-ui/src/react/table/table-wrapper.tsx
@@ -73,10 +73,15 @@ export function TableWrapper<TRaw = any, TProcessed = any>(
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
-  const { data, loading, error } = useAnalyticsQuery<TRaw[]>(
-    queryKey,
-    parameters,
-  );
+  // Pinned to JSON_ARRAY: the table walks `data.length` / `data[i]` for
+  // tabular rendering. A migration to Arrow's columnar API is a separate
+  // optimization — keeping it on the JSON shape preserves behavior across
+  // the default-switch to ARROW_STREAM.
+  const { data, loading, error } = useAnalyticsQuery<
+    TRaw[],
+    typeof queryKey,
+    "JSON_ARRAY"
+  >(queryKey, parameters, { format: "JSON_ARRAY" });
 
   useEffect(() => {
     if (onRowSelectionChange && enableRowSelection) {

--- a/packages/appkit/src/connectors/sql-warehouse/defaults.ts
+++ b/packages/appkit/src/connectors/sql-warehouse/defaults.ts
@@ -12,7 +12,7 @@ interface ExecuteStatementDefaults {
 export const executeStatementDefaults: ExecuteStatementDefaults = {
   wait_timeout: "30s",
   disposition: "INLINE",
-  format: "JSON_ARRAY",
+  format: "ARROW_STREAM",
   on_wait_timeout: "CONTINUE",
   timeout: 60000,
 };

--- a/packages/appkit/src/plugins/analytics/analytics.ts
+++ b/packages/appkit/src/plugins/analytics/analytics.ts
@@ -205,7 +205,7 @@ export class AnalyticsPlugin extends Plugin implements ToolProvider {
     res: express.Response,
   ): Promise<void> {
     const { query_key } = req.params;
-    const { parameters, format: rawFormat = "JSON_ARRAY" } =
+    const { parameters, format: rawFormat = "ARROW_STREAM" } =
       req.body as IAnalyticsQueryRequest;
 
     if (

--- a/packages/appkit/src/plugins/analytics/tests/analytics.integration.test.ts
+++ b/packages/appkit/src/plugins/analytics/tests/analytics.integration.test.ts
@@ -244,12 +244,20 @@ describe("Analytics Plugin Integration", () => {
         createSuccessfulSQLResponse([["cached_value"]], [{ name: "value" }]),
       );
 
+      // Caching is JSON_ARRAY-only — the ARROW_STREAM default bypasses
+      // cache because inline-stash ids drain on first /arrow-result fetch,
+      // so a cache hit would replay a dead id. Explicitly request the
+      // cacheable shape.
+      const cacheableBody = JSON.stringify({
+        parameters: {},
+        format: "JSON_ARRAY",
+      });
       const response1 = await fetch(
         `${baseUrl}/api/analytics/query/cache_test`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ parameters: {} }),
+          body: cacheableBody,
         },
       );
       const data1 = await parseSSEResponse(response1);
@@ -259,7 +267,7 @@ describe("Analytics Plugin Integration", () => {
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ parameters: {} }),
+          body: cacheableBody,
         },
       );
       const data2 = await parseSSEResponse(response2);

--- a/packages/appkit/src/plugins/analytics/tests/analytics.test.ts
+++ b/packages/appkit/src/plugins/analytics/tests/analytics.test.ts
@@ -699,7 +699,7 @@ describe("Analytics Plugin", () => {
       );
     });
 
-    test("/query/:query_key should use INLINE + JSON_ARRAY by default when no format specified", async () => {
+    test("/query/:query_key should use INLINE + ARROW_STREAM by default when no format specified", async () => {
       const plugin = new AnalyticsPlugin(config);
       const { router, getHandler } = createMockRouter();
 
@@ -708,8 +708,11 @@ describe("Analytics Plugin", () => {
         isAsUser: false,
       });
 
+      // ARROW_STREAM + INLINE returns an attachment (one row's worth of
+      // Arrow IPC bytes is fine for shape-checking the request, the
+      // contents don't need to be decoded for this test).
       const executeMock = vi.fn().mockResolvedValue({
-        result: { data: [{ id: 1 }] },
+        result: { attachment: Buffer.from("AQID").toString("base64") },
       });
       (plugin as any).SQLClient.executeStatement = executeMock;
 
@@ -728,7 +731,7 @@ describe("Analytics Plugin", () => {
         expect.anything(),
         expect.objectContaining({
           disposition: "INLINE",
-          format: "JSON_ARRAY",
+          format: "ARROW_STREAM",
         }),
         expect.any(AbortSignal),
       );

--- a/template/client/src/pages/analytics/AnalyticsPage.tsx
+++ b/template/client/src/pages/analytics/AnalyticsPage.tsx
@@ -42,13 +42,13 @@ export function AnalyticsPage() {
               </div>
             )}
             {error && <div className="text-destructive bg-destructive/10 p-3 rounded-md">Error: {error}</div>}
-            {data && data.length > 0 && (
+            {data && data.numRows > 0 && (
               <div className="space-y-2">
                 <div className="text-sm text-muted-foreground">Query: SELECT :message AS value</div>
-                <div className="text-2xl font-bold text-primary">{data[0].value}</div>
+                <div className="text-2xl font-bold text-primary">{data.getChild('value')?.get(0)}</div>
               </div>
             )}
-            {data && data.length === 0 && <div className="text-muted-foreground">No results</div>}
+            {data && data.numRows === 0 && <div className="text-muted-foreground">No results</div>}
           </CardContent>
         </Card>
 


### PR DESCRIPTION
## Summary

Switches the default analytics format from `JSON_ARRAY` to `ARROW_STREAM` across the hook, the chart-data hook, the SQL warehouse connector defaults, and the analytics plugin request handler.

**This is a breaking change** for code that consumes `useAnalyticsQuery("foo")` as a row array (`data.length`, `data[0].col`, `data.map(...)`). Two migration paths are documented below.

## Depends on #329

Merge https://github.com/databricks/appkit/pull/329 first. This PR is stacked on its branch and relies on the bidirectional disposition fallback added there — without that, the ARROW default doesn't work on warehouses that refuse `ARROW_STREAM` + `INLINE`.

## Why ARROW_STREAM is a better default

**Type fidelity.** ARROW preserves column types end-to-end — `INT` stays `number`, `BIGINT` stays `bigint`, `TIMESTAMP` stays `Date`. The warehouse's `JSON_ARRAY` serialization stringifies everything (`"1"`, `"2.5"`, ISO strings); callers have to coerce on their side and any nuance is lost.

**Wire compactness.** Arrow IPC is ~3–5× smaller than JSON for typical numeric data, and the binary parse is materially faster than `JSON.parse` for large tables. Charts/dashboards over real result sets are the primary `useAnalyticsQuery` use case, and they benefit measurably.

**Warehouse alignment.** The warehouses that only support one INLINE format (the case #329 was originally written for) want `ARROW_STREAM` + `INLINE`. With the ARROW default they get a clean single statement call. With the JSON_ARRAY default they trigger #329's server-side retry-and-decode path — correct but wasteful.

**Caveat — round trips on classic warehouses.** Classic warehouses (and some serverless) reject `ARROW_STREAM` + `INLINE` and require `ARROW_STREAM` + `EXTERNAL_LINKS`. Under the ARROW default that's two statement calls (initial INLINE rejected, then EXTERNAL_LINKS) plus the `/arrow-result` fetch — vs one call with the JSON_ARRAY default. The type-fidelity + wire-compactness win dominates for the typical analytics workload, but if your app is a small-result-set lookup against a classic warehouse, you may want to opt into `JSON_ARRAY` explicitly.

## Migration

For code that walks rows as an array (`data.length`, `data[i].col`, `data.map`):

- **Option A — opt back into JSON_ARRAY** (smallest diff):
  ```ts
  const { data } = useAnalyticsQuery("q", params, { format: "JSON_ARRAY" });
  ```
- **Option B — use the Arrow API** (gets type fidelity + smaller payloads):
  ```ts
  data?.numRows                  // instead of data.length
  data?.getChild("col")?.get(0)  // instead of data[0].col
  data?.toArray()                // if you need a plain row array
  ```

## In-repo migrations done in this PR

- `template/client/src/pages/analytics/AnalyticsPage.tsx` — **migrated to Arrow API** (this is the example new users get from `databricks apps init`; it should demonstrate the new default).
- `apps/dev-playground/client/src/features/smart-dashboard/hooks/use-dashboard-data.ts` — pinned to `JSON_ARRAY` (7 call sites, all feeding chart components that consume the row-array shape).
- `apps/dev-playground/client/src/routes/analytics.route.tsx` — pinned to `JSON_ARRAY` (3 call sites).
- `apps/dev-playground/client/src/routes/sql-helpers.route.tsx` — pinned to `JSON_ARRAY`.
- `packages/appkit-ui/src/react/table/table-wrapper.tsx` (`DataTable`) — pinned to `JSON_ARRAY`. The table renders rows as a JS array; an Arrow-native version is a separate optimization.

## Out-of-repo migrations needed (follow-up PRs)

These external repos all have call sites or examples that assume the JSON_ARRAY shape. None of them are blockers for landing this PR, but they should be updated when this lands or shortly after — flagged here so they don't get lost:

**Code in external repos:**
- `databricks/cli` — `experimental/aitools/templates/appkit/template/{{.project_name}}/client/src/App.tsx` uses `data.length` / `data[0].value`.
- `databricks/app-templates` — `appkit-all-in-one/client/src/pages/analytics/AnalyticsPage.tsx` and `appkit-analytics/client/src/pages/analytics/AnalyticsPage.tsx` use the same pattern.
- `databricks/devhub` — `examples/content-moderator/template/client/src/pages/AnalyticsPage.tsx` uses `useAnalyticsQuery`; needs an audit of its consumers.

**Docs in external repos (need text refresh, not code):**
- `databricks/devhub` — `static/raw-docs/appkit/v0/plugins/analytics.md`, `static/raw-docs/appkit/v0/development/type-generation.md`, `static/raw-docs/appkit/v0/api/appkit-ui/data/DataTable.mdx`, and the AI-skill references under `.agents/skills/databricks-apps/references/appkit/*.md`.
- `databricks/cli` — `experimental/aitools/templates/appkit/template/{{.project_name}}/docs/*.md` (AI agent docs that show the JSON shape).

## Tests

- `analytics.test.ts` — flipped the "default format" assertion from `JSON_ARRAY` to `ARROW_STREAM` (the test verifies the default; its meaning is unchanged).
- `analytics.integration.test.ts` — the cache test now explicitly requests `JSON_ARRAY` because the ARROW path bypasses cache by design (inline-stash ids drain on first read, so a cache hit would replay a dead id).
- `use-chart-data.test.ts` — flipped two "auto-selects default" assertions.

Full suite: **2,674 tests, all green**.

This pull request was AI-assisted by Isaac.
