### PR TITLE
fix: add @param type annotations to template SQL queries

### DIFF
--- a/template/config/queries/hello_world.sql
+++ b/template/config/queries/hello_world.sql
@@ -1,3 +1,4 @@
 {{if .plugins.analytics -}}
+-- @param message STRING
 SELECT :message AS value;
 {{- end}}

--- a/template/config/queries/mocked_sales.sql
+++ b/template/config/queries/mocked_sales.sql
@@ -1,4 +1,5 @@
 {{if .plugins.analytics -}}
+-- @param max_month_num INT
 WITH mock_data AS (
   SELECT 'January' AS month, 1 AS month_num, 65000 AS revenue, 45000 AS expenses, 850 AS customers
   UNION ALL SELECT 'February', 2, 72000, 48000, 920


### PR DESCRIPTION
## Summary

- Template query files (`hello_world.sql`, `mocked_sales.sql`) lacked `-- @param` type annotations, causing warnings during `appkit generate-types` on freshly scaffolded apps
- Added `-- @param message STRING` to `hello_world.sql` and `-- @param max_month_num INT` to `mocked_sales.sql`

## Why

Prior to #251 (April 2026), the type generator replaced all `:param` placeholders with a default string value (`''`) regardless of type — no annotation or inference system existed. That PR introduced `-- @param` annotations, positional type inference (for `LIMIT`, `OFFSET`, arithmetic), and warnings for unresolved parameters. The template SQL files were created before this feature and never got annotations, so every freshly scaffolded app now shows these warnings on first `npm run dev`.

## Screenshots

### Before

<img width="683" height="623" alt="image" src="https://github.com/user-attachments/assets/ae138016-5373-4b46-b1f3-217e2739e469" />

### After

<img width="683" height="464" alt="image" src="https://github.com/user-attachments/assets/ddb495e1-1838-405b-b281-219931ee58f1" />


## Test plan

- [x] Scaffolded a fresh app with `databricks apps init --template ./template` (analytics plugin selected)
- [x] Ran `appkit generate-types` — confirmed warnings appeared (before fix)
- [x] Applied fix, re-scaffolded, re-ran typegen — no warnings
- [x] `pnpm test` passes (pre-existing unrelated failure in `config.test.ts`)