### PR TITLE
fix(appkit): use retry client for Lakebase V1 transaction retry

### DIFF
--- a/packages/appkit/src/connectors/lakebase-v1/client.ts
+++ b/packages/appkit/src/connectors/lakebase-v1/client.ts
@@ -208,6 +208,14 @@ export class LakebaseV1Connector {
       async (span) => {
         const pool = await this.getPool();
         const client = await pool.connect();
+        let clientReleased = false;
+        const releaseClient = () => {
+          if (!clientReleased) {
+            client.release();
+            clientReleased = true;
+          }
+        };
+
         try {
           await client.query("BEGIN");
           const result = await callback(client);
@@ -221,14 +229,14 @@ export class LakebaseV1Connector {
           // retry on auth failure
           if (this.isAuthError(error)) {
             span.addEvent("auth_error_retry");
-            client.release();
+            releaseClient();
             await this.rotateCredentials();
             const newPool = await this.getPool();
             const retryClient = await newPool.connect();
             try {
-              await client.query("BEGIN");
+              await retryClient.query("BEGIN");
               const result = await callback(retryClient);
-              await client.query("COMMIT");
+              await retryClient.query("COMMIT");
               span.setStatus({ code: SpanStatusCode.OK });
               return result;
             } catch (retryError) {
@@ -244,7 +252,7 @@ export class LakebaseV1Connector {
           // retry on transient errors, but only once
           if (this.isTransientError(error) && retryCount < 1) {
             span.addEvent("transaction_error_retry");
-            client.release();
+            releaseClient();
             await new Promise((resolve) => setTimeout(resolve, 100));
             return await this.transaction<T>(callback, retryCount + 1);
           }
@@ -262,7 +270,7 @@ export class LakebaseV1Connector {
           }
           throw ConnectionError.transactionFailed(error as Error);
         } finally {
-          client.release();
+          releaseClient();
           const duration = Date.now() - startTime;
           this.telemetryMetrics.queryCount.add(1);
           this.telemetryMetrics.queryDuration.record(duration);

--- a/packages/appkit/src/connectors/tests/lakebase-v1.test.ts
+++ b/packages/appkit/src/connectors/tests/lakebase-v1.test.ts
@@ -358,6 +358,63 @@ describe("LakebaseV1Connector", () => {
       expect(mockClient.release).toHaveBeenCalled();
     });
 
+    test("should run retry transaction boundaries on the retry client if auth failure rotates credentials", async () => {
+      const authError = new Error("password authentication failed") as any;
+      authError.code = "28P01";
+
+      let initialClientReleased = false;
+      const initialClient = {
+        query: vi.fn().mockImplementation((sql: string) => {
+          if (sql === "BEGIN" && !initialClientReleased) {
+            return Promise.resolve({ rows: [] });
+          }
+          if (sql === "SELECT 1") {
+            return Promise.reject(authError);
+          }
+          if (sql === "ROLLBACK") {
+            return Promise.resolve({ rows: [] });
+          }
+          return Promise.reject(
+            new Error(`initial client should not run ${sql}`),
+          );
+        }),
+        release: vi.fn().mockImplementation(() => {
+          if (initialClientReleased) {
+            throw new Error("initial client released twice");
+          }
+          initialClientReleased = true;
+        }),
+      };
+      const retryClient = {
+        query: vi.fn().mockResolvedValue({ rows: [] }),
+        release: vi.fn(),
+      };
+      mockConnect
+        .mockResolvedValueOnce(initialClient)
+        .mockResolvedValueOnce(retryClient);
+
+      const seenClients: unknown[] = [];
+      const result = await connector.transaction(async (client) => {
+        seenClients.push(client);
+        await client.query("SELECT 1");
+        return seenClients.length === 2 ? "retried" : "initial";
+      });
+
+      expect(result).toBe("retried");
+      expect(seenClients[0]).toBe(initialClient);
+      expect(seenClients[1]).toBe(retryClient);
+      expect(initialClient.query).toHaveBeenNthCalledWith(1, "BEGIN");
+      expect(initialClient.query).toHaveBeenNthCalledWith(2, "SELECT 1");
+      expect(initialClient.query).toHaveBeenNthCalledWith(3, "ROLLBACK");
+      expect(initialClient.query).toHaveBeenCalledTimes(3);
+      expect(retryClient.query).toHaveBeenNthCalledWith(1, "BEGIN");
+      expect(retryClient.query).toHaveBeenNthCalledWith(2, "SELECT 1");
+      expect(retryClient.query).toHaveBeenNthCalledWith(3, "COMMIT");
+      expect(retryClient.query).toHaveBeenCalledTimes(3);
+      expect(initialClient.release).toHaveBeenCalledTimes(1);
+      expect(retryClient.release).toHaveBeenCalledTimes(1);
+    });
+
     test("should not log the SQL query string on transaction error", async () => {
       const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 


### PR DESCRIPTION
## Summary
- use the retry PostgreSQL client for retry transaction `BEGIN` and `COMMIT` after credential rotation
- guard the original transaction client release so retry paths do not release it twice
- add a regression test covering auth-failure transaction retry behavior

## Root Cause
The auth retry path opened a retry client and passed it to the transaction callback, but still ran transaction boundaries on the original client after releasing it. That could put callback work and transaction control on different clients, or fail because the original client was already released.

## Validation
- `pnpm exec vitest run packages/appkit/src/connectors/tests/lakebase-v1.test.ts`
- `pnpm exec biome check packages/appkit/src/connectors/lakebase-v1/client.ts packages/appkit/src/connectors/tests/lakebase-v1.test.ts`
- `pnpm --filter @databricks/appkit typecheck`
- `git diff --check`

Closes #392