### PR TITLE
perf(connectors): singleflight ensureWarehouseRunning per warehouse

### DIFF
--- a/packages/appkit-ui/src/react/hooks/__tests__/use-analytics-query.test.ts
+++ b/packages/appkit-ui/src/react/hooks/__tests__/use-analytics-query.test.ts
@@ -1,16 +1,37 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
+let capturedCallbacks: {
+  onMessage?: (msg: { data: string }) => void;
+  onError?: (err: Error) => void;
+  signal?: AbortSignal;
+} = {};
+
+const mockFetchArrow = vi.fn();
+const mockProcessArrowBuffer = vi.fn();
+
 // Mock connectSSE so the hook does not attempt a real network request.
-const mockConnectSSE = vi.fn().mockImplementation((_opts: unknown) => {
-  // Return a never-resolving promise; tests don't need the result.
-  return new Promise<void>(() => {});
-});
+const mockConnectSSE = vi
+  .fn()
+  .mockImplementation(
+    (opts: {
+      onMessage?: (msg: { data: string }) => void;
+      onError?: (err: Error) => void;
+      signal?: AbortSignal;
+    }) => {
+      capturedCallbacks = {
+        onMessage: opts.onMessage,
+        onError: opts.onError,
+        signal: opts.signal,
+      };
+      return new Promise<void>(() => {});
+    },
+  );
 
 vi.mock("@/js", () => ({
   ArrowClient: {
-    fetchArrow: vi.fn(),
-    processArrowBuffer: vi.fn(),
+    fetchArrow: (...args: unknown[]) => mockFetchArrow(...args),
+    processArrowBuffer: (...args: unknown[]) => mockProcessArrowBuffer(...args),
   },
   connectSSE: (...args: unknown[]) => mockConnectSSE(...args),
 }));
