### PR TITLE
feat(analytics): auto-start SQL warehouse and stream warehouse_status SSE events

### DIFF
--- a/packages/appkit/src/connectors/sql-warehouse/client.ts
+++ b/packages/appkit/src/connectors/sql-warehouse/client.ts
@@ -23,6 +23,8 @@ import {
   TelemetryManager,
 } from "../../telemetry";
 import { executeStatementDefaults } from "./defaults";
+import { WarehousePollBackoff } from "./warehouse-poll-backoff";
+import { WarehouseStatusEmitter } from "./warehouse-status-emitter";
 
 const logger = createLogger("connectors:sql-warehouse");
 
@@ -39,13 +41,6 @@ interface SQLWarehouseConfig {
  * serverless typically reaches RUNNING within ~30s.
  */
 export const DEFAULT_WAREHOUSE_STARTUP_TIMEOUT_MS = 5 * 60 * 1000;
-
-/**
- * Polling backoff bounds for the warehouse readiness loop. Backoff is
- * exponential with ±15% jitter to spread retries across concurrent waiters.
- */
-const WAREHOUSE_POLL_INITIAL_MS = 1_000;
-const WAREHOUSE_POLL_MAX_MS = 30_000;
 
 /**
  * Window during which a recent `RUNNING` observation lets subsequent calls
@@ -102,10 +97,9 @@ export class SQLWarehouseConnector {
   private _arrowProcessor: ArrowStreamProcessor | null = null;
 
   /**
-   * Per-warehouse "recently observed RUNNING" cache. Lets warm-path
-   * requests skip the readiness loop (and its `warehouses.get` round-trip)
-   * entirely. Map values are the timestamp of the last RUNNING observation;
-   * see {@link WAREHOUSE_RUNNING_CACHE_TTL_MS}.
+   * Per-warehouse cache of the last RUNNING observation timestamp. Used by
+   * {@link ensureWarehouseRunning} to short-circuit warm-path callers; see
+   * {@link WAREHOUSE_RUNNING_CACHE_TTL_MS}.
    */
   private _recentlyRunning = new Map<string, number>();
   // telemetry
@@ -351,19 +345,27 @@ export class SQLWarehouseConnector {
 
   /**
    * Wait until the SQL warehouse is in the `RUNNING` state, auto-starting it
-   * if currently `STOPPED`. Emits one {@link WarehouseStatusUpdate} per
-   * observation so callers can surface progress (e.g. over SSE) instead of
-   * letting the UI freeze on a cold warehouse.
+   * if currently `STOPPED`. Emits a {@link WarehouseStatusUpdate} whenever
+   * the observed state changes, so callers can surface progress (e.g. over
+   * SSE) instead of letting the UI freeze on a cold warehouse. Equal
+   * successive observations are de-duplicated.
+   *
+   * Fast path: if this connector recently observed the warehouse RUNNING
+   * (within {@link WAREHOUSE_RUNNING_CACHE_TTL_MS}), the call returns
+   * immediately without any SDK round-trip or status emission. This keeps
+   * cache-hit analytics requests off the Databricks control plane.
    *
    * Behaviour by initial state:
-   * - `RUNNING`: emits one update and returns immediately.
-   * - `STOPPED`: emits a `STARTING` update, calls
+   * - `RUNNING`: emits one update, caches the observation, returns.
+   * - `STOPPED`: emits a synthetic `STARTING` update, calls
    *   `workspaceClient.warehouses.start`, then polls until `RUNNING`.
+   *   When `autoStart: false`, throws `ConfigurationError` instead.
    * - `STARTING` / `STOPPING`: polls until `RUNNING`.
    * - `DELETED` / `DELETING`: throws `ConfigurationError.resourceNotFound`.
    *
-   * Aborts and timeouts surface as `ExecutionError`. The whole loop runs
-   * inside a `sql.warehouseReady` telemetry span.
+   * Aborts and timeouts surface as `ExecutionError`. The poll loop uses
+   * exponential backoff with ±15% jitter (1s → 30s cap) and runs inside a
+   * `sql.warehouseReady` telemetry span.
    */
   async ensureWarehouseRunning(
     workspaceClient: WorkspaceClient,
@@ -377,26 +379,9 @@ export class SQLWarehouseConnector {
       autoStart = true,
     } = opts;
 
-    if (signal?.aborted) {
-      throw ExecutionError.canceled();
-    }
-
-    if (!warehouseId) {
-      throw ValidationError.missingField("warehouse_id");
-    }
-
-    // Fast path: skip the readiness loop entirely (no SDK round-trip, no
-    // SSE warehouse_status events) when this connector recently observed
-    // the warehouse RUNNING. Keeps the steady-state hot path off the
-    // Databricks control plane so cache-hit analytics requests aren't
-    // taxed an extra ~50–200 ms RTT per call.
-    const observedAt = this._recentlyRunning.get(warehouseId);
-    if (
-      observedAt !== undefined &&
-      Date.now() - observedAt < WAREHOUSE_RUNNING_CACHE_TTL_MS
-    ) {
-      return;
-    }
+    if (signal?.aborted) throw ExecutionError.canceled();
+    if (!warehouseId) throw ValidationError.missingField("warehouse_id");
+    if (this._isRecentlyRunning(warehouseId)) return;
 
     return this.telemetry.startActiveSpan(
       "sql.warehouseReady",
@@ -410,51 +395,14 @@ export class SQLWarehouseConnector {
       },
       async (span: Span) => {
         const startTime = Date.now();
-        let attempt = 0;
+        const emitter = new WarehouseStatusEmitter(span, startTime, onStatus);
         let didStart = false;
-        let lastEmittedState: sql.State | null = null;
-        let pollIntervalMs = WAREHOUSE_POLL_INITIAL_MS;
-
-        const emit = (state: sql.State, summary: string | undefined): void => {
-          attempt += 1;
-          // Record the raw SDK summary on the span for server-side debugging
-          // only — never on the wire (R1: SDK health.summary contains
-          // operator-oriented internals like cluster IDs and capacity
-          // reasons that must not reach end users).
-          span.addEvent("warehouse.status", {
-            "db.warehouse.state": state,
-            "db.warehouse.attempt": attempt,
-            "db.warehouse.elapsed_ms": Date.now() - startTime,
-            ...(summary ? { "db.warehouse.summary": summary } : {}),
-          });
-          // De-dup successive equal states. A cold-start that takes 60s no
-          // longer fans out 20 redundant SSE frames + 20 client re-renders.
-          if (state === lastEmittedState) return;
-          lastEmittedState = state;
-          const update: WarehouseStatusUpdate = {
-            state,
-            elapsedMs: Date.now() - startTime,
-            attempt,
-          };
-          try {
-            onStatus(update);
-          } catch (err) {
-            // The status callback is provided by the route; if it throws we
-            // still need to complete the readiness wait. Just log via span.
-            span.addEvent("warehouse.onStatus.error", {
-              "exception.message":
-                err instanceof Error ? err.message : String(err),
-            });
-          }
-        };
+        const backoff = new WarehousePollBackoff();
 
         try {
           while (true) {
-            if (signal?.aborted) {
-              throw ExecutionError.canceled();
-            }
-            const elapsed = Date.now() - startTime;
-            if (elapsed > timeoutMs) {
+            if (signal?.aborted) throw ExecutionError.canceled();
+            if (Date.now() - startTime > timeoutMs) {
               throw ExecutionError.statementFailed(
                 `Warehouse ${warehouseId} did not reach RUNNING within ${timeoutMs}ms`,
               );
@@ -469,9 +417,9 @@ export class SQLWarehouseConnector {
 
             switch (state) {
               case "RUNNING":
-                emit(state, summary);
+                emitter.emit(state, summary);
                 this._recentlyRunning.set(warehouseId, Date.now());
-                span.setAttribute("db.warehouse.attempts", attempt);
+                span.setAttribute("db.warehouse.attempts", emitter.attempt);
                 span.setStatus({ code: SpanStatusCode.OK });
                 return;
               case "DELETED":
@@ -488,68 +436,75 @@ export class SQLWarehouseConnector {
                   );
                 }
                 if (!didStart) {
-                  emit("STARTING", summary);
+                  emitter.emit("STARTING", summary);
                   await workspaceClient.warehouses.start(
                     { id: warehouseId },
                     this._createContext(signal),
                   );
                   didStart = true;
                 } else {
-                  // Already attempted to start but the warehouse went back to
-                  // STOPPED — surface the state and keep polling so the user
-                  // sees what's happening.
-                  emit(state, summary);
+                  // Warehouse fell back to STOPPED after our start attempt —
+                  // surface the state and keep polling.
+                  emitter.emit(state, summary);
                 }
                 break;
               case "STARTING":
               case "STOPPING":
-                emit(state, summary);
+                emitter.emit(state, summary);
                 break;
               default:
                 throw ExecutionError.unknownState(String(state ?? "unknown"));
             }
 
-            // Exponential backoff with ±15% jitter, capped at WAREHOUSE_POLL_MAX_MS.
-            const jitterFactor = 0.85 + Math.random() * 0.3;
-            await this._sleepRespectingAbort(
-              pollIntervalMs * jitterFactor,
-              signal,
-            );
-            pollIntervalMs = Math.min(
-              WAREHOUSE_POLL_MAX_MS,
-              pollIntervalMs * 2,
-            );
+            await this._sleepRespectingAbort(backoff.next(), signal);
           }
         } catch (error) {
-          // R1: never put raw SDK message text on the rethrown error. Keep
-          // structured AppKitErrors as-is (their messages are curated);
-          // wrap everything else in a fixed-text ExecutionError and put the
-          // original on the span only.
-          if (error instanceof AppKitError) {
-            span.recordException(error);
-            span.setStatus({
-              code: SpanStatusCode.ERROR,
-              message: error.code,
-            });
-            throw error;
-          }
-          span.recordException(
-            error instanceof Error ? error : new Error(String(error)),
-          );
-          const wrapped = ExecutionError.statementFailed(
-            `Warehouse readiness check failed for ${warehouseId}`,
-          );
-          span.setStatus({
-            code: SpanStatusCode.ERROR,
-            message: wrapped.code,
-          });
-          throw wrapped;
+          this._throwSanitizedReadinessError(error, warehouseId, span);
         } finally {
           span.end();
         }
       },
       { name: this.name, includePrefix: true },
     );
+  }
+
+  /**
+   * `true` if this connector observed `warehouseId` in the RUNNING state
+   * within the recent-cache TTL.
+   */
+  private _isRecentlyRunning(warehouseId: string): boolean {
+    const observedAt = this._recentlyRunning.get(warehouseId);
+    return (
+      observedAt !== undefined &&
+      Date.now() - observedAt < WAREHOUSE_RUNNING_CACHE_TTL_MS
+    );
+  }
+
+  /**
+   * Final landing for any error thrown by the readiness poll loop. Records
+   * the original on the span (so server-side debugging keeps the raw text)
+   * and rethrows either the structured AppKitError unchanged or a curated
+   * ExecutionError — never the raw SDK message, which can contain operator
+   * internals.
+   */
+  private _throwSanitizedReadinessError(
+    error: unknown,
+    warehouseId: string,
+    span: Span,
+  ): never {
+    if (error instanceof AppKitError) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR, message: error.code });
+      throw error;
+    }
+    span.recordException(
+      error instanceof Error ? error : new Error(String(error)),
+    );
+    const wrapped = ExecutionError.statementFailed(
+      `Warehouse readiness check failed for ${warehouseId}`,
+    );
+    span.setStatus({ code: SpanStatusCode.ERROR, message: wrapped.code });
+    throw wrapped;
   }
 
   /**

--- a/packages/appkit/src/connectors/sql-warehouse/client.ts
+++ b/packages/appkit/src/connectors/sql-warehouse/client.ts
@@ -6,6 +6,7 @@ import {
 import type { TelemetryOptions } from "shared";
 import {
   AppKitError,
+  ConfigurationError,
   ConnectionError,
   ExecutionError,
   ValidationError,
@@ -30,6 +31,68 @@ interface SQLWarehouseConfig {
   telemetry?: TelemetryOptions;
 }
 
+/**
+ * Default ceiling for how long {@link SQLWarehouseConnector.ensureWarehouseRunning}
+ * will wait for a warehouse to reach the RUNNING state before giving up.
+ *
+ * Five minutes covers a cold-start of a classic warehouse on most workspaces;
+ * serverless typically reaches RUNNING within ~30s.
+ */
+export const DEFAULT_WAREHOUSE_STARTUP_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * Polling backoff bounds for the warehouse readiness loop. Backoff is
+ * exponential with ±15% jitter to spread retries across concurrent waiters.
+ */
+const WAREHOUSE_POLL_INITIAL_MS = 1_000;
+const WAREHOUSE_POLL_MAX_MS = 30_000;
+
+/**
+ * Window during which a recent `RUNNING` observation lets subsequent calls
+ * to {@link SQLWarehouseConnector.ensureWarehouseRunning} short-circuit
+ * without making any SDK calls. Sized to roughly the upper bound of how
+ * long Databricks keeps a warehouse "stickily" available between requests
+ * — past that, we re-verify.
+ */
+const WAREHOUSE_RUNNING_CACHE_TTL_MS = 30_000;
+
+/**
+ * A single observation of the warehouse state, emitted by
+ * {@link SQLWarehouseConnector.ensureWarehouseRunning} so callers can stream
+ * progress to clients (e.g. over SSE).
+ *
+ * Note: `health.summary` from the SDK is intentionally NOT exposed on this
+ * type. It's free-form operator-oriented diagnostic text (cluster IDs,
+ * capacity-failure reasons, internal RPC errors) that must not reach end
+ * users. The raw value stays in the OTel span attributes for server-side
+ * debugging only.
+ */
+export interface WarehouseStatusUpdate {
+  /** Current state from the SDK (RUNNING | STARTING | STOPPED | STOPPING | DELETED | DELETING). */
+  state: sql.State;
+  /** Milliseconds elapsed since `ensureWarehouseRunning` was called. */
+  elapsedMs: number;
+  /** 1-based attempt counter — useful for tests and telemetry. */
+  attempt: number;
+}
+
+/** Options for {@link SQLWarehouseConnector.ensureWarehouseRunning}. */
+interface EnsureWarehouseRunningOptions {
+  /** Invoked every time the warehouse state changes during the wait. */
+  onStatus: (update: WarehouseStatusUpdate) => void;
+  /** Aborts the wait. The connector treats abort as `ExecutionError.canceled()`. */
+  signal?: AbortSignal;
+  /** Hard ceiling on the total wait. Defaults to {@link DEFAULT_WAREHOUSE_STARTUP_TIMEOUT_MS}. */
+  timeoutMs?: number;
+  /**
+   * When `true` (default), a `STOPPED` warehouse is auto-started.
+   * When `false`, `STOPPED` surfaces as `ConfigurationError` immediately —
+   * useful for cost-controlled deployments that don't want any caller to
+   * trigger billable warehouse starts.
+   */
+  autoStart?: boolean;
+}
+
 export class SQLWarehouseConnector {
   private readonly name = "sql-warehouse";
 
@@ -37,6 +100,14 @@ export class SQLWarehouseConnector {
 
   // Lazy-initialized: only created when Arrow format is used
   private _arrowProcessor: ArrowStreamProcessor | null = null;
+
+  /**
+   * Per-warehouse "recently observed RUNNING" cache. Lets warm-path
+   * requests skip the readiness loop (and its `warehouses.get` round-trip)
+   * entirely. Map values are the timestamp of the last RUNNING observation;
+   * see {@link WAREHOUSE_RUNNING_CACHE_TTL_MS}.
+   */
+  private _recentlyRunning = new Map<string, number>();
   // telemetry
   private readonly telemetry: TelemetryProvider;
   private readonly telemetryMetrics: {
@@ -276,6 +347,233 @@ export class SQLWarehouseConnector {
       },
       { name: this.name, includePrefix: true },
     );
+  }
+
+  /**
+   * Wait until the SQL warehouse is in the `RUNNING` state, auto-starting it
+   * if currently `STOPPED`. Emits one {@link WarehouseStatusUpdate} per
+   * observation so callers can surface progress (e.g. over SSE) instead of
+   * letting the UI freeze on a cold warehouse.
+   *
+   * Behaviour by initial state:
+   * - `RUNNING`: emits one update and returns immediately.
+   * - `STOPPED`: emits a `STARTING` update, calls
+   *   `workspaceClient.warehouses.start`, then polls until `RUNNING`.
+   * - `STARTING` / `STOPPING`: polls until `RUNNING`.
+   * - `DELETED` / `DELETING`: throws `ConfigurationError.resourceNotFound`.
+   *
+   * Aborts and timeouts surface as `ExecutionError`. The whole loop runs
+   * inside a `sql.warehouseReady` telemetry span.
+   */
+  async ensureWarehouseRunning(
+    workspaceClient: WorkspaceClient,
+    warehouseId: string,
+    opts: EnsureWarehouseRunningOptions,
+  ): Promise<void> {
+    const {
+      onStatus,
+      signal,
+      timeoutMs = DEFAULT_WAREHOUSE_STARTUP_TIMEOUT_MS,
+      autoStart = true,
+    } = opts;
+
+    if (signal?.aborted) {
+      throw ExecutionError.canceled();
+    }
+
+    if (!warehouseId) {
+      throw ValidationError.missingField("warehouse_id");
+    }
+
+    // Fast path: skip the readiness loop entirely (no SDK round-trip, no
+    // SSE warehouse_status events) when this connector recently observed
+    // the warehouse RUNNING. Keeps the steady-state hot path off the
+    // Databricks control plane so cache-hit analytics requests aren't
+    // taxed an extra ~50–200 ms RTT per call.
+    const observedAt = this._recentlyRunning.get(warehouseId);
+    if (
+      observedAt !== undefined &&
+      Date.now() - observedAt < WAREHOUSE_RUNNING_CACHE_TTL_MS
+    ) {
+      return;
+    }
+
+    return this.telemetry.startActiveSpan(
+      "sql.warehouseReady",
+      {
+        kind: SpanKind.CLIENT,
+        attributes: {
+          "db.system": "databricks",
+          "db.warehouse_id": warehouseId,
+          "db.warehouse.startup_timeout_ms": timeoutMs,
+        },
+      },
+      async (span: Span) => {
+        const startTime = Date.now();
+        let attempt = 0;
+        let didStart = false;
+        let lastEmittedState: sql.State | null = null;
+        let pollIntervalMs = WAREHOUSE_POLL_INITIAL_MS;
+
+        const emit = (state: sql.State, summary: string | undefined): void => {
+          attempt += 1;
+          // Record the raw SDK summary on the span for server-side debugging
+          // only — never on the wire (R1: SDK health.summary contains
+          // operator-oriented internals like cluster IDs and capacity
+          // reasons that must not reach end users).
+          span.addEvent("warehouse.status", {
+            "db.warehouse.state": state,
+            "db.warehouse.attempt": attempt,
+            "db.warehouse.elapsed_ms": Date.now() - startTime,
+            ...(summary ? { "db.warehouse.summary": summary } : {}),
+          });
+          // De-dup successive equal states. A cold-start that takes 60s no
+          // longer fans out 20 redundant SSE frames + 20 client re-renders.
+          if (state === lastEmittedState) return;
+          lastEmittedState = state;
+          const update: WarehouseStatusUpdate = {
+            state,
+            elapsedMs: Date.now() - startTime,
+            attempt,
+          };
+          try {
+            onStatus(update);
+          } catch (err) {
+            // The status callback is provided by the route; if it throws we
+            // still need to complete the readiness wait. Just log via span.
+            span.addEvent("warehouse.onStatus.error", {
+              "exception.message":
+                err instanceof Error ? err.message : String(err),
+            });
+          }
+        };
+
+        try {
+          while (true) {
+            if (signal?.aborted) {
+              throw ExecutionError.canceled();
+            }
+            const elapsed = Date.now() - startTime;
+            if (elapsed > timeoutMs) {
+              throw ExecutionError.statementFailed(
+                `Warehouse ${warehouseId} did not reach RUNNING within ${timeoutMs}ms`,
+              );
+            }
+
+            const info = await workspaceClient.warehouses.get(
+              { id: warehouseId },
+              this._createContext(signal),
+            );
+            const state = info?.state;
+            const summary = info?.health?.summary;
+
+            switch (state) {
+              case "RUNNING":
+                emit(state, summary);
+                this._recentlyRunning.set(warehouseId, Date.now());
+                span.setAttribute("db.warehouse.attempts", attempt);
+                span.setStatus({ code: SpanStatusCode.OK });
+                return;
+              case "DELETED":
+              case "DELETING":
+                throw ConfigurationError.resourceNotFound(
+                  "Warehouse ID",
+                  `Warehouse ${warehouseId} is ${state}. Configure DATABRICKS_WAREHOUSE_ID to point at an active warehouse.`,
+                );
+              case "STOPPED":
+                if (!autoStart) {
+                  throw ConfigurationError.resourceNotFound(
+                    "SQL warehouse",
+                    `Warehouse ${warehouseId} is STOPPED and analytics auto-start is disabled. Start the warehouse manually or set analytics.autoStartWarehouse=true.`,
+                  );
+                }
+                if (!didStart) {
+                  emit("STARTING", summary);
+                  await workspaceClient.warehouses.start(
+                    { id: warehouseId },
+                    this._createContext(signal),
+                  );
+                  didStart = true;
+                } else {
+                  // Already attempted to start but the warehouse went back to
+                  // STOPPED — surface the state and keep polling so the user
+                  // sees what's happening.
+                  emit(state, summary);
+                }
+                break;
+              case "STARTING":
+              case "STOPPING":
+                emit(state, summary);
+                break;
+              default:
+                throw ExecutionError.unknownState(String(state ?? "unknown"));
+            }
+
+            // Exponential backoff with ±15% jitter, capped at WAREHOUSE_POLL_MAX_MS.
+            const jitterFactor = 0.85 + Math.random() * 0.3;
+            await this._sleepRespectingAbort(
+              pollIntervalMs * jitterFactor,
+              signal,
+            );
+            pollIntervalMs = Math.min(
+              WAREHOUSE_POLL_MAX_MS,
+              pollIntervalMs * 2,
+            );
+          }
+        } catch (error) {
+          // R1: never put raw SDK message text on the rethrown error. Keep
+          // structured AppKitErrors as-is (their messages are curated);
+          // wrap everything else in a fixed-text ExecutionError and put the
+          // original on the span only.
+          if (error instanceof AppKitError) {
+            span.recordException(error);
+            span.setStatus({
+              code: SpanStatusCode.ERROR,
+              message: error.code,
+            });
+            throw error;
+          }
+          span.recordException(
+            error instanceof Error ? error : new Error(String(error)),
+          );
+          const wrapped = ExecutionError.statementFailed(
+            `Warehouse readiness check failed for ${warehouseId}`,
+          );
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: wrapped.code,
+          });
+          throw wrapped;
+        } finally {
+          span.end();
+        }
+      },
+      { name: this.name, includePrefix: true },
+    );
+  }
+
+  /**
+   * Sleep for `ms` milliseconds, but resolve early (and reject with
+   * `ExecutionError.canceled()`) if `signal` aborts mid-sleep. Used by the
+   * warehouse readiness loop so that client disconnects don't keep the loop
+   * polling for the full interval.
+   */
+  private _sleepRespectingAbort(
+    ms: number,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    if (signal?.aborted) return Promise.reject(ExecutionError.canceled());
+    return new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        signal?.removeEventListener("abort", onAbort);
+        resolve();
+      }, ms);
+      const onAbort = () => {
+        clearTimeout(timer);
+        reject(ExecutionError.canceled());
+      };
+      signal?.addEventListener("abort", onAbort, { once: true });
+    });
   }
 
   private async _pollForStatementResult(

--- a/packages/appkit/src/connectors/sql-warehouse/client.ts
+++ b/packages/appkit/src/connectors/sql-warehouse/client.ts
@@ -404,7 +404,7 @@ export class SQLWarehouseConnector {
             if (signal?.aborted) throw ExecutionError.canceled();
             if (Date.now() - startTime > timeoutMs) {
               throw ExecutionError.statementFailed(
-                `Warehouse ${warehouseId} did not reach RUNNING within ${timeoutMs}ms`,
+                `SQL warehouse did not reach RUNNING within ${timeoutMs}ms`,
               );
             }
 
@@ -426,13 +426,16 @@ export class SQLWarehouseConnector {
               case "DELETING":
                 throw ConfigurationError.resourceNotFound(
                   "Warehouse ID",
-                  `Warehouse ${warehouseId} is ${state}. Configure DATABRICKS_WAREHOUSE_ID to point at an active warehouse.`,
+                  `The configured SQL warehouse is ${state}. Update DATABRICKS_WAREHOUSE_ID to point at an active warehouse.`,
                 );
               case "STOPPED":
                 if (!autoStart) {
-                  throw ConfigurationError.resourceNotFound(
-                    "SQL warehouse",
-                    `Warehouse ${warehouseId} is STOPPED and analytics auto-start is disabled. Start the warehouse manually or set analytics.autoStartWarehouse=true.`,
+                  // The warehouse exists, it's just in the wrong state and
+                  // policy forbids auto-starting it — use the base
+                  // ConfigurationError directly so the message isn't
+                  // prefixed with "not found".
+                  throw new ConfigurationError(
+                    "The configured SQL warehouse is STOPPED and analytics auto-start is disabled. Start the warehouse manually or set analytics.autoStartWarehouse=true.",
                   );
                 }
                 if (!didStart) {
@@ -456,7 +459,17 @@ export class SQLWarehouseConnector {
                 throw ExecutionError.unknownState(String(state ?? "unknown"));
             }
 
-            await this._sleepRespectingAbort(backoff.next(), signal);
+            // Preempt the next timeout check: if sleeping the full backoff
+            // would push us past `timeoutMs`, throw now rather than waste
+            // up to ~30s sleeping past the deadline (`backoff.next()` caps
+            // at WAREHOUSE_POLL_MAX_MS).
+            const sleepMs = backoff.next();
+            if (Date.now() + sleepMs - startTime >= timeoutMs) {
+              throw ExecutionError.statementFailed(
+                `SQL warehouse did not reach RUNNING within ${timeoutMs}ms`,
+              );
+            }
+            await this._sleepRespectingAbort(sleepMs, signal);
           }
         } catch (error) {
           this._throwSanitizedReadinessError(error, warehouseId, span);
@@ -482,10 +495,14 @@ export class SQLWarehouseConnector {
 
   /**
    * Final landing for any error thrown by the readiness poll loop. Records
-   * the original on the span (so server-side debugging keeps the raw text)
-   * and rethrows either the structured AppKitError unchanged or a curated
+   * the original on the span and (at debug level) on the logger, then
+   * rethrows either the structured AppKitError unchanged or a curated
    * ExecutionError — never the raw SDK message, which can contain operator
    * internals.
+   *
+   * The `logger.debug` covers environments where OTel isn't configured
+   * (common in dev) so the raw error isn't lost just because no span
+   * exporter is hooked up.
    */
   private _throwSanitizedReadinessError(
     error: unknown,
@@ -500,8 +517,13 @@ export class SQLWarehouseConnector {
     span.recordException(
       error instanceof Error ? error : new Error(String(error)),
     );
+    logger.debug(
+      "Warehouse readiness check raw error for %s: %O",
+      warehouseId,
+      error,
+    );
     const wrapped = ExecutionError.statementFailed(
-      `Warehouse readiness check failed for ${warehouseId}`,
+      "Warehouse readiness check failed",
     );
     span.setStatus({ code: SpanStatusCode.ERROR, message: wrapped.code });
     throw wrapped;

--- a/packages/appkit/src/connectors/sql-warehouse/warehouse-poll-backoff.ts
+++ b/packages/appkit/src/connectors/sql-warehouse/warehouse-poll-backoff.ts
@@ -1,0 +1,21 @@
+const WAREHOUSE_POLL_INITIAL_MS = 1_000;
+const WAREHOUSE_POLL_MAX_MS = 30_000;
+
+/**
+ * Stateful exponential backoff for the warehouse readiness poll loop. Each
+ * `next()` returns the next sleep duration with ±15% jitter applied, then
+ * doubles the underlying interval up to {@link WAREHOUSE_POLL_MAX_MS}.
+ *
+ * Jitter spreads retries across concurrent waiters; the cap (30s) prevents
+ * pathological starvation when a warehouse takes minutes to come up.
+ */
+export class WarehousePollBackoff {
+  private intervalMs = WAREHOUSE_POLL_INITIAL_MS;
+
+  /** Returns the next sleep duration in ms; advances internal state. */
+  next(): number {
+    const sleep = this.intervalMs * (0.85 + Math.random() * 0.3);
+    this.intervalMs = Math.min(WAREHOUSE_POLL_MAX_MS, this.intervalMs * 2);
+    return sleep;
+  }
+}

--- a/packages/appkit/src/connectors/sql-warehouse/warehouse-status-emitter.ts
+++ b/packages/appkit/src/connectors/sql-warehouse/warehouse-status-emitter.ts
@@ -1,0 +1,43 @@
+import type { sql } from "@databricks/sdk-experimental";
+import type { Span } from "../../telemetry";
+import type { WarehouseStatusUpdate } from "./client";
+
+/**
+ * Tracks state-change emissions for the warehouse readiness loop. Records
+ * every poll on the OTel span and forwards real state changes (with de-dup)
+ * to the route's `onStatus` callback. The raw SDK `health.summary` is
+ * recorded on the span only — never on the wire.
+ */
+export class WarehouseStatusEmitter {
+  attempt = 0;
+  private lastEmittedState: sql.State | null = null;
+
+  constructor(
+    private readonly span: Span,
+    private readonly startTime: number,
+    private readonly onStatus: (update: WarehouseStatusUpdate) => void,
+  ) {}
+
+  emit(state: sql.State, summary: string | undefined): void {
+    this.attempt += 1;
+    this.span.addEvent("warehouse.status", {
+      "db.warehouse.state": state,
+      "db.warehouse.attempt": this.attempt,
+      "db.warehouse.elapsed_ms": Date.now() - this.startTime,
+      ...(summary ? { "db.warehouse.summary": summary } : {}),
+    });
+    if (state === this.lastEmittedState) return;
+    this.lastEmittedState = state;
+    try {
+      this.onStatus({
+        state,
+        elapsedMs: Date.now() - this.startTime,
+        attempt: this.attempt,
+      });
+    } catch (err) {
+      this.span.addEvent("warehouse.onStatus.error", {
+        "exception.message": err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}

--- a/packages/appkit/src/connectors/tests/sql-warehouse.test.ts
+++ b/packages/appkit/src/connectors/tests/sql-warehouse.test.ts
@@ -218,7 +218,23 @@ describe("SQLWarehouseConnector", () => {
         connector.ensureWarehouseRunning(wsClient as any, "wh-4", {
           onStatus: (u) => updates.push(u),
         }),
-      ).rejects.toThrow(/wh-4 is DELETED/);
+      ).rejects.toThrow(/configured SQL warehouse is DELETED/);
+
+      expect(start).not.toHaveBeenCalled();
+      expect(updates).toHaveLength(0);
+    });
+
+    test("rejects when warehouse is DELETING", async () => {
+      const get = vi.fn().mockResolvedValue({ state: "DELETING" });
+      const start = vi.fn();
+      const wsClient = { warehouses: { get, start } };
+      const updates: any[] = [];
+
+      await expect(
+        connector.ensureWarehouseRunning(wsClient as any, "wh-deleting", {
+          onStatus: (u) => updates.push(u),
+        }),
+      ).rejects.toThrow(/configured SQL warehouse is DELETING/);
 
       expect(start).not.toHaveBeenCalled();
       expect(updates).toHaveLength(0);
@@ -345,7 +361,7 @@ describe("SQLWarehouseConnector", () => {
         connector.ensureWarehouseRunning(wsClient as any, "wh-leak", {
           onStatus: () => {},
         }),
-      ).rejects.toThrow(/Warehouse readiness check failed for wh-leak/);
+      ).rejects.toThrow(/Warehouse readiness check failed/);
       // Verify the raw SDK text didn't survive into the thrown error.
       try {
         await connector.ensureWarehouseRunning(wsClient as any, "wh-leak", {
@@ -355,6 +371,35 @@ describe("SQLWarehouseConnector", () => {
         expect((err as Error).message).not.toContain(sensitive);
         expect((err as Error).message).not.toContain("ENOTFOUND");
       }
+    });
+
+    test("continues the readiness loop when onStatus callback throws", async () => {
+      // A consumer crash mid-poll must not abort the readiness contract;
+      // the emitter swallows the throw onto the OTel span and the loop
+      // keeps polling until the warehouse reports RUNNING.
+      const get = vi
+        .fn()
+        .mockResolvedValueOnce({ state: "STARTING" })
+        .mockResolvedValueOnce({ state: "RUNNING" });
+      const wsClient = { warehouses: { get, start: vi.fn() } };
+      let callCount = 0;
+
+      const promise = connector.ensureWarehouseRunning(
+        wsClient as any,
+        "wh-throw",
+        {
+          onStatus: () => {
+            callCount += 1;
+            throw new Error("consumer crashed");
+          },
+          timeoutMs: 60_000,
+        },
+      );
+      await vi.runAllTimersAsync();
+      await expect(promise).resolves.toBeUndefined();
+
+      expect(get).toHaveBeenCalledTimes(2);
+      expect(callCount).toBe(2);
     });
   });
 });

--- a/packages/appkit/src/connectors/tests/sql-warehouse.test.ts
+++ b/packages/appkit/src/connectors/tests/sql-warehouse.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { SQLWarehouseConnector } from "../sql-warehouse";
 
 // Mock telemetry to pass through span callbacks
@@ -114,6 +114,247 @@ describe("SQLWarehouseConnector", () => {
       expect(loggedOutput).not.toContain("vault");
 
       errorSpy.mockRestore();
+    });
+  });
+
+  describe("ensureWarehouseRunning", () => {
+    let connector: SQLWarehouseConnector;
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      connector = new SQLWarehouseConnector({ timeout: 5000 });
+      // Use fake timers so the 3s poll interval doesn't sleep in real time.
+      // Each test that needs polling drains scheduled timers via
+      // `vi.runAllTimersAsync()` to fast-forward through the loop.
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    test("emits a single RUNNING update and returns when warehouse is already running", async () => {
+      const get = vi.fn().mockResolvedValue({ state: "RUNNING" });
+      const start = vi.fn();
+      const wsClient = { warehouses: { get, start } };
+      const updates: any[] = [];
+
+      await connector.ensureWarehouseRunning(wsClient as any, "wh-1", {
+        onStatus: (u) => updates.push(u),
+      });
+
+      expect(get).toHaveBeenCalledTimes(1);
+      expect(start).not.toHaveBeenCalled();
+      expect(updates).toHaveLength(1);
+      expect(updates[0].state).toBe("RUNNING");
+      expect(updates[0].attempt).toBe(1);
+    });
+
+    test("starts a STOPPED warehouse and waits until RUNNING", async () => {
+      const get = vi
+        .fn()
+        .mockResolvedValueOnce({ state: "STOPPED" })
+        .mockResolvedValueOnce({ state: "STARTING" })
+        .mockResolvedValueOnce({ state: "RUNNING" });
+      const start = vi.fn().mockResolvedValue(undefined);
+      const wsClient = { warehouses: { get, start } };
+      const updates: any[] = [];
+
+      const promise = connector.ensureWarehouseRunning(
+        wsClient as any,
+        "wh-2",
+        {
+          onStatus: (u) => updates.push(u),
+          timeoutMs: 60_000,
+        },
+      );
+      // Fast-forward through the inter-poll sleeps.
+      await vi.runAllTimersAsync();
+      await promise;
+
+      expect(start).toHaveBeenCalledTimes(1);
+      expect(start).toHaveBeenCalledWith({ id: "wh-2" }, expect.anything());
+      // STOPPED branch emits a synthetic STARTING update before calling start,
+      // then de-dup suppresses the redundant STARTING from the next poll,
+      // and finally RUNNING is emitted.
+      const states = updates.map((u) => u.state);
+      expect(states).toEqual(["STARTING", "RUNNING"]);
+      // attempt counter still increments per poll, so the final entry is on
+      // the third observation even though only two updates fire.
+      expect(updates.at(-1).attempt).toBe(3);
+    });
+
+    test("polls a STARTING warehouse until RUNNING without calling start", async () => {
+      const get = vi
+        .fn()
+        .mockResolvedValueOnce({ state: "STARTING" })
+        .mockResolvedValueOnce({ state: "RUNNING" });
+      const start = vi.fn();
+      const wsClient = { warehouses: { get, start } };
+      const updates: any[] = [];
+
+      const promise = connector.ensureWarehouseRunning(
+        wsClient as any,
+        "wh-3",
+        {
+          onStatus: (u) => updates.push(u),
+          timeoutMs: 60_000,
+        },
+      );
+      await vi.runAllTimersAsync();
+      await promise;
+
+      expect(start).not.toHaveBeenCalled();
+      expect(updates.map((u) => u.state)).toEqual(["STARTING", "RUNNING"]);
+    });
+
+    test("rejects when warehouse is DELETED", async () => {
+      const get = vi.fn().mockResolvedValue({ state: "DELETED" });
+      const start = vi.fn();
+      const wsClient = { warehouses: { get, start } };
+      const updates: any[] = [];
+
+      await expect(
+        connector.ensureWarehouseRunning(wsClient as any, "wh-4", {
+          onStatus: (u) => updates.push(u),
+        }),
+      ).rejects.toThrow(/wh-4 is DELETED/);
+
+      expect(start).not.toHaveBeenCalled();
+      expect(updates).toHaveLength(0);
+    });
+
+    test("aborts immediately when signal is already aborted", async () => {
+      const get = vi.fn();
+      const wsClient = { warehouses: { get, start: vi.fn() } };
+      const controller = new AbortController();
+      controller.abort();
+
+      await expect(
+        connector.ensureWarehouseRunning(wsClient as any, "wh-5", {
+          onStatus: () => {},
+          signal: controller.signal,
+        }),
+      ).rejects.toThrow(/canceled/i);
+      expect(get).not.toHaveBeenCalled();
+    });
+
+    test("times out if warehouse never reaches RUNNING", async () => {
+      const get = vi.fn().mockResolvedValue({ state: "STARTING" });
+      const wsClient = { warehouses: { get, start: vi.fn() } };
+
+      const promise = connector.ensureWarehouseRunning(
+        wsClient as any,
+        "wh-6",
+        {
+          onStatus: () => {},
+          // 1ms timeout — the first poll succeeds (sleeps 3s), then the next
+          // iteration sees elapsed > timeoutMs and throws.
+          timeoutMs: 1,
+        },
+      );
+      // Attach the assertion synchronously before running timers so the
+      // rejection is awaited and not flagged as an unhandled promise.
+      const assertion = expect(promise).rejects.toThrow(
+        /did not reach RUNNING/,
+      );
+      await vi.runAllTimersAsync();
+      await assertion;
+    });
+
+    test("rejects when warehouse_id is empty", async () => {
+      const wsClient = {
+        warehouses: { get: vi.fn(), start: vi.fn() },
+      };
+
+      await expect(
+        connector.ensureWarehouseRunning(wsClient as any, "", {
+          onStatus: () => {},
+        }),
+      ).rejects.toThrow(/warehouse_id/);
+    });
+
+    test("skips the SDK round-trip on a subsequent call within the recently-running TTL", async () => {
+      const get = vi.fn().mockResolvedValue({ state: "RUNNING" });
+      const wsClient = { warehouses: { get, start: vi.fn() } };
+
+      const updates1: any[] = [];
+      await connector.ensureWarehouseRunning(wsClient as any, "wh-cache", {
+        onStatus: (u) => updates1.push(u),
+      });
+
+      const updates2: any[] = [];
+      await connector.ensureWarehouseRunning(wsClient as any, "wh-cache", {
+        onStatus: (u) => updates2.push(u),
+      });
+
+      // First call observed RUNNING and emitted; second call short-circuited.
+      expect(get).toHaveBeenCalledTimes(1);
+      expect(updates1.map((u) => u.state)).toEqual(["RUNNING"]);
+      expect(updates2).toEqual([]);
+    });
+
+    test("rejects with ConfigurationError when STOPPED and autoStart is false", async () => {
+      const get = vi.fn().mockResolvedValue({ state: "STOPPED" });
+      const start = vi.fn();
+      const wsClient = { warehouses: { get, start } };
+
+      await expect(
+        connector.ensureWarehouseRunning(wsClient as any, "wh-no-auto", {
+          onStatus: () => {},
+          autoStart: false,
+        }),
+      ).rejects.toThrow(/STOPPED.*auto-start is disabled/i);
+      expect(start).not.toHaveBeenCalled();
+    });
+
+    test("de-duplicates successive equal states", async () => {
+      const get = vi
+        .fn()
+        .mockResolvedValueOnce({ state: "STARTING" })
+        .mockResolvedValueOnce({ state: "STARTING" })
+        .mockResolvedValueOnce({ state: "STARTING" })
+        .mockResolvedValueOnce({ state: "RUNNING" });
+      const wsClient = { warehouses: { get, start: vi.fn() } };
+      const updates: any[] = [];
+
+      const promise = connector.ensureWarehouseRunning(
+        wsClient as any,
+        "wh-dedup",
+        {
+          onStatus: (u) => updates.push(u),
+          timeoutMs: 60_000,
+        },
+      );
+      await vi.runAllTimersAsync();
+      await promise;
+
+      // Three STARTING polls collapse into one emitted update; RUNNING is
+      // its own emission. attempt counts every poll, not every emission.
+      const states = updates.map((u) => u.state);
+      expect(states).toEqual(["STARTING", "RUNNING"]);
+    });
+
+    test("does not leak raw SDK error text in the rethrown error", async () => {
+      const sensitive =
+        "getaddrinfo ENOTFOUND adb-1234567890.10.azuredatabricks.net";
+      const get = vi.fn().mockRejectedValue(new Error(sensitive));
+      const wsClient = { warehouses: { get, start: vi.fn() } };
+
+      await expect(
+        connector.ensureWarehouseRunning(wsClient as any, "wh-leak", {
+          onStatus: () => {},
+        }),
+      ).rejects.toThrow(/Warehouse readiness check failed for wh-leak/);
+      // Verify the raw SDK text didn't survive into the thrown error.
+      try {
+        await connector.ensureWarehouseRunning(wsClient as any, "wh-leak", {
+          onStatus: () => {},
+        });
+      } catch (err) {
+        expect((err as Error).message).not.toContain(sensitive);
+        expect((err as Error).message).not.toContain("ENOTFOUND");
+      }
     });
   });
 });

--- a/packages/appkit/src/plugins/analytics/analytics.ts
+++ b/packages/appkit/src/plugins/analytics/analytics.ts
@@ -40,6 +40,54 @@ import { normalizeAnalyticsFormat } from "./types";
 
 const logger = createLogger("analytics");
 
+/**
+ * Bridges a callback-emitting async function into an async iterable.
+ *
+ * `start(emit)` runs concurrently; every value passed to `emit` is yielded
+ * in order. The iterable completes when `start`'s promise resolves and
+ * re-throws (after draining) if it rejects. Lets a callback-based progress
+ * API (e.g. SQL warehouse readiness) be consumed with `for await`.
+ */
+async function* streamCallbacks<T>(
+  start: (emit: (value: T) => void) => Promise<void>,
+): AsyncGenerator<T, void, unknown> {
+  const queue: T[] = [];
+  let wake: (() => void) | null = null;
+  let settled = false;
+  let error: unknown = null;
+
+  const notify = (): void => {
+    wake?.();
+    wake = null;
+  };
+
+  // The .then(_, err => ...) chain converts a rejection into a resolved
+  // promise; the consumer surfaces `error` after draining the queue.
+  void start((value) => {
+    queue.push(value);
+    notify();
+  }).then(
+    () => {
+      settled = true;
+      notify();
+    },
+    (err) => {
+      error = err;
+      settled = true;
+      notify();
+    },
+  );
+
+  while (!settled || queue.length > 0) {
+    while (queue.length > 0) yield queue.shift() as T;
+    if (settled) break;
+    await new Promise<void>((resolve) => {
+      wake = resolve;
+    });
+  }
+  if (error) throw error;
+}
+
 export class AnalyticsPlugin extends Plugin implements ToolProvider {
   /** Plugin manifest declaring metadata and resource requirements */
   static manifest = manifest as PluginManifest<"analytics">;
@@ -231,60 +279,29 @@ export class AnalyticsPlugin extends Plugin implements ToolProvider {
         const workspaceClient = getWorkspaceClient();
         const warehouseId = await getWarehouseId();
 
-        // Drain the warehouse-readiness updates as SSE events. The
-        // ensureWarehouseRunning call pushes to `queue` via onStatus; the
-        // generator wakes whenever onStatus fires or the call settles.
-        const queue: WarehouseStatusUpdate[] = [];
-        let wake: (() => void) | null = null;
-        let settled = false;
-        let readinessError: unknown = null;
-
-        // Errors from ensureWarehouseRunning are observed via readinessError
-        // below; the .then(_, err => ...) chain converts the rejection into
-        // a resolved promise so we don't need to await it after the drain.
-        void self.SQLClient.ensureWarehouseRunning(
-          workspaceClient,
-          warehouseId,
-          {
-            signal,
-            timeoutMs: startupTimeoutMs,
-            autoStart: autoStartWarehouse,
-            onStatus: (update) => {
-              queue.push(update);
-              wake?.();
-              wake = null;
-            },
-          },
-        ).then(
-          () => {
-            settled = true;
-            wake?.();
-            wake = null;
-          },
-          (err) => {
-            readinessError = err;
-            settled = true;
-            wake?.();
-            wake = null;
-          },
+        // Stream warehouse-readiness updates as SSE events, then run SQL.
+        const readinessUpdates = streamCallbacks<WarehouseStatusUpdate>(
+          (emit) =>
+            self.SQLClient.ensureWarehouseRunning(
+              workspaceClient,
+              warehouseId,
+              {
+                signal,
+                timeoutMs: startupTimeoutMs,
+                autoStart: autoStartWarehouse,
+                onStatus: emit,
+              },
+            ),
         );
-
-        while (!settled || queue.length > 0) {
-          while (queue.length > 0) {
-            const update = queue.shift() as WarehouseStatusUpdate;
-            const status: WarehouseStatus = {
+        for await (const update of readinessUpdates) {
+          yield {
+            type: "warehouse_status",
+            status: {
               state: update.state as WarehouseStatus["state"],
               elapsedMs: update.elapsedMs,
-            };
-            yield { type: "warehouse_status", status };
-          }
-          if (settled) break;
-          await new Promise<void>((resolve) => {
-            wake = resolve;
-          });
+            },
+          };
         }
-
-        if (readinessError) throw readinessError;
 
         const sqlResult = await executor.execute(
           async (sig) => {

--- a/packages/appkit/src/plugins/analytics/analytics.ts
+++ b/packages/appkit/src/plugins/analytics/analytics.ts
@@ -10,6 +10,10 @@ import type {
 } from "shared";
 import { z } from "zod";
 import { SQLWarehouseConnector } from "../../connectors";
+import {
+  DEFAULT_WAREHOUSE_STARTUP_TIMEOUT_MS,
+  type WarehouseStatusUpdate,
+} from "../../connectors/sql-warehouse/client";
 import { getWarehouseId, getWorkspaceClient } from "../../context";
 import { buildToolkitEntries } from "../../core/agent/build-toolkit";
 import {
@@ -18,6 +22,7 @@ import {
   toolsFromRegistry,
 } from "../../core/agent/tools/define-tool";
 import { assertReadOnlySql } from "../../core/agent/tools/sql-policy";
+import { ExecutionError } from "../../errors";
 import { createLogger } from "../../logging/logger";
 import { Plugin, toPlugin } from "../../plugin";
 import type { PluginManifest } from "../../registry";
@@ -26,8 +31,10 @@ import manifest from "./manifest.json";
 import { QueryProcessor } from "./query";
 import type {
   AnalyticsQueryResponse,
+  AnalyticsStreamMessage,
   IAnalyticsConfig,
   IAnalyticsQueryRequest,
+  WarehouseStatus,
 } from "./types";
 import { normalizeAnalyticsFormat } from "./types";
 
@@ -173,15 +180,18 @@ export class AnalyticsPlugin extends Plugin implements ToolProvider {
               disposition: "EXTERNAL_LINKS",
               format: "ARROW_STREAM",
             },
-            type: "arrow",
+            type: "arrow" as const,
           }
         : {
-            type: "result",
+            type: "result" as const,
           };
 
     const hashedQuery = this.queryProcessor.hashQuery(query);
 
-    const defaultConfig: PluginExecuteConfig = {
+    // Cache/retry/timeout are scoped to the SQL execution itself (inner
+    // `execute`) so the warehouse-readiness phase isn't subject to retries
+    // and the generator value never leaks into the cache.
+    const sqlConfig: PluginExecuteConfig = {
       ...queryDefaults,
       cache: {
         ...queryDefaults.cache,
@@ -196,26 +206,110 @@ export class AnalyticsPlugin extends Plugin implements ToolProvider {
       },
     };
 
+    // Outer stream: no cache/retry — `executeStream` would otherwise wrap the
+    // generator factory and cache the generator object itself. Telemetry +
+    // user-scoped trace context still apply.
     const streamExecutionSettings: StreamExecutionSettings = {
-      default: defaultConfig,
+      default: {
+        cache: { enabled: false },
+        retry: { enabled: false },
+      },
     };
+
+    const startupTimeoutMs =
+      this.config.warehouseStartupTimeoutMs ??
+      DEFAULT_WAREHOUSE_STARTUP_TIMEOUT_MS;
+    const autoStartWarehouse = this.config.autoStartWarehouse ?? true;
+
+    const self = this;
 
     await executor.executeStream(
       res,
-      async (signal) => {
-        const processedParams = await this.queryProcessor.processQueryParams(
-          query,
-          parameters,
+      async function* (
+        signal,
+      ): AsyncGenerator<AnalyticsStreamMessage, void, unknown> {
+        const workspaceClient = getWorkspaceClient();
+        const warehouseId = await getWarehouseId();
+
+        // Drain the warehouse-readiness updates as SSE events. The
+        // ensureWarehouseRunning call pushes to `queue` via onStatus; the
+        // generator wakes whenever onStatus fires or the call settles.
+        const queue: WarehouseStatusUpdate[] = [];
+        let wake: (() => void) | null = null;
+        let settled = false;
+        let readinessError: unknown = null;
+
+        // Errors from ensureWarehouseRunning are observed via readinessError
+        // below; the .then(_, err => ...) chain converts the rejection into
+        // a resolved promise so we don't need to await it after the drain.
+        void self.SQLClient.ensureWarehouseRunning(
+          workspaceClient,
+          warehouseId,
+          {
+            signal,
+            timeoutMs: startupTimeoutMs,
+            autoStart: autoStartWarehouse,
+            onStatus: (update) => {
+              queue.push(update);
+              wake?.();
+              wake = null;
+            },
+          },
+        ).then(
+          () => {
+            settled = true;
+            wake?.();
+            wake = null;
+          },
+          (err) => {
+            readinessError = err;
+            settled = true;
+            wake?.();
+            wake = null;
+          },
         );
 
-        const result = await executor.query(
-          query,
-          processedParams,
-          queryParameters.formatParameters,
-          signal,
+        while (!settled || queue.length > 0) {
+          while (queue.length > 0) {
+            const update = queue.shift() as WarehouseStatusUpdate;
+            const status: WarehouseStatus = {
+              state: update.state as WarehouseStatus["state"],
+              elapsedMs: update.elapsedMs,
+            };
+            yield { type: "warehouse_status", status };
+          }
+          if (settled) break;
+          await new Promise<void>((resolve) => {
+            wake = resolve;
+          });
+        }
+
+        if (readinessError) throw readinessError;
+
+        const sqlResult = await executor.execute(
+          async (sig) => {
+            const processedParams =
+              await self.queryProcessor.processQueryParams(query, parameters);
+            const result = await executor.query(
+              query,
+              processedParams,
+              queryParameters.formatParameters,
+              sig,
+            );
+            return { type: queryParameters.type, ...result };
+          },
+          { default: sqlConfig },
+          executorKey,
         );
 
-        return { type: queryParameters.type, ...result };
+        if (!sqlResult.ok) {
+          // Surface a typed AppKitError so StreamManager can categorize via
+          // the structured `code`. The HTTP status code from `execute()`
+          // doesn't apply to SSE error frames.
+          throw ExecutionError.statementFailed(sqlResult.message);
+        }
+
+        yield sqlResult.data as AnalyticsStreamMessage;
       },
       streamExecutionSettings,
       executorKey,

--- a/packages/appkit/src/plugins/analytics/manifest.json
+++ b/packages/appkit/src/plugins/analytics/manifest.json
@@ -43,6 +43,16 @@
           "type": "number",
           "default": 30000,
           "description": "Query execution timeout in milliseconds"
+        },
+        "warehouseStartupTimeoutMs": {
+          "type": "number",
+          "default": 300000,
+          "description": "Maximum time (ms) to wait for a STOPPED/STARTING SQL warehouse to reach RUNNING before failing the request"
+        },
+        "autoStartWarehouse": {
+          "type": "boolean",
+          "default": true,
+          "description": "When true, a STOPPED SQL warehouse is auto-started on the first analytics request. Set to false for cost-controlled deployments where billable warehouse starts must not be triggered by user requests."
         }
       }
     }

--- a/packages/appkit/src/plugins/analytics/tests/analytics.test.ts
+++ b/packages/appkit/src/plugins/analytics/tests/analytics.test.ts
@@ -585,6 +585,71 @@ describe("Analytics Plugin", () => {
       );
     });
 
+    test("emits warehouse_status events before the result for a STARTING warehouse", async () => {
+      const plugin = new AnalyticsPlugin(config);
+      const { router, getHandler } = createMockRouter();
+
+      (plugin as any).app.getAppQuery = vi.fn().mockResolvedValue({
+        query: "SELECT * FROM test",
+        isAsUser: false,
+      });
+
+      const executeMock = vi.fn().mockResolvedValue({
+        result: { data: [{ id: 1, name: "test" }] },
+      });
+      (plugin as any).SQLClient.executeStatement = executeMock;
+
+      plugin.injectRoutes(router);
+
+      const handler = getHandler("POST", "/query/:query_key");
+
+      // Override the default RUNNING mock with a STARTING -> RUNNING sequence
+      // so the route streams a warehouse_status event before the result.
+      const warehouseGet = vi
+        .fn()
+        .mockResolvedValueOnce({ state: "STARTING" })
+        .mockResolvedValueOnce({ state: "RUNNING" });
+      const mockReq = createMockRequest({
+        params: { query_key: "test_query" },
+        body: { parameters: {} },
+      });
+      mockReq.serviceWorkspaceClient.warehouses.get = warehouseGet;
+      mockReq.userWorkspaceClient.warehouses.get = warehouseGet;
+      const mockRes = createMockResponse();
+
+      // The connector polls every 3s between warehouse state checks; use fake
+      // timers so the test doesn't actually sleep.
+      vi.useFakeTimers();
+      const handlerPromise = handler(mockReq, mockRes);
+      await vi.runAllTimersAsync();
+      await handlerPromise;
+      vi.useRealTimers();
+
+      // Inspect the SSE writes: a `warehouse_status` event must precede the
+      // `result` event.
+      const eventLines = (mockRes.write as any).mock.calls
+        .map((call: any[]) => call[0] as string)
+        .filter((s: string) => s.startsWith("event: "));
+      const warehouseIdx = eventLines.findIndex(
+        (s: string) => s === "event: warehouse_status\n",
+      );
+      const resultIdx = eventLines.findIndex(
+        (s: string) => s === "event: result\n",
+      );
+      expect(warehouseIdx).toBeGreaterThanOrEqual(0);
+      expect(resultIdx).toBeGreaterThanOrEqual(0);
+      expect(warehouseIdx).toBeLessThan(resultIdx);
+
+      // The status payload should include the state field.
+      expect(mockRes.write).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /"type":"warehouse_status".*"state":"(STARTING|RUNNING)"/,
+        ),
+      );
+
+      expect(executeMock).toHaveBeenCalledTimes(1);
+    });
+
     test("should return 404 when query file is not found", async () => {
       const plugin = new AnalyticsPlugin(config);
       const { router, getHandler } = createMockRouter();

--- a/packages/appkit/src/plugins/analytics/types.ts
+++ b/packages/appkit/src/plugins/analytics/types.ts
@@ -2,7 +2,64 @@ import type { BasePluginConfig } from "shared";
 
 export interface IAnalyticsConfig extends BasePluginConfig {
   timeout?: number;
+  /**
+   * Maximum time (ms) the analytics route waits for a STOPPED/STARTING SQL
+   * warehouse to reach RUNNING before failing the request. Defaults to 5 min.
+   */
+  warehouseStartupTimeoutMs?: number;
+  /**
+   * When `true` (default), a `STOPPED` SQL warehouse is auto-started on the
+   * first analytics request that reaches it. Set to `false` for cost-
+   * controlled deployments where billable warehouse starts must not be
+   * triggered by user requests; in that case `STOPPED` surfaces as a
+   * `ConfigurationError`.
+   */
+  autoStartWarehouse?: boolean;
 }
+
+/**
+ * SQL warehouse lifecycle states surfaced by the analytics route.
+ * Mirrors the states emitted by the Databricks SQL SDK (`sql.State`).
+ */
+export type WarehouseState =
+  | "RUNNING"
+  | "STARTING"
+  | "STOPPED"
+  | "STOPPING"
+  | "DELETED"
+  | "DELETING";
+
+/**
+ * Snapshot of warehouse readiness streamed to the client over SSE before the
+ * SQL result. Lets the UI render a "warehouse starting…" affordance instead
+ * of a frozen spinner during cold starts.
+ *
+ * Note: the SDK's `health.summary` is intentionally NOT forwarded here. It's
+ * free-form operator-oriented diagnostic text (cluster IDs, capacity-failure
+ * reasons, internal RPC errors) that must not reach end users; it stays in
+ * server-side telemetry only.
+ */
+export interface WarehouseStatus {
+  state: WarehouseState;
+  /** Milliseconds elapsed since the route began waiting for the warehouse. */
+  elapsedMs: number;
+}
+
+/**
+ * Discriminated union of every SSE message shape emitted by
+ * `POST /api/analytics/query/:query_key`. Useful for typing the client-side
+ * `onMessage` handler (and is the source of truth re-mirrored in
+ * `appkit-ui` since that package can't depend on `appkit`).
+ */
+export type AnalyticsStreamMessage =
+  | { type: "warehouse_status"; status: WarehouseStatus }
+  | { type: "result"; data: unknown[] }
+  | {
+      type: "arrow";
+      statement_id: string;
+      status: { state: string };
+    }
+  | { type: "error"; error: string; code?: string };
 
 /**
  * Supported response formats for analytics queries.

--- a/tools/test-helpers.ts
+++ b/tools/test-helpers.ts
@@ -107,6 +107,13 @@ export function createMockRequest(overrides: any = {}) {
         result: { data: [] },
       }),
     },
+    // Analytics route now calls `warehouses.get` before issuing SQL to
+    // ensure the warehouse is RUNNING. Default to RUNNING so existing
+    // tests that only care about SQL behaviour aren't affected.
+    warehouses: {
+      get: vi.fn().mockResolvedValue({ state: "RUNNING" }),
+      start: vi.fn().mockResolvedValue(undefined),
+    },
   };
 
   const req = {
@@ -203,6 +210,13 @@ export function createMockWorkspaceClient() {
         status: { state: "SUCCEEDED" },
         result: { data: [] },
       }),
+    },
+    // Analytics route now calls `warehouses.get` before issuing SQL to
+    // ensure the warehouse is RUNNING. Default to RUNNING so existing
+    // tests that only care about SQL behaviour aren't affected.
+    warehouses: {
+      get: vi.fn().mockResolvedValue({ state: "RUNNING" }),
+      start: vi.fn().mockResolvedValue(undefined),
     },
   };
 }
@@ -345,11 +359,20 @@ export async function parseSSEResponse(response: Response): Promise<any> {
 export function createConfigurableMockWorkspaceClient() {
   const executeStatement = vi.fn();
   const getStatement = vi.fn();
+  // Analytics route now calls `warehouses.get` before issuing SQL; default to
+  // RUNNING so callers that don't care about warehouse readiness don't have
+  // to wire it up.
+  const warehousesGet = vi.fn().mockResolvedValue({ state: "RUNNING" });
+  const warehousesStart = vi.fn().mockResolvedValue(undefined);
 
   const client = {
     statementExecution: {
       executeStatement,
       getStatement,
+    },
+    warehouses: {
+      get: warehousesGet,
+      start: warehousesStart,
     },
   };
 
@@ -358,6 +381,8 @@ export function createConfigurableMockWorkspaceClient() {
     mocks: {
       executeStatement,
       getStatement,
+      warehousesGet,
+      warehousesStart,
     },
   };
 }


### PR DESCRIPTION
## Summary

The analytics `/query` route used to fail or freeze the UI on a stalled spinner when the configured SQL warehouse was `STOPPED`/`STARTING`. This wires up auto-start + readiness streaming so the frontend can give users feedback during cold starts (which can take 30s–2min).

## What changed

- **`SqlWarehouseClient.ensureWarehouseRunning()`** — new method that checks warehouse state, calls `warehouses.start` when `STOPPED`, polls until `RUNNING` (configurable timeout, default 5min), and reports `DELETED`/`DELETING` as a hard error.
- **`/query` route handler is now an async generator** that yields `warehouse_status` events over SSE while the warehouse warms up, followed by the regular `result`/`arrow`/`error` event for the SQL itself.
- **Caching/retries** are kept on the inner SQL `execute()` call only — the outer stream isn't cached because async generators yield once per consumer.
- **New analytics plugin config:** `warehouseStartupTimeoutMs` (default `300000`).
- **Test helpers** default `workspaceClient.warehouses.{get,start}` to a `RUNNING`-warehouse mock so existing tests keep passing without modification.

## Follow-up

A follow-up PR exposes `warehouseStatus` on `useAnalyticsQuery`, suppresses misleading chart skeletons during warmup, and adds a generic `ResourceStatusProvider` + drop-in indicator (also wired into the template + playground). That PR is independent of this one — the new SSE event simply stays unused until both land.

## Test plan

- [x] Unit tests for `ensureWarehouseRunning` covering `RUNNING`, `STOPPED→start→poll→RUNNING`, `STARTING→poll→RUNNING`, `DELETED`/`DELETING`, abort, and timeout (with `vi.useFakeTimers`).
- [x] Analytics SSE test verifying `warehouse_status` events arrive before `result`.
- [x] Existing analytics suite passes with the new test-helpers default mocks.
- [x] Manual smoke against a real STOPPED warehouse before merge.