### PR TITLE
feat: improve template and component responsiveness

### DIFF
--- a/docs/static/appkit-ui/styles.gen.css
+++ b/docs/static/appkit-ui/styles.gen.css
@@ -3967,6 +3967,11 @@
       flex-direction: row;
     }
   }
+  .sm\:items-center {
+    @media (width >= 40rem) {
+      align-items: center;
+    }
+  }
   .sm\:justify-end {
     @media (width >= 40rem) {
       justify-content: flex-end;
@@ -3975,6 +3980,11 @@
   .sm\:gap-2\.5 {
     @media (width >= 40rem) {
       gap: calc(var(--spacing) * 2.5);
+    }
+  }
+  .sm\:gap-6 {
+    @media (width >= 40rem) {
+      gap: calc(var(--spacing) * 6);
     }
   }
   .sm\:pr-2\.5 {

--- a/packages/appkit-ui/src/react/charts/options.ts
+++ b/packages/appkit-ui/src/react/charts/options.ts
@@ -141,7 +141,6 @@ export function buildHorizontalBarOption(
       right: "10%",
       top: ctx.title ? "15%" : "5%",
       bottom: ctx.showLegend && hasMultipleSeries ? "15%" : "5%",
-      containLabel: true,
     },
     xAxis: { type: "value" },
     yAxis: {
@@ -200,7 +199,6 @@ export function buildHeatmapOption(
       right: "15%",
       top: ctx.title ? "15%" : "10%",
       bottom: "15%",
-      containLabel: true,
     },
     xAxis: {
       type: "category",

--- a/packages/appkit-ui/src/react/charts/options.ts
+++ b/packages/appkit-ui/src/react/charts/options.ts
@@ -141,6 +141,7 @@ export function buildHorizontalBarOption(
       right: "10%",
       top: ctx.title ? "15%" : "5%",
       bottom: ctx.showLegend && hasMultipleSeries ? "15%" : "5%",
+      containLabel: true,
     },
     xAxis: { type: "value" },
     yAxis: {
@@ -199,6 +200,7 @@ export function buildHeatmapOption(
       right: "15%",
       top: ctx.title ? "15%" : "10%",
       bottom: "15%",
+      containLabel: true,
     },
     xAxis: {
       type: "category",
@@ -270,6 +272,7 @@ export function buildCartesianOption(
       right: "10%",
       top: ctx.title ? "15%" : "10%",
       bottom: ctx.showLegend && hasMultipleSeries ? "20%" : "15%",
+      containLabel: true,
     },
     xAxis: {
       type: isScatter ? "value" : isTimeSeries ? "time" : "category",

--- a/packages/appkit-ui/src/react/hooks/index.ts
+++ b/packages/appkit-ui/src/react/hooks/index.ts
@@ -25,6 +25,7 @@ export {
   type UseChartDataResult,
   useChartData,
 } from "./use-chart-data";
+export { useIsMobile } from "./use-mobile";
 export { usePluginClientConfig } from "./use-plugin-config";
 export {
   type UseServingInvokeOptions,

--- a/packages/appkit-ui/src/react/table/data-table.tsx
+++ b/packages/appkit-ui/src/react/table/data-table.tsx
@@ -256,6 +256,7 @@ export function DataTable(props: DataTableProps) {
                 </Table>
               </div>
             </div>
+            {/* On mobile, flex-col-reverse places pagination buttons above the info row for easier thumb access */}
             <div className="flex flex-col-reverse sm:flex-row items-start sm:items-center justify-between gap-3 py-4">
               <div className="flex flex-wrap items-center gap-3 sm:gap-6">
                 <div className="text-foreground text-sm">

--- a/packages/appkit-ui/src/react/table/data-table.tsx
+++ b/packages/appkit-ui/src/react/table/data-table.tsx
@@ -256,8 +256,8 @@ export function DataTable(props: DataTableProps) {
                 </Table>
               </div>
             </div>
-            <div className="flex items-center justify-between py-4">
-              <div className="flex items-center gap-6">
+            <div className="flex flex-col-reverse sm:flex-row items-start sm:items-center justify-between gap-3 py-4">
+              <div className="flex flex-wrap items-center gap-3 sm:gap-6">
                 <div className="text-foreground text-sm">
                   {totalRows > 0
                     ? finalLabels.showing

--- a/template/client/src/App.tsx
+++ b/template/client/src/App.tsx
@@ -1,5 +1,5 @@
 import { createBrowserRouter, RouterProvider, NavLink, Outlet } from 'react-router';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import {
   Button,
   Card,
@@ -52,7 +52,9 @@ const mobileNavLinkClass = ({ isActive }: { isActive: boolean }) =>
       : 'text-muted-foreground hover:bg-muted hover:text-foreground'
   }`;
 
-function NavLinks({ className, linkClass, onClick }: { className?: string; linkClass: typeof navLinkClass; onClick?: () => void }) {
+type NavLinkClassFn = (props: { isActive: boolean }) => string;
+
+function NavLinks({ className, linkClass, onClick }: { className?: string; linkClass: NavLinkClassFn; onClick?: () => void }) {
   return (
     <nav className={className}>
       <NavLink to="/" end className={linkClass} onClick={onClick}>
@@ -106,13 +108,21 @@ function Layout() {
   const isMobile = useIsMobile();
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
 
+  // Close mobile nav when viewport crosses to desktop
+  useEffect(() => {
+    if (!isMobile) setMobileNavOpen(false);
+  }, [isMobile]);
+
   return (
     <div className="min-h-screen bg-background flex flex-col">
-      <header className="border-b px-4 sm:px-6 py-3 flex items-center gap-4">
+      <header className="border-b px-4 md:px-6 py-3 flex items-center gap-4">
         <h1 className="text-lg font-semibold text-foreground">{{.projectName}}</h1>
-        {isMobile ? (
+        {/* Desktop nav — hidden below md breakpoint */}
+        <NavLinks className="hidden md:flex gap-1" linkClass={navLinkClass} />
+        {/* Mobile nav — visible below md breakpoint */}
+        <div className="ml-auto md:hidden">
           <Sheet open={mobileNavOpen} onOpenChange={setMobileNavOpen}>
-            <Button variant="ghost" size="icon" className="ml-auto" onClick={() => setMobileNavOpen(true)}>
+            <Button variant="ghost" size="icon" onClick={() => setMobileNavOpen(true)}>
               <Menu className="h-5 w-5" />
               <span className="sr-only">Open navigation</span>
             </Button>
@@ -123,12 +133,10 @@ function Layout() {
               <NavLinks className="flex flex-col gap-1" linkClass={mobileNavLinkClass} onClick={() => setMobileNavOpen(false)} />
             </SheetContent>
           </Sheet>
-        ) : (
-          <NavLinks className="flex gap-1" linkClass={navLinkClass} />
-        )}
+        </div>
       </header>
 
-      <main className="flex-1 p-4 sm:p-6">
+      <main className="flex-1 p-4 md:p-6">
         <Outlet />
       </main>
     </div>

--- a/template/client/src/App.tsx
+++ b/template/client/src/App.tsx
@@ -120,7 +120,7 @@ function Layout() {
               <SheetHeader>
                 <SheetTitle>Navigation</SheetTitle>
               </SheetHeader>
-              <NavLinks className="flex flex-col gap-1 mt-4" linkClass={mobileNavLinkClass} onClick={() => setMobileNavOpen(false)} />
+              <NavLinks className="flex flex-col gap-1" linkClass={mobileNavLinkClass} onClick={() => setMobileNavOpen(false)} />
             </SheetContent>
           </Sheet>
         ) : (

--- a/template/client/src/App.tsx
+++ b/template/client/src/App.tsx
@@ -1,10 +1,18 @@
 import { createBrowserRouter, RouterProvider, NavLink, Outlet } from 'react-router';
+import { useState } from 'react';
 import {
+  Button,
   Card,
   CardContent,
   CardHeader,
   CardTitle,
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  useIsMobile,
 } from '@databricks/appkit-ui/react';
+import { Menu } from 'lucide-react';
 {{- if .plugins.agents}}
 import { AgentChat } from './pages/agents/AgentChat';
 {{- end}}
@@ -37,59 +45,90 @@ const navLinkClass = ({ isActive }: { isActive: boolean }) =>
       : 'text-muted-foreground hover:bg-muted hover:text-foreground'
   }`;
 
-function Layout() {
+const mobileNavLinkClass = ({ isActive }: { isActive: boolean }) =>
+  `block px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+    isActive
+      ? 'bg-primary text-primary-foreground'
+      : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+  }`;
+
+function NavLinks({ className, linkClass, onClick }: { className?: string; linkClass: typeof navLinkClass; onClick?: () => void }) {
   return (
-    <div className="min-h-screen bg-background flex flex-col">
-      <header className="border-b px-6 py-3 flex items-center gap-4">
-        <h1 className="text-lg font-semibold text-foreground">{{.projectName}}</h1>
-        <nav className="flex gap-1">
-          <NavLink to="/" end className={navLinkClass}>
-            Home
-          </NavLink>
+    <nav className={className}>
+      <NavLink to="/" end className={linkClass} onClick={onClick}>
+        Home
+      </NavLink>
 {{- if .plugins.agents}}
-          <NavLink to="/agents" className={navLinkClass}>
-            Agents
-          </NavLink>
+      <NavLink to="/agents" className={linkClass} onClick={onClick}>
+        Agents
+      </NavLink>
 {{- end}}
 {{- if .plugins.analytics}}
-          <NavLink to="/analytics" className={navLinkClass}>
-            Analytics
-          </NavLink>
+      <NavLink to="/analytics" className={linkClass} onClick={onClick}>
+        Analytics
+      </NavLink>
 {{- end}}
 {{- if .plugins.lakebase}}
-          <NavLink to="/lakebase" className={navLinkClass}>
-            Lakebase
-          </NavLink>
+      <NavLink to="/lakebase" className={linkClass} onClick={onClick}>
+        Lakebase
+      </NavLink>
 {{- end}}
 {{- if .plugins.genie}}
-          <NavLink to="/genie" className={navLinkClass}>
-            Genie
-          </NavLink>
+      <NavLink to="/genie" className={linkClass} onClick={onClick}>
+        Genie
+      </NavLink>
 {{- end}}
 {{- if .plugins.files}}
-          <NavLink to="/files" className={navLinkClass}>
-            Files
-          </NavLink>
+      <NavLink to="/files" className={linkClass} onClick={onClick}>
+        Files
+      </NavLink>
 {{- end}}
 {{- if .plugins.serving}}
-          <NavLink to="/serving" className={navLinkClass}>
-            Serving
-          </NavLink>
+      <NavLink to="/serving" className={linkClass} onClick={onClick}>
+        Serving
+      </NavLink>
 {{- end}}
 {{- if .plugins.vectorSearch}}
-          <NavLink to="/vector-search" className={navLinkClass}>
-            Vector Search
-          </NavLink>
+      <NavLink to="/vector-search" className={linkClass} onClick={onClick}>
+        Vector Search
+      </NavLink>
 {{- end}}
 {{- if .plugins.jobs}}
-          <NavLink to="/jobs" className={navLinkClass}>
-            Jobs
-          </NavLink>
+      <NavLink to="/jobs" className={linkClass} onClick={onClick}>
+        Jobs
+      </NavLink>
 {{- end}}
-        </nav>
+    </nav>
+  );
+}
+
+function Layout() {
+  const isMobile = useIsMobile();
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
+
+  return (
+    <div className="min-h-screen bg-background flex flex-col">
+      <header className="border-b px-4 sm:px-6 py-3 flex items-center gap-4">
+        <h1 className="text-lg font-semibold text-foreground">{{.projectName}}</h1>
+        {isMobile ? (
+          <Sheet open={mobileNavOpen} onOpenChange={setMobileNavOpen}>
+            <Button variant="ghost" size="icon" className="ml-auto" onClick={() => setMobileNavOpen(true)}>
+              <Menu className="h-5 w-5" />
+              <span className="sr-only">Open navigation</span>
+            </Button>
+            <SheetContent side="left">
+              <SheetHeader>
+                <SheetTitle>Navigation</SheetTitle>
+              </SheetHeader>
+              <NavLinks className="flex flex-col gap-1 mt-4" linkClass={mobileNavLinkClass} onClick={() => setMobileNavOpen(false)} />
+            </SheetContent>
+          </Sheet>
+        ) : (
+          <NavLinks className="flex gap-1" linkClass={navLinkClass} />
+        )}
       </header>
 
-      <main className="flex-1 p-6">
+      <main className="flex-1 p-4 sm:p-6">
         <Outlet />
       </main>
     </div>

--- a/template/client/src/pages/agents/AgentChat.tsx
+++ b/template/client/src/pages/agents/AgentChat.tsx
@@ -141,7 +141,7 @@ export function AgentChat() {
         </p>
       </div>
 
-      <Card className="h-[600px] flex flex-col">
+      <Card className="h-[min(600px,70vh)] flex flex-col">
         <CardContent
           className="flex-1 overflow-y-auto p-4 space-y-3"
           ref={scrollRef}

--- a/template/client/src/pages/files/FilesPage.tsx
+++ b/template/client/src/pages/files/FilesPage.tsx
@@ -289,7 +289,7 @@ export function FilesPage() {
         </p>
       </div>
 
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3">
         <div className="flex items-center gap-3">
           {volumes.length > 1 && (
             <select
@@ -351,7 +351,7 @@ export function FilesPage() {
         </div>
       </div>
 
-      <div className="flex gap-6">
+      <div className="flex flex-col md:flex-row gap-4 md:gap-6">
         <DirectoryList
           className="flex-2 min-w-0"
           entries={entries}

--- a/template/client/src/pages/genie/GeniePage.tsx
+++ b/template/client/src/pages/genie/GeniePage.tsx
@@ -10,7 +10,7 @@ export function GeniePage() {
           Ask questions about your data using Databricks AI/BI Genie.
         </p>
       </div>
-      <div className="h-[600px] border rounded-lg overflow-hidden">
+      <div className="h-[min(600px,70vh)] border rounded-lg overflow-hidden">
         <GenieChat alias="default" />
       </div>
     </div>

--- a/template/client/src/pages/jobs/JobsPage.tsx
+++ b/template/client/src/pages/jobs/JobsPage.tsx
@@ -154,7 +154,7 @@ export function JobsPage() {
         </p>
       </div>
 
-      <div className="flex items-center gap-3">
+      <div className="flex flex-wrap items-center gap-3">
         <label
           htmlFor={inputId}
           className="text-sm font-medium text-foreground"
@@ -166,7 +166,7 @@ export function JobsPage() {
           type="text"
           value={jobKey}
           onChange={(e) => setJobKey(e.target.value)}
-          className="rounded-md border border-input bg-background px-3 py-1.5 text-sm w-48"
+          className="rounded-md border border-input bg-background px-3 py-1.5 text-sm w-full sm:w-48"
         />
         <Button
           onClick={fetchStatus}

--- a/template/client/src/pages/serving/ServingPage.tsx
+++ b/template/client/src/pages/serving/ServingPage.tsx
@@ -69,7 +69,7 @@ export function ServingPage() {
         </p>
       </div>
 
-      <div className="border rounded-lg flex flex-col h-[600px]">
+      <div className="border rounded-lg flex flex-col h-[min(600px,70vh)]">
         <div className="flex-1 overflow-y-auto p-4 space-y-4">
           {messages.map((msg) => (
             <div

--- a/tools/generate-app-templates.ts
+++ b/tools/generate-app-templates.ts
@@ -66,6 +66,7 @@ const APP_TEMPLATES: AppTemplate[] = [
       "analytics.sql-warehouse.id": "placeholder",
       "files.files.path": "placeholder",
       "genie.genie-space.id": "placeholder",
+      "genie.genie-space.name": "placeholder",
       "lakebase.postgres.branch": "placeholder",
       "lakebase.postgres.database": "placeholder",
       "serving.serving-endpoint.name": "placeholder",
@@ -86,6 +87,7 @@ const APP_TEMPLATES: AppTemplate[] = [
     features: ["genie"],
     set: {
       "genie.genie-space.id": "placeholder",
+      "genie.genie-space.name": "placeholder",
     },
     description:
       "Node.js app with AI/BI Genie for natural language data queries",


### PR DESCRIPTION
## Summary

Audit and improve responsiveness across the AppKit template and `appkit-ui` components so that scaffolded apps are mobile-friendly out of the box.

### What was fixed

**Template (affects every `databricks apps init` app):**
- **Mobile navigation**: Added Sheet/drawer nav with hamburger menu on mobile (<768px), horizontal nav on desktop. Uses `useIsMobile` hook and `Sheet` component from appkit-ui.
- **Viewport-relative chat heights**: Replaced fixed `h-[600px]` with `h-[min(600px,70vh)]` on AgentChat, GeniePage, and ServingPage — prevents clipping on short mobile viewports.
- **Files page stacking**: Directory list + preview panel now stack vertically on mobile (`flex-col md:flex-row`). Toolbar wraps responsively.
- **Jobs page wrapping**: Controls use `flex-wrap` and input uses `w-full sm:w-48` so they don't overflow on narrow screens.
- **Responsive padding**: Header and main content use `px-4 sm:px-6` / `p-4 sm:p-6`.

**appkit-ui:**
- **DataTable pagination**: Footer stacks on mobile (`flex-col-reverse sm:flex-row`) so controls don't squish together.
- **Chart label overlap**: Added `containLabel: true` to cartesian chart grid config. This makes ECharts auto-size the grid to include rotated axis labels, preventing them from overlapping the bottom legend.
- **Export `useIsMobile` hook**: Now exported from `@databricks/appkit-ui/react` for consumer use.

**Tooling:**
- **Fix `generate-app-templates`**: Added missing `genie.genie-space.name` field for genie templates.

### What was already responsive (no changes needed)
- **Charts (width)**: `echarts-for-react` auto-resizes width; height is consumer-configurable via prop.
- **Genie components**: Well-structured flexbox layout with ScrollArea and ResizeObserver. Message bubbles use `max-w-[80%]` + `break-words`.
- **File browser components**: DirectoryList, FileEntry, FilePreviewPanel already handle overflow and truncation.
- **shadcn/ui primitives**: Dialog, Sheet, Drawer, Breadcrumb, Pagination, etc. all use Radix viewport-aware positioning and Tailwind responsive classes.

## Screenshots

Screenshots taken from the generated `appkit-all-in-one` template using Chrome DevTools MCP.
<img width="1440" height="900" alt="desktop-analytics" src="https://github.com/user-attachments/assets/a87b1892-59a6-418a-8864-4e36284e86e2" />
<img width="1440" height="900" alt="desktop-files" src="https://github.com/user-attachments/assets/bdf038be-c8e1-4961-b749-db11bc1a675b" />
<img width="1440" height="900" alt="desktop-genie" src="https://github.com/user-attachments/assets/5ad6d73e-b5e6-4b21-a59b-a960a6ab0115" />
<img width="1440" height="900" alt="desktop-home" src="https://github.com/user-attachments/assets/464a1fd3-e6fb-45cb-9828-51159f284974" />
<img width="750" height="3394" alt="mobile-analytics" src="https://github.com/user-attachments/assets/184eff24-a107-4acc-9a2d-1ad5f89e5578" />
<img width="750" height="1624" alt="mobile-files" src="https://github.com/user-attachments/assets/237c6025-a8af-48c0-9493-35c49c913ddf" />
<img width="750" height="1624" alt="mobile-files-new-folder" src="https://github.com/user-attachments/assets/e7f8955f-0c72-4605-b28d-b8fab29420b0" />
<img width="750" height="1624" alt="mobile-genie-messages" src="https://github.com/user-attachments/assets/3dfd9434-77dd-4dc0-9387-b67f43dd1006" />
<img width="750" height="1624" alt="mobile-home" src="https://github.com/user-attachments/assets/ed49d779-58b4-43c1-8d8e-41b293bd51ce" />
<img width="750" height="1624" alt="mobile-nav-open" src="https://github.com/user-attachments/assets/aa8464df-7e43-4e70-808e-68335f5ee290" />
<img width="750" height="1624" alt="mobile-serving" src="https://github.com/user-attachments/assets/73860c15-01c8-4473-8e51-657419738259" />
<img width="750" height="1624" alt="mobile-serving" src="https://github.com/user-attachments/assets/96c2f2b0-9a0f-427d-ae11-9c7391c3919a" />
<img width="750" height="1624" alt="mobile-lakebase" src="https://github.com/user-attachments/assets/4296e83c-2a2b-47b5-ad86-67c5f2027c78" />


## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` passes (3 pre-existing telemetry test failures, unrelated)
- [x] `pnpm -r typecheck` passes
- [x] Generated `appkit-all-in-one` template with `DATABRICKS_CLI=dbx pnpm generate:app-templates`
- [x] Installed local SDK tarballs and ran dev server
- [x] Chrome DevTools MCP visual verification at 375px (mobile) and 1440px (desktop)
  - Mobile: hamburger nav with Sheet, viewport-relative heights, stacked Files, Genie message bubbles responsive
  - Desktop: horizontal nav, multi-column grids, side-by-side Files layout, charts with proper label spacing