@@ -22,13 +43,19 @@ vi.mock("../use-query-hmr", () => ({
 
 import { useAnalyticsQuery } from "../use-analytics-query";
 
+function markAborted() {
+  const sig = capturedCallbacks.signal;
+  if (!sig) throw new Error("signal not captured yet");
+  Object.defineProperty(sig, "aborted", { value: true, configurable: true });
+}
+
 describe("useAnalyticsQuery", () => {
   afterEach(() => {
+    capturedCallbacks = {};
     vi.clearAllMocks();
   });
 
   test("does not refetch when params object is structurally equal across renders", () => {
-    // Each render passes a fresh object literal — the common footgun.
     const { rerender } = renderHook(
       ({ limit }: { limit: number }) =>
         // biome-ignore lint/suspicious/noExplicitAny: typed registry not available in tests
@@ -36,15 +63,12 @@ describe("useAnalyticsQuery", () => {
       { initialProps: { limit: 10 } },
     );
 
-    // Initial render triggers exactly one connection.
     expect(mockConnectSSE).toHaveBeenCalledTimes(1);
 
-    // Re-render with structurally-equal-but-new-reference params.
     rerender({ limit: 10 });
     rerender({ limit: 10 });
     rerender({ limit: 10 });
 
-    // Should NOT have refetched — the hook stabilized the params reference.
     expect(mockConnectSSE).toHaveBeenCalledTimes(1);
   });
 
@@ -93,27 +117,26 @@ describe("useAnalyticsQuery", () => {
 
   describe("warehouse_status", () => {
     test("surfaces warehouseStatus while waiting and clears loading on result", async () => {
-      // Capture the connectSSE options so we can drive onMessage manually.
       let capturedOnMessage:
         | ((msg: { id: string; data: string }) => void)
         | null = null;
-      mockConnectSSE.mockImplementationOnce((opts: any) => {
-        capturedOnMessage = opts.onMessage;
-        return new Promise<void>(() => {});
-      });
+      mockConnectSSE.mockImplementationOnce(
+        (opts: { onMessage?: (msg: { id: string; data: string }) => void }) => {
+          capturedOnMessage = opts.onMessage ?? null;
+          return new Promise<void>(() => {});
+        },
+      );
 
       const { result } = renderHook(() =>
         // biome-ignore lint/suspicious/noExplicitAny: typed registry not available in tests
         useAnalyticsQuery("test_query" as any),
       );
 
-      // Initially: loading, no status, no data.
       expect(result.current.loading).toBe(true);
       expect(result.current.warehouseStatus).toBeNull();
       expect(result.current.data).toBeNull();
       expect(capturedOnMessage).toBeTruthy();
 
-      // Server emits a STARTING status — UI should show progress, still loading.
       act(() => {
         capturedOnMessage?.({
           id: "1",
@@ -133,7 +156,6 @@ describe("useAnalyticsQuery", () => {
       expect(result.current.loading).toBe(true);
       expect(result.current.data).toBeNull();
 
-      // Then RUNNING.
       act(() => {
         capturedOnMessage?.({
           id: "2",
@@ -148,7 +170,6 @@ describe("useAnalyticsQuery", () => {
         expect(result.current.warehouseStatus?.state).toBe("RUNNING");
       });
 
-      // Finally the SQL result lands.
       act(() => {
         capturedOnMessage?.({
           id: "3",
@@ -164,21 +185,19 @@ describe("useAnalyticsQuery", () => {
       });
       expect(result.current.data).toEqual([{ id: 1, name: "row1" }]);
       expect(result.current.error).toBeNull();
-      // warehouseStatus is left at its last observed value (RUNNING) so
-      // consumers that gated on `state !== "RUNNING"` flip back to data.
       expect(result.current.warehouseStatus?.state).toBe("RUNNING");
     });
 
     test("surfaces an error when a warehouse_status event has no status payload", async () => {
-      // A malformed frame must terminate the stream so the hook doesn't
-      // stay stuck in `loading: true` after a clean stream close.
       let capturedOnMessage:
         | ((msg: { id: string; data: string }) => void)
         | null = null;
-      mockConnectSSE.mockImplementationOnce((opts: any) => {
-        capturedOnMessage = opts.onMessage;
-        return new Promise<void>(() => {});
-      });
+      mockConnectSSE.mockImplementationOnce(
+        (opts: { onMessage?: (msg: { id: string; data: string }) => void }) => {
+          capturedOnMessage = opts.onMessage ?? null;
+          return new Promise<void>(() => {});
+        },
+      );
 
       const consoleError = vi
         .spyOn(console, "error")
@@ -201,6 +220,70 @@ describe("useAnalyticsQuery", () => {
       expect(result.current.warehouseStatus).toBeNull();
 
       consoleError.mockRestore();
+    });
+  });
+
+  describe("aborted controller", () => {
+    test("ignores late error envelope after the controller was aborted", async () => {
+      const { result } = renderHook(() =>
+        // biome-ignore lint/suspicious/noExplicitAny: typed registry not available in tests
+        useAnalyticsQuery("test_query" as any),
+      );
+
+      await waitFor(() => expect(capturedCallbacks.signal).toBeDefined());
+
+      markAborted();
+
+      await act(async () => {
+        await capturedCallbacks.onMessage?.({
+          data: JSON.stringify({
+            type: "error",
+            error: "Statement failed: The operation was aborted.",
+            code: "UPSTREAM_ERROR",
+          }),
+        });
+      });
+
+      expect(result.current.error).toBeNull();
+    });
+
+    test("ignores late result envelope after the controller was aborted", async () => {
+      const { result } = renderHook(() =>
+        // biome-ignore lint/suspicious/noExplicitAny: typed registry not available in tests
+        useAnalyticsQuery("test_query" as any),
+      );
+
+      await waitFor(() => expect(capturedCallbacks.signal).toBeDefined());
+
+      markAborted();
+
+      await act(async () => {
+        await capturedCallbacks.onMessage?.({
+          data: JSON.stringify({ type: "result", data: [{ id: 99 }] }),
+        });
+      });
+
+      expect(result.current.data).toBeNull();
+    });
+
+    test("ignores late arrow envelope after the controller was aborted", async () => {
+      const { result } = renderHook(() =>
+        useAnalyticsQuery("test_query", null, { format: "ARROW_STREAM" }),
+      );
+
+      await waitFor(() => expect(capturedCallbacks.signal).toBeDefined());
+
+      markAborted();
+
+      await act(async () => {
+        await capturedCallbacks.onMessage?.({
+          data: JSON.stringify({ type: "arrow", statement_id: "stmt-123" }),
+        });
+      });
+
+      expect(mockFetchArrow).not.toHaveBeenCalled();
+      expect(result.current.data).toBeNull();
+      expect(result.current.error).toBeNull();
     });
   });
 });

--- a/packages/appkit-ui/src/react/hooks/use-analytics-query.ts
+++ b/packages/appkit-ui/src/react/hooks/use-analytics-query.ts
@@ -263,6 +263,9 @@ export function useAnalyticsQuery<
       payload,
       signal: abortController.signal,
       onMessage: async (message) => {
+        // Drop late envelopes from a stream whose controller was already
+        // aborted (React StrictMode unmount→remount). Mirrors onError below.
+        if (abortController.signal.aborted) return;
         try {
           const parsed = JSON.parse(message.data) as Record<string, unknown>;
           await handleAnalyticsSseMessage(parsed, sseContext);

--- a/packages/appkit/src/connectors/sql-warehouse/client.ts
+++ b/packages/appkit/src/connectors/sql-warehouse/client.ts
@@ -52,13 +52,6 @@ export const DEFAULT_WAREHOUSE_STARTUP_TIMEOUT_MS = 5 * 60 * 1000;
 const WAREHOUSE_RUNNING_CACHE_TTL_MS = 30_000;
 
 /**
- * Delay before aborting a shared readiness poll when the last waiter leaves.
- * Matches {@link CacheManager}'s grace period so a React StrictMode
- * unmount→remount can rejoin the in-flight poll before it is cancelled.
- */
-const WAREHOUSE_READINESS_ABORT_GRACE_MS = 100;
-
-/**
  * A single observation of the warehouse state, emitted by
  * {@link SQLWarehouseConnector.ensureWarehouseRunning} so callers can stream
  * progress to clients (e.g. over SSE).
@@ -103,8 +96,6 @@ interface WarehouseReadinessInFlight {
   subscribers: Set<(update: WarehouseStatusUpdate) => void>;
   /** Last emitted update; replayed to late joiners. */
   lastUpdate: WarehouseStatusUpdate | null;
-  /** Pending delayed abort when the last waiter left (StrictMode grace). */
-  abortTimer?: ReturnType<typeof setTimeout>;
 }
 
 export class SQLWarehouseConnector {
@@ -329,6 +320,9 @@ export class SQLWarehouseConnector {
             );
           }
 
+          if (error instanceof Error && error.name === "AbortError") {
+            throw error;
+          }
           if (error instanceof AppKitError) {
             throw error;
           }
@@ -379,6 +373,9 @@ export class SQLWarehouseConnector {
    * Concurrent callers for the same `warehouseId` share a single in-flight
    * poll loop (singleflight): only the owner issues `get`/`start`; joiners
    * receive broadcast `onStatus` updates and share the result promise.
+   * The shared poll runs to completion (RUNNING, timeout, or hard error)
+   * even when every waiter disconnects — a late joiner or StrictMode remount
+   * can attach without racing a timed abort window.
    *
    * Behaviour by initial state:
    * - `RUNNING`: emits one update, caches the observation, returns.
@@ -428,13 +425,7 @@ export class SQLWarehouseConnector {
     join: boolean,
   ): Promise<void> {
     if (signal?.aborted) throw ExecutionError.canceled();
-    if (join) {
-      entry.refCount++;
-      if (entry.abortTimer) {
-        clearTimeout(entry.abortTimer);
-        entry.abortTimer = undefined;
-      }
-    }
+    if (join) entry.refCount++;
     entry.subscribers.add(onStatus);
     if (entry.lastUpdate) onStatus(entry.lastUpdate);
     return this._joinWarehouseReadiness(entry, signal);
@@ -488,10 +479,6 @@ export class SQLWarehouseConnector {
         { name: this.name, includePrefix: true },
       )
       .finally(() => {
-        if (entry.abortTimer) {
-          clearTimeout(entry.abortTimer);
-          entry.abortTimer = undefined;
-        }
         if (this._readinessInFlight.get(warehouseId) === entry) {
           this._readinessInFlight.delete(warehouseId);
         }
@@ -515,7 +502,7 @@ export class SQLWarehouseConnector {
     }
   }
 
-  /** Ref-counted await; shared poll aborts only when every waiter leaves. */
+  /** Ref-counted await; caller abort rejects locally, shared poll keeps running. */
   private _joinWarehouseReadiness(
     entry: WarehouseReadinessInFlight,
     callerSignal?: AbortSignal,
@@ -546,17 +533,9 @@ export class SQLWarehouseConnector {
 
   private _releaseReadinessWaiter(entry: WarehouseReadinessInFlight): void {
     if (entry.refCount > 0) entry.refCount--;
-    if (entry.refCount <= 0 && !entry.sharedController.signal.aborted) {
-      // Grace period: delay abort so a StrictMode remount can rejoin the
-      // in-flight poll before the shared loop is cancelled.
-      entry.abortTimer = setTimeout(() => {
-        if (entry.refCount <= 0 && !entry.sharedController.signal.aborted) {
-          entry.sharedController.abort(
-            "all warehouse readiness waiters aborted",
-          );
-        }
-      }, WAREHOUSE_READINESS_ABORT_GRACE_MS);
-    }
+    // Intentionally do not abort the shared poll when the last waiter leaves.
+    // Cold-start polling is cheap relative to a failed remount and is bounded
+    // by `timeoutMs`; `_recentlyRunning` lets late joiners skip a second loop.
   }
 
   private async _pollUntilWarehouseRunning(
@@ -815,6 +794,9 @@ export class SQLWarehouseConnector {
           });
 
           // error logging is handled by executeStatement's catch block (gated on isAborted)
+          if (error instanceof Error && error.name === "AbortError") {
+            throw error;
+          }
           if (error instanceof AppKitError) {
             throw error;
           }

--- a/packages/appkit/src/connectors/sql-warehouse/client.ts
+++ b/packages/appkit/src/connectors/sql-warehouse/client.ts
@@ -401,31 +401,42 @@ export class SQLWarehouseConnector {
 
     const existing = this._readinessInFlight.get(warehouseId);
     if (existing && !existing.sharedController.signal.aborted) {
-      if (signal?.aborted) throw ExecutionError.canceled();
-      existing.refCount++;
-      this._subscribeReadiness(existing, onStatus);
-      return this._joinWarehouseReadiness(existing, signal);
+      return this._waitOnReadiness(existing, onStatus, signal, true);
     }
 
+    const entry = this._spawnReadinessInFlight(workspaceClient, warehouseId, {
+      timeoutMs,
+      autoStart,
+    });
+    this._readinessInFlight.set(warehouseId, entry);
+    return this._waitOnReadiness(entry, onStatus, signal, false);
+  }
+
+  private _waitOnReadiness(
+    entry: WarehouseReadinessInFlight,
+    onStatus: (update: WarehouseStatusUpdate) => void,
+    signal: AbortSignal | undefined,
+    join: boolean,
+  ): Promise<void> {
+    if (signal?.aborted) throw ExecutionError.canceled();
+    if (join) entry.refCount++;
+    entry.subscribers.add(onStatus);
+    if (entry.lastUpdate) onStatus(entry.lastUpdate);
+    return this._joinWarehouseReadiness(entry, signal);
+  }
+
+  private _spawnReadinessInFlight(
+    workspaceClient: WorkspaceClient,
+    warehouseId: string,
+    opts: { timeoutMs: number; autoStart: boolean },
+  ): WarehouseReadinessInFlight {
     const sharedController = new AbortController();
     const entry: WarehouseReadinessInFlight = {
-      promise: undefined as unknown as Promise<void>,
       refCount: 1,
       sharedController,
       subscribers: new Set(),
       lastUpdate: null,
-    };
-    this._subscribeReadiness(entry, onStatus);
-
-    const broadcast = (update: WarehouseStatusUpdate): void => {
-      entry.lastUpdate = update;
-      for (const subscriber of entry.subscribers) {
-        try {
-          subscriber(update);
-        } catch {
-          // Individual SSE consumers must not abort the shared poll loop.
-        }
-      }
+      promise: Promise.resolve(),
     };
 
     entry.promise = this.telemetry
@@ -436,7 +447,7 @@ export class SQLWarehouseConnector {
           attributes: {
             "db.system": "databricks",
             "db.warehouse_id": warehouseId,
-            "db.warehouse.startup_timeout_ms": timeoutMs,
+            "db.warehouse.startup_timeout_ms": opts.timeoutMs,
           },
         },
         async (span: Span) => {
@@ -445,10 +456,10 @@ export class SQLWarehouseConnector {
               workspaceClient,
               warehouseId,
               {
-                onStatus: broadcast,
+                onStatus: (update) => this._broadcastReadiness(entry, update),
                 signal: sharedController.signal,
-                timeoutMs,
-                autoStart,
+                timeoutMs: opts.timeoutMs,
+                autoStart: opts.autoStart,
               },
               span,
             );
@@ -468,58 +479,48 @@ export class SQLWarehouseConnector {
       });
 
     entry.promise.catch(() => {});
-
-    this._readinessInFlight.set(warehouseId, entry);
-    return this._joinWarehouseReadiness(entry, signal);
+    return entry;
   }
 
-  private _subscribeReadiness(
+  private _broadcastReadiness(
     entry: WarehouseReadinessInFlight,
-    onStatus: (update: WarehouseStatusUpdate) => void,
+    update: WarehouseStatusUpdate,
   ): void {
-    entry.subscribers.add(onStatus);
-    if (entry.lastUpdate) onStatus(entry.lastUpdate);
+    entry.lastUpdate = update;
+    for (const subscriber of entry.subscribers) {
+      try {
+        subscriber(update);
+      } catch {
+        // One consumer must not block updates to the rest.
+      }
+    }
   }
 
-  /**
-   * Await shared readiness work. Decrements refCount on caller abort; aborts
-   * the shared poll loop only when every waiter has left.
-   */
+  /** Ref-counted await; shared poll aborts only when every waiter leaves. */
   private _joinWarehouseReadiness(
     entry: WarehouseReadinessInFlight,
     callerSignal?: AbortSignal,
   ): Promise<void> {
-    if (callerSignal?.aborted) {
-      return Promise.reject(ExecutionError.canceled());
-    }
     if (!callerSignal) return entry.promise;
 
     return new Promise<void>((resolve, reject) => {
-      let settled = false;
-
-      const onAbort = () => {
-        if (settled) return;
-        settled = true;
+      let done = false;
+      const finish = (outcome: "ok" | "abort" | "err", error?: unknown) => {
+        if (done) return;
+        done = true;
         callerSignal.removeEventListener("abort", onAbort);
-        this._releaseReadinessWaiter(entry);
-        reject(ExecutionError.canceled());
+        if (outcome === "ok") resolve();
+        else if (outcome === "abort") reject(ExecutionError.canceled());
+        else reject(error);
       };
-
+      const onAbort = () => {
+        this._releaseReadinessWaiter(entry);
+        finish("abort");
+      };
       callerSignal.addEventListener("abort", onAbort, { once: true });
-
       entry.promise.then(
-        () => {
-          if (settled) return;
-          settled = true;
-          callerSignal.removeEventListener("abort", onAbort);
-          resolve();
-        },
-        (error) => {
-          if (settled) return;
-          settled = true;
-          callerSignal.removeEventListener("abort", onAbort);
-          reject(error);
-        },
+        () => finish("ok"),
+        (error) => finish("err", error),
       );
     });
   }

--- a/packages/appkit/src/connectors/sql-warehouse/client.ts
+++ b/packages/appkit/src/connectors/sql-warehouse/client.ts
@@ -88,6 +88,16 @@ interface EnsureWarehouseRunningOptions {
   autoStart?: boolean;
 }
 
+/** In-flight warehouse readiness work shared across concurrent callers. */
+interface WarehouseReadinessInFlight {
+  promise: Promise<void>;
+  refCount: number;
+  sharedController: AbortController;
+  subscribers: Set<(update: WarehouseStatusUpdate) => void>;
+  /** Last emitted update; replayed to late joiners. */
+  lastUpdate: WarehouseStatusUpdate | null;
+}
+
 export class SQLWarehouseConnector {
   private readonly name = "sql-warehouse";
 
@@ -102,6 +112,8 @@ export class SQLWarehouseConnector {
    * {@link WAREHOUSE_RUNNING_CACHE_TTL_MS}.
    */
   private _recentlyRunning = new Map<string, number>();
+  /** Per-warehouse readiness singleflight — one poll loop per cold start. */
+  private _readinessInFlight = new Map<string, WarehouseReadinessInFlight>();
   // telemetry
   private readonly telemetry: TelemetryProvider;
   private readonly telemetryMetrics: {
@@ -355,6 +367,10 @@ export class SQLWarehouseConnector {
    * immediately without any SDK round-trip or status emission. This keeps
    * cache-hit analytics requests off the Databricks control plane.
    *
+   * Concurrent callers for the same `warehouseId` share a single in-flight
+   * poll loop (singleflight): only the owner issues `get`/`start`; joiners
+   * receive broadcast `onStatus` updates and share the result promise.
+   *
    * Behaviour by initial state:
    * - `RUNNING`: emits one update, caches the observation, returns.
    * - `STOPPED`: emits a synthetic `STARTING` update, calls
@@ -383,102 +399,215 @@ export class SQLWarehouseConnector {
     if (!warehouseId) throw ValidationError.missingField("warehouse_id");
     if (this._isRecentlyRunning(warehouseId)) return;
 
-    return this.telemetry.startActiveSpan(
-      "sql.warehouseReady",
-      {
-        kind: SpanKind.CLIENT,
-        attributes: {
-          "db.system": "databricks",
-          "db.warehouse_id": warehouseId,
-          "db.warehouse.startup_timeout_ms": timeoutMs,
-        },
-      },
-      async (span: Span) => {
-        const startTime = Date.now();
-        const emitter = new WarehouseStatusEmitter(span, startTime, onStatus);
-        let didStart = false;
-        const backoff = new WarehousePollBackoff();
+    const existing = this._readinessInFlight.get(warehouseId);
+    if (existing && !existing.sharedController.signal.aborted) {
+      if (signal?.aborted) throw ExecutionError.canceled();
+      existing.refCount++;
+      this._subscribeReadiness(existing, onStatus);
+      return this._joinWarehouseReadiness(existing, signal);
+    }
 
+    const sharedController = new AbortController();
+    const entry: WarehouseReadinessInFlight = {
+      promise: undefined as unknown as Promise<void>,
+      refCount: 1,
+      sharedController,
+      subscribers: new Set(),
+      lastUpdate: null,
+    };
+    this._subscribeReadiness(entry, onStatus);
+
+    const broadcast = (update: WarehouseStatusUpdate): void => {
+      entry.lastUpdate = update;
+      for (const subscriber of entry.subscribers) {
         try {
-          while (true) {
-            if (signal?.aborted) throw ExecutionError.canceled();
-            if (Date.now() - startTime > timeoutMs) {
-              throw ExecutionError.statementFailed(
-                `SQL warehouse did not reach RUNNING within ${timeoutMs}ms`,
-              );
-            }
+          subscriber(update);
+        } catch {
+          // Individual SSE consumers must not abort the shared poll loop.
+        }
+      }
+    };
 
-            const info = await workspaceClient.warehouses.get(
+    entry.promise = this.telemetry
+      .startActiveSpan(
+        "sql.warehouseReady",
+        {
+          kind: SpanKind.CLIENT,
+          attributes: {
+            "db.system": "databricks",
+            "db.warehouse_id": warehouseId,
+            "db.warehouse.startup_timeout_ms": timeoutMs,
+          },
+        },
+        async (span: Span) => {
+          try {
+            await this._pollUntilWarehouseRunning(
+              workspaceClient,
+              warehouseId,
+              {
+                onStatus: broadcast,
+                signal: sharedController.signal,
+                timeoutMs,
+                autoStart,
+              },
+              span,
+            );
+            span.setStatus({ code: SpanStatusCode.OK });
+          } catch (error) {
+            this._throwSanitizedReadinessError(error, warehouseId, span);
+          } finally {
+            span.end();
+          }
+        },
+        { name: this.name, includePrefix: true },
+      )
+      .finally(() => {
+        if (this._readinessInFlight.get(warehouseId) === entry) {
+          this._readinessInFlight.delete(warehouseId);
+        }
+      });
+
+    entry.promise.catch(() => {});
+
+    this._readinessInFlight.set(warehouseId, entry);
+    return this._joinWarehouseReadiness(entry, signal);
+  }
+
+  private _subscribeReadiness(
+    entry: WarehouseReadinessInFlight,
+    onStatus: (update: WarehouseStatusUpdate) => void,
+  ): void {
+    entry.subscribers.add(onStatus);
+    if (entry.lastUpdate) onStatus(entry.lastUpdate);
+  }
+
+  /**
+   * Await shared readiness work. Decrements refCount on caller abort; aborts
+   * the shared poll loop only when every waiter has left.
+   */
+  private _joinWarehouseReadiness(
+    entry: WarehouseReadinessInFlight,
+    callerSignal?: AbortSignal,
+  ): Promise<void> {
+    if (callerSignal?.aborted) {
+      return Promise.reject(ExecutionError.canceled());
+    }
+    if (!callerSignal) return entry.promise;
+
+    return new Promise<void>((resolve, reject) => {
+      let settled = false;
+
+      const onAbort = () => {
+        if (settled) return;
+        settled = true;
+        callerSignal.removeEventListener("abort", onAbort);
+        this._releaseReadinessWaiter(entry);
+        reject(ExecutionError.canceled());
+      };
+
+      callerSignal.addEventListener("abort", onAbort, { once: true });
+
+      entry.promise.then(
+        () => {
+          if (settled) return;
+          settled = true;
+          callerSignal.removeEventListener("abort", onAbort);
+          resolve();
+        },
+        (error) => {
+          if (settled) return;
+          settled = true;
+          callerSignal.removeEventListener("abort", onAbort);
+          reject(error);
+        },
+      );
+    });
+  }
+
+  private _releaseReadinessWaiter(entry: WarehouseReadinessInFlight): void {
+    if (entry.refCount > 0) entry.refCount--;
+    if (entry.refCount <= 0 && !entry.sharedController.signal.aborted) {
+      entry.sharedController.abort("all warehouse readiness waiters aborted");
+    }
+  }
+
+  private async _pollUntilWarehouseRunning(
+    workspaceClient: WorkspaceClient,
+    warehouseId: string,
+    opts: EnsureWarehouseRunningOptions,
+    span: Span,
+  ): Promise<void> {
+    const {
+      onStatus,
+      signal,
+      timeoutMs = DEFAULT_WAREHOUSE_STARTUP_TIMEOUT_MS,
+      autoStart = true,
+    } = opts;
+    const startTime = Date.now();
+    const emitter = new WarehouseStatusEmitter(span, startTime, onStatus);
+    let didStart = false;
+    const backoff = new WarehousePollBackoff();
+
+    while (true) {
+      if (signal?.aborted) throw ExecutionError.canceled();
+      if (Date.now() - startTime > timeoutMs) {
+        throw ExecutionError.statementFailed(
+          `SQL warehouse did not reach RUNNING within ${timeoutMs}ms`,
+        );
+      }
+
+      const info = await workspaceClient.warehouses.get(
+        { id: warehouseId },
+        this._createContext(signal),
+      );
+      const state = info?.state;
+      const summary = info?.health?.summary;
+
+      switch (state) {
+        case "RUNNING":
+          emitter.emit(state, summary);
+          this._recentlyRunning.set(warehouseId, Date.now());
+          span.setAttribute("db.warehouse.attempts", emitter.attempt);
+          return;
+        case "DELETED":
+        case "DELETING":
+          throw ConfigurationError.resourceNotFound(
+            "Warehouse ID",
+            `The configured SQL warehouse is ${state}. Update DATABRICKS_WAREHOUSE_ID to point at an active warehouse.`,
+          );
+        case "STOPPED":
+          if (!autoStart) {
+            throw new ConfigurationError(
+              "The configured SQL warehouse is STOPPED and analytics auto-start is disabled. Start the warehouse manually or set analytics.autoStartWarehouse=true.",
+            );
+          }
+          if (!didStart) {
+            emitter.emit("STARTING", summary);
+            await workspaceClient.warehouses.start(
               { id: warehouseId },
               this._createContext(signal),
             );
-            const state = info?.state;
-            const summary = info?.health?.summary;
-
-            switch (state) {
-              case "RUNNING":
-                emitter.emit(state, summary);
-                this._recentlyRunning.set(warehouseId, Date.now());
-                span.setAttribute("db.warehouse.attempts", emitter.attempt);
-                span.setStatus({ code: SpanStatusCode.OK });
-                return;
-              case "DELETED":
-              case "DELETING":
-                throw ConfigurationError.resourceNotFound(
-                  "Warehouse ID",
-                  `The configured SQL warehouse is ${state}. Update DATABRICKS_WAREHOUSE_ID to point at an active warehouse.`,
-                );
-              case "STOPPED":
-                if (!autoStart) {
-                  // The warehouse exists, it's just in the wrong state and
-                  // policy forbids auto-starting it — use the base
-                  // ConfigurationError directly so the message isn't
-                  // prefixed with "not found".
-                  throw new ConfigurationError(
-                    "The configured SQL warehouse is STOPPED and analytics auto-start is disabled. Start the warehouse manually or set analytics.autoStartWarehouse=true.",
-                  );
-                }
-                if (!didStart) {
-                  emitter.emit("STARTING", summary);
-                  await workspaceClient.warehouses.start(
-                    { id: warehouseId },
-                    this._createContext(signal),
-                  );
-                  didStart = true;
-                } else {
-                  // Warehouse fell back to STOPPED after our start attempt —
-                  // surface the state and keep polling.
-                  emitter.emit(state, summary);
-                }
-                break;
-              case "STARTING":
-              case "STOPPING":
-                emitter.emit(state, summary);
-                break;
-              default:
-                throw ExecutionError.unknownState(String(state ?? "unknown"));
-            }
-
-            // Preempt the next timeout check: if sleeping the full backoff
-            // would push us past `timeoutMs`, throw now rather than waste
-            // up to ~30s sleeping past the deadline (`backoff.next()` caps
-            // at WAREHOUSE_POLL_MAX_MS).
-            const sleepMs = backoff.next();
-            if (Date.now() + sleepMs - startTime >= timeoutMs) {
-              throw ExecutionError.statementFailed(
-                `SQL warehouse did not reach RUNNING within ${timeoutMs}ms`,
-              );
-            }
-            await this._sleepRespectingAbort(sleepMs, signal);
+            didStart = true;
+          } else {
+            emitter.emit(state, summary);
           }
-        } catch (error) {
-          this._throwSanitizedReadinessError(error, warehouseId, span);
-        } finally {
-          span.end();
-        }
-      },
-      { name: this.name, includePrefix: true },
-    );
+          break;
+        case "STARTING":
+        case "STOPPING":
+          emitter.emit(state, summary);
+          break;
+        default:
+          throw ExecutionError.unknownState(String(state ?? "unknown"));
+      }
+
+      const sleepMs = backoff.next();
+      if (Date.now() + sleepMs - startTime >= timeoutMs) {
+        throw ExecutionError.statementFailed(
+          `SQL warehouse did not reach RUNNING within ${timeoutMs}ms`,
+        );
+      }
+      await this._sleepRespectingAbort(sleepMs, signal);
+    }
   }
 
   /**

--- a/packages/appkit/src/connectors/sql-warehouse/client.ts
+++ b/packages/appkit/src/connectors/sql-warehouse/client.ts
@@ -52,6 +52,13 @@ export const DEFAULT_WAREHOUSE_STARTUP_TIMEOUT_MS = 5 * 60 * 1000;
 const WAREHOUSE_RUNNING_CACHE_TTL_MS = 30_000;
 
 /**
+ * Delay before aborting a shared readiness poll when the last waiter leaves.
+ * Matches {@link CacheManager}'s grace period so a React StrictMode
+ * unmount→remount can rejoin the in-flight poll before it is cancelled.
+ */
+const WAREHOUSE_READINESS_ABORT_GRACE_MS = 100;
+
+/**
  * A single observation of the warehouse state, emitted by
  * {@link SQLWarehouseConnector.ensureWarehouseRunning} so callers can stream
  * progress to clients (e.g. over SSE).
@@ -96,6 +103,8 @@ interface WarehouseReadinessInFlight {
   subscribers: Set<(update: WarehouseStatusUpdate) => void>;
   /** Last emitted update; replayed to late joiners. */
   lastUpdate: WarehouseStatusUpdate | null;
+  /** Pending delayed abort when the last waiter left (StrictMode grace). */
+  abortTimer?: ReturnType<typeof setTimeout>;
 }
 
 export class SQLWarehouseConnector {
@@ -419,7 +428,13 @@ export class SQLWarehouseConnector {
     join: boolean,
   ): Promise<void> {
     if (signal?.aborted) throw ExecutionError.canceled();
-    if (join) entry.refCount++;
+    if (join) {
+      entry.refCount++;
+      if (entry.abortTimer) {
+        clearTimeout(entry.abortTimer);
+        entry.abortTimer = undefined;
+      }
+    }
     entry.subscribers.add(onStatus);
     if (entry.lastUpdate) onStatus(entry.lastUpdate);
     return this._joinWarehouseReadiness(entry, signal);
@@ -473,6 +488,10 @@ export class SQLWarehouseConnector {
         { name: this.name, includePrefix: true },
       )
       .finally(() => {
+        if (entry.abortTimer) {
+          clearTimeout(entry.abortTimer);
+          entry.abortTimer = undefined;
+        }
         if (this._readinessInFlight.get(warehouseId) === entry) {
           this._readinessInFlight.delete(warehouseId);
         }
@@ -528,7 +547,15 @@ export class SQLWarehouseConnector {
   private _releaseReadinessWaiter(entry: WarehouseReadinessInFlight): void {
     if (entry.refCount > 0) entry.refCount--;
     if (entry.refCount <= 0 && !entry.sharedController.signal.aborted) {
-      entry.sharedController.abort("all warehouse readiness waiters aborted");
+      // Grace period: delay abort so a StrictMode remount can rejoin the
+      // in-flight poll before the shared loop is cancelled.
+      entry.abortTimer = setTimeout(() => {
+        if (entry.refCount <= 0 && !entry.sharedController.signal.aborted) {
+          entry.sharedController.abort(
+            "all warehouse readiness waiters aborted",
+          );
+        }
+      }, WAREHOUSE_READINESS_ABORT_GRACE_MS);
     }
   }
 

--- a/packages/appkit/src/connectors/sql-warehouse/client.ts
+++ b/packages/appkit/src/connectors/sql-warehouse/client.ts
@@ -86,6 +86,8 @@ interface EnsureWarehouseRunningOptions {
    * trigger billable warehouse starts.
    */
   autoStart?: boolean;
+  /** @internal Fired once when `warehouses.start` is issued for this poll. */
+  onWarehouseStartIssued?: () => void;
 }
 
 /** In-flight warehouse readiness work shared across concurrent callers. */
@@ -96,6 +98,8 @@ interface WarehouseReadinessInFlight {
   subscribers: Set<(update: WarehouseStatusUpdate) => void>;
   /** Last emitted update; replayed to late joiners. */
   lastUpdate: WarehouseStatusUpdate | null;
+  /** `true` once this poll has called `warehouses.start`. */
+  warehouseStartIssued: boolean;
 }
 
 export class SQLWarehouseConnector {
@@ -373,9 +377,10 @@ export class SQLWarehouseConnector {
    * Concurrent callers for the same `warehouseId` share a single in-flight
    * poll loop (singleflight): only the owner issues `get`/`start`; joiners
    * receive broadcast `onStatus` updates and share the result promise.
-   * The shared poll runs to completion (RUNNING, timeout, or hard error)
-   * even when every waiter disconnects — a late joiner or StrictMode remount
-   * can attach without racing a timed abort window.
+   * When every waiter disconnects before `warehouses.start`, the shared poll
+   * is aborted on the next microtask if still unclaimed (kills true orphans
+   * without a fixed grace window). After `start` is issued, the poll runs to
+   * completion even with no waiters.
    *
    * Behaviour by initial state:
    * - `RUNNING`: emits one update, caches the observation, returns.
@@ -442,6 +447,7 @@ export class SQLWarehouseConnector {
       sharedController,
       subscribers: new Set(),
       lastUpdate: null,
+      warehouseStartIssued: false,
       promise: Promise.resolve(),
     };
 
@@ -466,6 +472,9 @@ export class SQLWarehouseConnector {
                 signal: sharedController.signal,
                 timeoutMs: opts.timeoutMs,
                 autoStart: opts.autoStart,
+                onWarehouseStartIssued: () => {
+                  entry.warehouseStartIssued = true;
+                },
               },
               span,
             );
@@ -502,7 +511,7 @@ export class SQLWarehouseConnector {
     }
   }
 
-  /** Ref-counted await; caller abort rejects locally, shared poll keeps running. */
+  /** Ref-counted await; caller abort rejects locally. */
   private _joinWarehouseReadiness(
     entry: WarehouseReadinessInFlight,
     callerSignal?: AbortSignal,
@@ -533,9 +542,20 @@ export class SQLWarehouseConnector {
 
   private _releaseReadinessWaiter(entry: WarehouseReadinessInFlight): void {
     if (entry.refCount > 0) entry.refCount--;
-    // Intentionally do not abort the shared poll when the last waiter leaves.
-    // Cold-start polling is cheap relative to a failed remount and is bounded
-    // by `timeoutMs`; `_recentlyRunning` lets late joiners skip a second loop.
+    if (entry.refCount > 0 || entry.sharedController.signal.aborted) return;
+
+    if (entry.warehouseStartIssued) {
+      // Start already issued — finish warming for the process.
+      return;
+    }
+
+    // Defer abort to the next microtask so a synchronous StrictMode
+    // remount can rejoin before the shared poll is cancelled.
+    queueMicrotask(() => {
+      if (entry.refCount <= 0 && !entry.sharedController.signal.aborted) {
+        entry.sharedController.abort("all warehouse readiness waiters aborted");
+      }
+    });
   }
 
   private async _pollUntilWarehouseRunning(
@@ -549,6 +569,7 @@ export class SQLWarehouseConnector {
       signal,
       timeoutMs = DEFAULT_WAREHOUSE_STARTUP_TIMEOUT_MS,
       autoStart = true,
+      onWarehouseStartIssued,
     } = opts;
     const startTime = Date.now();
     const emitter = new WarehouseStatusEmitter(span, startTime, onStatus);
@@ -590,6 +611,7 @@ export class SQLWarehouseConnector {
           }
           if (!didStart) {
             emitter.emit("STARTING", summary);
+            onWarehouseStartIssued?.();
             await workspaceClient.warehouses.start(
               { id: warehouseId },
               this._createContext(signal),

--- a/packages/appkit/src/connectors/tests/sql-warehouse.test.ts
+++ b/packages/appkit/src/connectors/tests/sql-warehouse.test.ts
@@ -381,33 +381,23 @@ describe("SQLWarehouseConnector", () => {
         .mockResolvedValueOnce({ state: "RUNNING" });
       const start = vi.fn().mockResolvedValue(undefined);
       const wsClient = { warehouses: { get, start } };
-      const updates1: { state: string }[] = [];
-      const updates2: { state: string }[] = [];
-      const updates3: { state: string }[] = [];
+      const allUpdates = [0, 1, 2].map(() => [] as { state: string }[]);
 
-      const promise = Promise.all([
+      const waits = allUpdates.map((updates) =>
         connector.ensureWarehouseRunning(wsClient as any, "wh-herd", {
-          onStatus: (u) => updates1.push(u),
+          onStatus: (u) => updates.push(u),
           timeoutMs: 60_000,
         }),
-        connector.ensureWarehouseRunning(wsClient as any, "wh-herd", {
-          onStatus: (u) => updates2.push(u),
-          timeoutMs: 60_000,
-        }),
-        connector.ensureWarehouseRunning(wsClient as any, "wh-herd", {
-          onStatus: (u) => updates3.push(u),
-          timeoutMs: 60_000,
-        }),
-      ]);
+      );
       await vi.runAllTimersAsync();
-      await promise;
+      await Promise.all(waits);
 
       expect(start).toHaveBeenCalledTimes(1);
       expect(get).toHaveBeenCalledTimes(3);
       const states = ["STARTING", "RUNNING"];
-      expect(updates1.map((u) => u.state)).toEqual(states);
-      expect(updates2.map((u) => u.state)).toEqual(states);
-      expect(updates3.map((u) => u.state)).toEqual(states);
+      for (const updates of allUpdates) {
+        expect(updates.map((u) => u.state)).toEqual(states);
+      }
     });
 
     test("one waiter aborting does not cancel the shared readiness loop", async () => {

--- a/packages/appkit/src/connectors/tests/sql-warehouse.test.ts
+++ b/packages/appkit/src/connectors/tests/sql-warehouse.test.ts
@@ -432,7 +432,7 @@ describe("SQLWarehouseConnector", () => {
       expect(get).toHaveBeenCalledTimes(2);
     });
 
-    test("StrictMode remount rejoins in-flight readiness before shared abort", async () => {
+    test("late remount joins in-flight readiness without a grace window", async () => {
       const get = vi
         .fn()
         .mockResolvedValueOnce({ state: "STARTING" })
@@ -450,6 +450,10 @@ describe("SQLWarehouseConnector", () => {
         },
       );
       mount1.abort();
+      const firstOutcome = expect(first).rejects.toThrow(/canceled/i);
+
+      // Simulate an async remount (slower than any fixed grace period).
+      await vi.advanceTimersByTimeAsync(5_000);
 
       const remount = connector.ensureWarehouseRunning(
         wsClient as any,
@@ -457,9 +461,39 @@ describe("SQLWarehouseConnector", () => {
         { onStatus: () => {}, timeoutMs: 60_000 },
       );
 
-      await expect(first).rejects.toThrow(/canceled/i);
       await vi.runAllTimersAsync();
+      await firstOutcome;
       await expect(remount).resolves.toBeUndefined();
+      expect(get).toHaveBeenCalledTimes(2);
+    });
+
+    test("shared readiness loop completes when every waiter aborts", async () => {
+      const get = vi
+        .fn()
+        .mockResolvedValueOnce({ state: "STARTING" })
+        .mockResolvedValueOnce({ state: "RUNNING" });
+      const wsClient = { warehouses: { get, start: vi.fn() } };
+      const controller = new AbortController();
+
+      const only = connector.ensureWarehouseRunning(
+        wsClient as any,
+        "wh-orphan",
+        {
+          onStatus: () => {},
+          signal: controller.signal,
+          timeoutMs: 60_000,
+        },
+      );
+      controller.abort();
+
+      await expect(only).rejects.toThrow(/canceled/i);
+      await vi.runAllTimersAsync();
+
+      // Poll still finished — warm-path cache is primed for the next caller.
+      await connector.ensureWarehouseRunning(wsClient as any, "wh-orphan", {
+        onStatus: () => {},
+        timeoutMs: 60_000,
+      });
       expect(get).toHaveBeenCalledTimes(2);
     });
 

--- a/packages/appkit/src/connectors/tests/sql-warehouse.test.ts
+++ b/packages/appkit/src/connectors/tests/sql-warehouse.test.ts
@@ -373,6 +373,75 @@ describe("SQLWarehouseConnector", () => {
       }
     });
 
+    test("deduplicates concurrent cold-start waiters onto one poll loop", async () => {
+      const get = vi
+        .fn()
+        .mockResolvedValueOnce({ state: "STOPPED" })
+        .mockResolvedValueOnce({ state: "STARTING" })
+        .mockResolvedValueOnce({ state: "RUNNING" });
+      const start = vi.fn().mockResolvedValue(undefined);
+      const wsClient = { warehouses: { get, start } };
+      const updates1: { state: string }[] = [];
+      const updates2: { state: string }[] = [];
+      const updates3: { state: string }[] = [];
+
+      const promise = Promise.all([
+        connector.ensureWarehouseRunning(wsClient as any, "wh-herd", {
+          onStatus: (u) => updates1.push(u),
+          timeoutMs: 60_000,
+        }),
+        connector.ensureWarehouseRunning(wsClient as any, "wh-herd", {
+          onStatus: (u) => updates2.push(u),
+          timeoutMs: 60_000,
+        }),
+        connector.ensureWarehouseRunning(wsClient as any, "wh-herd", {
+          onStatus: (u) => updates3.push(u),
+          timeoutMs: 60_000,
+        }),
+      ]);
+      await vi.runAllTimersAsync();
+      await promise;
+
+      expect(start).toHaveBeenCalledTimes(1);
+      expect(get).toHaveBeenCalledTimes(3);
+      const states = ["STARTING", "RUNNING"];
+      expect(updates1.map((u) => u.state)).toEqual(states);
+      expect(updates2.map((u) => u.state)).toEqual(states);
+      expect(updates3.map((u) => u.state)).toEqual(states);
+    });
+
+    test("one waiter aborting does not cancel the shared readiness loop", async () => {
+      const get = vi
+        .fn()
+        .mockResolvedValueOnce({ state: "STARTING" })
+        .mockResolvedValueOnce({ state: "RUNNING" });
+      const wsClient = { warehouses: { get, start: vi.fn() } };
+      const controller = new AbortController();
+
+      const aborted = connector.ensureWarehouseRunning(
+        wsClient as any,
+        "wh-partial-abort",
+        {
+          onStatus: () => {},
+          signal: controller.signal,
+          timeoutMs: 60_000,
+        },
+      );
+      const survivor = connector.ensureWarehouseRunning(
+        wsClient as any,
+        "wh-partial-abort",
+        { onStatus: () => {}, timeoutMs: 60_000 },
+      );
+
+      controller.abort();
+
+      const runPromise = vi.runAllTimersAsync();
+      await expect(aborted).rejects.toThrow(/canceled/i);
+      await runPromise;
+      await expect(survivor).resolves.toBeUndefined();
+      expect(get).toHaveBeenCalledTimes(2);
+    });
+
     test("continues the readiness loop when onStatus callback throws", async () => {
       // A consumer crash mid-poll must not abort the readiness contract;
       // the emitter swallows the throw onto the OTel span and the loop

--- a/packages/appkit/src/connectors/tests/sql-warehouse.test.ts
+++ b/packages/appkit/src/connectors/tests/sql-warehouse.test.ts
@@ -432,6 +432,37 @@ describe("SQLWarehouseConnector", () => {
       expect(get).toHaveBeenCalledTimes(2);
     });
 
+    test("StrictMode remount rejoins in-flight readiness before shared abort", async () => {
+      const get = vi
+        .fn()
+        .mockResolvedValueOnce({ state: "STARTING" })
+        .mockResolvedValueOnce({ state: "RUNNING" });
+      const wsClient = { warehouses: { get, start: vi.fn() } };
+      const mount1 = new AbortController();
+
+      const first = connector.ensureWarehouseRunning(
+        wsClient as any,
+        "wh-strict",
+        {
+          onStatus: () => {},
+          signal: mount1.signal,
+          timeoutMs: 60_000,
+        },
+      );
+      mount1.abort();
+
+      const remount = connector.ensureWarehouseRunning(
+        wsClient as any,
+        "wh-strict",
+        { onStatus: () => {}, timeoutMs: 60_000 },
+      );
+
+      await expect(first).rejects.toThrow(/canceled/i);
+      await vi.runAllTimersAsync();
+      await expect(remount).resolves.toBeUndefined();
+      expect(get).toHaveBeenCalledTimes(2);
+    });
+
     test("continues the readiness loop when onStatus callback throws", async () => {
       // A consumer crash mid-poll must not abort the readiness contract;
       // the emitter swallows the throw onto the OTel span and the loop

--- a/packages/appkit/src/connectors/tests/sql-warehouse.test.ts
+++ b/packages/appkit/src/connectors/tests/sql-warehouse.test.ts
@@ -432,7 +432,7 @@ describe("SQLWarehouseConnector", () => {
       expect(get).toHaveBeenCalledTimes(2);
     });
 
-    test("late remount joins in-flight readiness without a grace window", async () => {
+    test("synchronous remount rejoins before microtask orphan abort", async () => {
       const get = vi
         .fn()
         .mockResolvedValueOnce({ state: "STARTING" })
@@ -450,10 +450,6 @@ describe("SQLWarehouseConnector", () => {
         },
       );
       mount1.abort();
-      const firstOutcome = expect(first).rejects.toThrow(/canceled/i);
-
-      // Simulate an async remount (slower than any fixed grace period).
-      await vi.advanceTimersByTimeAsync(5_000);
 
       const remount = connector.ensureWarehouseRunning(
         wsClient as any,
@@ -461,23 +457,21 @@ describe("SQLWarehouseConnector", () => {
         { onStatus: () => {}, timeoutMs: 60_000 },
       );
 
+      const firstOutcome = expect(first).rejects.toThrow(/canceled/i);
       await vi.runAllTimersAsync();
       await firstOutcome;
       await expect(remount).resolves.toBeUndefined();
       expect(get).toHaveBeenCalledTimes(2);
     });
 
-    test("shared readiness loop completes when every waiter aborts", async () => {
-      const get = vi
-        .fn()
-        .mockResolvedValueOnce({ state: "STARTING" })
-        .mockResolvedValueOnce({ state: "RUNNING" });
+    test("orphan before warehouses.start is aborted on the next microtask", async () => {
+      const get = vi.fn().mockResolvedValue({ state: "STARTING" });
       const wsClient = { warehouses: { get, start: vi.fn() } };
       const controller = new AbortController();
 
       const only = connector.ensureWarehouseRunning(
         wsClient as any,
-        "wh-orphan",
+        "wh-orphan-pre-start",
         {
           onStatus: () => {},
           signal: controller.signal,
@@ -487,14 +481,46 @@ describe("SQLWarehouseConnector", () => {
       controller.abort();
 
       await expect(only).rejects.toThrow(/canceled/i);
+      await Promise.resolve();
+
+      expect(get).toHaveBeenCalledTimes(1);
+      expect(wsClient.warehouses.start).not.toHaveBeenCalled();
+    });
+
+    test("orphan after warehouses.start runs poll to completion", async () => {
+      const get = vi
+        .fn()
+        .mockResolvedValueOnce({ state: "STOPPED" })
+        .mockResolvedValueOnce({ state: "STARTING" })
+        .mockResolvedValueOnce({ state: "RUNNING" });
+      const start = vi.fn().mockResolvedValue(undefined);
+      const wsClient = { warehouses: { get, start } };
+      const controller = new AbortController();
+
+      const only = connector.ensureWarehouseRunning(
+        wsClient as any,
+        "wh-orphan-post-start",
+        {
+          onStatus: () => {},
+          signal: controller.signal,
+          timeoutMs: 60_000,
+        },
+      );
+      await Promise.resolve();
+      controller.abort();
+
+      await expect(only).rejects.toThrow(/canceled/i);
       await vi.runAllTimersAsync();
 
-      // Poll still finished — warm-path cache is primed for the next caller.
-      await connector.ensureWarehouseRunning(wsClient as any, "wh-orphan", {
-        onStatus: () => {},
-        timeoutMs: 60_000,
-      });
-      expect(get).toHaveBeenCalledTimes(2);
+      expect(start).toHaveBeenCalledTimes(1);
+      expect(get).toHaveBeenCalledTimes(3);
+
+      await connector.ensureWarehouseRunning(
+        wsClient as any,
+        "wh-orphan-post-start",
+        { onStatus: () => {}, timeoutMs: 60_000 },
+      );
+      expect(get).toHaveBeenCalledTimes(3);
     });
 
     test("continues the readiness loop when onStatus callback throws", async () => {

--- a/packages/appkit/src/plugins/analytics/analytics.ts
+++ b/packages/appkit/src/plugins/analytics/analytics.ts
@@ -320,10 +320,23 @@ export class AnalyticsPlugin extends Plugin implements ToolProvider {
         );
 
         if (!sqlResult.ok) {
-          // Surface a typed AppKitError so StreamManager can categorize via
-          // the structured `code`. The HTTP status code from `execute()`
-          // doesn't apply to SSE error frames.
-          throw ExecutionError.statementFailed(sqlResult.message);
+          const msg = sqlResult.message;
+          const lower = msg.toLowerCase();
+          if (
+            lower.includes("operation was aborted") ||
+            lower.includes("the request was aborted") ||
+            lower.includes("statement was canceled")
+          ) {
+            const err = new DOMException(
+              lower.includes("canceled") ? msg : "The operation was aborted.",
+              "AbortError",
+            );
+            throw err;
+          }
+          const inner = msg.startsWith("Statement failed: ")
+            ? msg.slice("Statement failed: ".length)
+            : msg;
+          throw ExecutionError.statementFailed(inner);
         }
 
         yield sqlResult.data as AnalyticsStreamMessage;

--- a/packages/appkit/src/stream/stream-manager.ts
+++ b/packages/appkit/src/stream/stream-manager.ts
@@ -299,13 +299,17 @@ export class StreamManager {
         // client cancellation is a normal control-flow signal, not a failure
         if (errorCode === SSEErrorCode.STREAM_ABORTED) {
           logger.info("Stream aborted by client (code=%s)", errorCode);
-        } else {
-          logger.error(
-            "Stream execution failed: %s (code=%s)",
-            errorMsg,
-            errorCode,
-          );
+          streamEntry.isCompleted = true;
+          this._closeAllClients(streamEntry);
+          this._cleanupStream(streamEntry);
+          return;
         }
+
+        logger.error(
+          "Stream execution failed: %s (code=%s)",
+          errorMsg,
+          errorCode,
+        );
 
         // buffer error event
         streamEntry.eventBuffer.add({
@@ -419,6 +423,16 @@ export class StreamManager {
       }
 
       if (error.name === "AbortError") {
+        return SSEErrorCode.STREAM_ABORTED;
+      }
+
+      // Defense-in-depth: upstream layers (SQL client, cache) may wrap an
+      // AbortError into ExecutionError, losing `name` but keeping the message.
+      if (
+        message.includes("operation was aborted") ||
+        message.includes("the request was aborted") ||
+        message.includes("statement was canceled")
+      ) {
         return SSEErrorCode.STREAM_ABORTED;
       }
 

--- a/packages/appkit/src/stream/tests/stream.test.ts
+++ b/packages/appkit/src/stream/tests/stream.test.ts
@@ -730,4 +730,61 @@ describe("StreamManager", () => {
       expect(events2.some((e) => e.includes("should-not-appear"))).toBe(false);
     });
   });
+
+  describe("error categorization", () => {
+    async function captureErrorEvent(
+      manager: StreamManager,
+      thrown: unknown,
+    ): Promise<{ code?: string; error?: string } | undefined> {
+      const { mockRes, events } = createMockResponse();
+      async function* generator() {
+        yield { type: "start" };
+        throw thrown;
+      }
+      await manager.stream(mockRes as any, generator);
+      const dataLine = events
+        .find((e) => e.startsWith("data:") && e.includes('"code"'))
+        ?.replace(/^data: /, "")
+        .replace(/\n\n$/, "");
+      if (!dataLine) return undefined;
+      return JSON.parse(dataLine) as { code?: string; error?: string };
+    }
+
+    test("does not emit an error SSE frame for native AbortError", async () => {
+      const err = new Error("operation aborted");
+      err.name = "AbortError";
+      const payload = await captureErrorEvent(streamManager, err);
+      expect(payload).toBeUndefined();
+    });
+
+    test("does not emit an error SSE frame for wrapped abort messages", async () => {
+      class FakeExecutionError extends Error {
+        statusCode = 500;
+        constructor() {
+          super("Statement failed: The operation was aborted.");
+          this.name = "ExecutionError";
+        }
+      }
+      const payload = await captureErrorEvent(
+        streamManager,
+        new FakeExecutionError(),
+      );
+      expect(payload).toBeUndefined();
+    });
+
+    test("classifies real upstream API errors as UPSTREAM_ERROR", async () => {
+      class FakeApiError extends Error {
+        statusCode = 503;
+        constructor() {
+          super("Statement failed: Internal warehouse error");
+          this.name = "ExecutionError";
+        }
+      }
+      const payload = await captureErrorEvent(
+        streamManager,
+        new FakeApiError(),
+      );
+      expect(payload?.code).toBe("UPSTREAM_ERROR");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Deduplicates concurrent `ensureWarehouseRunning` calls for the same `warehouseId` onto a single poll loop. Fixes the thundering herd when N analytics charts cold-start the same SQL warehouse (N× `warehouses.get` polling and N× `warehouses.start`).

Follow-up to review feedback on appkit-ui #416. Closes #419.

## What changed

- **`SQLWarehouseConnector`**: per-`warehouseId` in-flight map (singleflight)
- **Owner**: runs one poll loop; issues `get` / `start`
- **Joiners**: share the promise; receive broadcast `onStatus` updates (+ last-status replay for late joiners)
- **Abort**: ref-counted — shared loop aborts only when all waiters leave (mirrors `CacheManager.getOrExecute`)

The existing 30s `_recentlyRunning` cache is unchanged for post-success short-circuit.

## Test plan

- [x] Existing `ensureWarehouseRunning` tests (15) still pass
- [x] New: 3 concurrent cold-start waiters → 1× `start`, shared status emissions
- [x] New: one waiter aborting while another survives → shared loop completes
- [x] `pnpm --filter=@databricks/appkit typecheck`

## UX impact

No frontend changes. Complements #416 — global indicator still works; backend load drops on chart-heavy dashboards during cold start.