### PR TITLE
fix(template): use public npm registry for @babel/parser

### DIFF
--- a/template/package-lock.json
+++ b/template/package-lock.json
@@ -442,7 +442,7 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.29.2",
-      "resolved": "https://npm-proxy.dev.databricks.com/@babel/parser/-/parser-7.29.2.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
       "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
       "dev": true,
       "license": "MIT",


### PR DESCRIPTION
## Summary

- Restore the public npm registry as the `resolved` URL for `@babel/parser@7.29.2` in `template/package-lock.json`.
- Before this fix, the entry was pointing at `https://npm-proxy.dev.databricks.com/...`, which external users cannot reach, causing `npm install` to fail in the scaffolded template.
- The Databricks proxy URL was inadvertently introduced in #347.
- The `integrity` hash is unchanged and matches the public registry's tarball, so `npm install` still verifies the bytes.
