### PR TITLE
chore: copy databricks.yml.tmpl to pre-rendered app templates

### DIFF
--- a/tools/generate-app-templates.ts
+++ b/tools/generate-app-templates.ts
@@ -193,7 +193,19 @@ function postProcess(appDir: string, app: AppTemplate): void {
   const envTmplBody = readFileSync(join(TEMPLATE_PATH, ".env.tmpl"), "utf-8");
   writeFileSync(join(appDir, ".env.tmpl"), envTmplHeader + envTmplBody);
 
-  // 2. Sync appkit.plugins.json based on server imports (discovers available plugins
+  // 2. Copy databricks.yml.tmpl from the source template so that
+  //    `databricks apps init --template <pre-rendered>` can render it
+  //    with the user's project name, workspace host, and --set values.
+  //    The static databricks.yml remains as a readable reference;
+  //    copyTemplate()'s lexical walk order ensures the .tmpl version
+  //    overwrites it in the output.
+  const databricksYmlTmpl = readFileSync(
+    join(TEMPLATE_PATH, "databricks.yml.tmpl"),
+    "utf-8",
+  );
+  writeFileSync(join(appDir, "databricks.yml.tmpl"), databricksYmlTmpl);
+
+  // 3. Sync appkit.plugins.json based on server imports (discovers available plugins
   //    and marks the ones used in the plugins array as required).
   const syncStatus = run(
     "node",
@@ -205,7 +217,7 @@ function postProcess(appDir: string, app: AppTemplate): void {
     process.exit(syncStatus);
   }
 
-  // 3. Replace the resolved workspace host URL with a placeholder.
+  // 4. Replace the resolved workspace host URL with a placeholder.
   const databricksYmlPath = join(appDir, "databricks.yml");
   const yml = readFileSync(databricksYmlPath, "utf-8");
   const fixedYml = yml.replace(


### PR DESCRIPTION
## Summary

Updates `tools/generate-app-templates.ts` to copy `databricks.yml.tmpl` from the source template into each generated pre-rendered app directory.

This enables `databricks apps init --template <pre-rendered>` to render resource blocks, target variables, project name and workspace host via `--set` values — instead of keeping a static `databricks.yml` that requires post-hoc YAML manipulation.

## How it works

- The static `databricks.yml` remains as a readable reference
- The CLI's `copyTemplate()` walks files in lexical order, so `databricks.yml.tmpl` renders second and overwrites the static file
- `--set` values flow through `{{.bundle.resources}}`, `{{.bundle.targetVariables}}`, etc.

## Related PRs

- CLI: https://github.com/databricks/cli/pull/5400
- App-Templates: TBD (regenerate after this merges)

This pull request and its description were written by Isaac.