### PR TITLE
fix(appkit): unify typegen warehouse readiness + sanitize timeout (PR1)

### DIFF
--- a/docs/docs/development/type-generation.md
+++ b/docs/docs/development/type-generation.md
@@ -82,7 +82,7 @@ Pass `--wait` for CI and production builds, where accurate types must be present
 npx @databricks/appkit generate-types --wait
 ```
 
-In blocking mode the generator starts a stopped warehouse, waits (bounded) for it to reach `RUNNING`, and then describes your queries. It fails only when the configured warehouse no longer exists (deleted/deleting), so a transient outage or a cold warehouse degrades gracefully rather than breaking the build. The app template wires this up for you: `postinstall` and `predev` run the non-blocking default, while `prebuild` runs `--wait`.
+In blocking mode the generator starts a stopped warehouse and waits — up to a bounded **5-minute** ceiling — for it to reach `RUNNING`, then describes your queries. It fails when the configured warehouse is **deleted/deleting** (it can't be started) **or when the wait times out** before the warehouse reaches `RUNNING`. A transient outage or an unreachable warehouse still degrades gracefully rather than breaking the build. The app template wires this up for you: `postinstall` and `predev` run the non-blocking default, while `prebuild` runs `--wait`.
 
 ## How it works
 

--- a/docs/static/appkit-ui/styles.gen.css
+++ b/docs/static/appkit-ui/styles.gen.css
@@ -594,6 +594,9 @@
   .h-3 {
     height: calc(var(--spacing) * 3);
   }
+  .h-3\.5 {
+    height: calc(var(--spacing) * 3.5);
+  }
   .h-4 {
     height: calc(var(--spacing) * 4);
   }
@@ -725,6 +728,9 @@
   }
   .w-3 {
     width: calc(var(--spacing) * 3);
+  }
+  .w-3\.5 {
+    width: calc(var(--spacing) * 3.5);
   }
   .w-3\/4 {
     width: calc(3/4 * 100%);
@@ -1267,6 +1273,12 @@
       border-color: color-mix(in oklab, var(--border) 50%, transparent);
     }
   }
+  .border-border\/60 {
+    border-color: var(--border);
+    @supports (color: color-mix(in lab, red, red)) {
+      border-color: color-mix(in oklab, var(--border) 60%, transparent);
+    }
+  }
   .border-input {
     border-color: var(--input);
   }
@@ -1727,6 +1739,9 @@
   }
   .opacity-50 {
     opacity: 50%;
+  }
+  .opacity-60 {
+    opacity: 60%;
   }
   .opacity-70 {
     opacity: 70%;

--- a/packages/appkit/src/type-generator/index.ts
+++ b/packages/appkit/src/type-generator/index.ts
@@ -207,6 +207,14 @@ export async function generateFromEntryPoint(options: {
   warehouseId: string;
   noCache?: boolean;
   mode?: PreflightMode;
+  /**
+   * Optional sink for the blocking-mode "still waiting for the warehouse" cold
+   * start notice. The CLI `--wait` path passes a console printer (so a
+   * multi-minute wait isn't silent); dev/non-CLI callers omit it and the
+   * generator falls back to `logger.debug`. Caller-supplied to keep the library
+   * free of direct stdout writes.
+   */
+  report?: (msg: string) => void;
 }) {
   const {
     outFile,
@@ -214,6 +222,7 @@ export async function generateFromEntryPoint(options: {
     warehouseId,
     noCache,
     mode = "non-blocking",
+    report,
   } = options;
   const projectRoot = resolveProjectRoot(outFile);
 
@@ -226,6 +235,7 @@ export async function generateFromEntryPoint(options: {
     const result = await generateQueriesFromDescribe(queryFolder, warehouseId, {
       noCache,
       mode,
+      report,
     });
     queryRegistry = result.schemas;
     syntaxErrors = result.syntaxErrors ?? [];

--- a/packages/appkit/src/type-generator/query-registry.ts
+++ b/packages/appkit/src/type-generator/query-registry.ts
@@ -18,6 +18,8 @@ import {
 import {
   getWarehouseState,
   startWarehouse,
+  WAREHOUSE_WAIT_TIMEOUT,
+  type WarehouseState,
   waitUntilRunning,
 } from "./warehouse-status";
 
@@ -219,6 +221,147 @@ function isConnectivityError(error: unknown): boolean {
   }
 
   return false;
+}
+
+/**
+ * Outcome of {@link ensureRunning}: either the warehouse is RUNNING and the
+ * caller should DESCRIBE (`ok: true`), or it can't serve this run and the caller
+ * should fail with `reason`. Connectivity failures are NOT represented here —
+ * they propagate as thrown errors so the caller's existing `isConnectivityError`
+ * branch degrades them silently (a transient outage must never fail a build).
+ */
+type EnsureRunningResult = { ok: true } | { ok: false; reason: string };
+
+/**
+ * Single owner of "get this warehouse to RUNNING (or decide it can't)" for the
+ * blocking preflight. Collapses what used to be two near-duplicate branches
+ * (start-then-wait for a stopped warehouse, wait for a starting one) into one
+ * routine, fixing two problems they shared:
+ *
+ *  1. Correctness: a STARTING→STOPPED regression mid-wait used to be treated as
+ *     fatal, even though the warehouse merely needs (re)starting. Here, a
+ *     non-terminal STOPPED/STOPPING reading loops back to a fresh start + wait
+ *     under the SAME overall deadline, so the only blocking-mode fatals are a
+ *     genuinely terminal warehouse (DELETED/DELETING) and a real wait-timeout.
+ *  2. Security (CWE-209): the fatal messages here are sanitized — a deleted
+ *     warehouse or a timeout, never a raw SDK/host diagnostic dump. Auth/config
+ *     errors (and connectivity) are surfaced as throws for the caller to
+ *     classify, so this routine never embeds untrusted error text.
+ *
+ * Classification per observed state:
+ *  - DELETED / DELETING → fatal (can't be started; terminal).
+ *  - RUNNING → ok (describe now).
+ *  - STOPPED / STOPPING → nudge it with {@link startWarehouse}, then wait. We
+ *    pass `treatStoppedAsTransient` so the stale pre-start STOPPED reading the
+ *    start hasn't propagated past yet rides out instead of bailing the wait.
+ *  - STARTING (or any other non-RUNNING state) → already coming up; wait without
+ *    a redundant start. If it regresses to STOPPED, the wait surfaces it and the
+ *    loop restarts it on the next pass.
+ *
+ * Everything runs under one `maxMs` deadline shared across loop iterations, so a
+ * regression-driven restart can't extend the budget. A genuine timeout resolves
+ * to a fatal with a distinct, sanitized message (no raw error text).
+ *
+ * @param report - optional caller sink for a one-time "still waiting" notice
+ *   (console for the CLI `--wait` path; `logger.debug`/no-op for dev). Wrapped in
+ *   a once-guard here so it fires at most once even across restart loops.
+ * @throws any non-timeout error from the SDK (auth, connectivity, abort) — the
+ *   caller classifies it (connectivity → degrade, otherwise → sanitized fatal).
+ */
+async function ensureRunning(
+  client: WorkspaceClient,
+  warehouseId: string,
+  opts: { maxMs: number; signal?: AbortSignal; report?: (msg: string) => void },
+): Promise<EnsureRunningResult> {
+  const { maxMs, signal, report } = opts;
+  const deadline = Date.now() + maxMs;
+
+  // Fire the caller's "still waiting" notice at most once across the whole
+  // routine, even if a regression makes us loop through several waitUntilRunning
+  // calls (each of which would otherwise report on its own first poll).
+  let reported = false;
+  const reportOnce = report
+    ? (msg: string) => {
+        if (reported) return;
+        reported = true;
+        report(msg);
+      }
+    : undefined;
+
+  // Distinct, sanitized timeout fatal: seconds only, no last-observed state or
+  // raw SDK text (CWE-209). Used both for the between-iteration budget check and
+  // for a timeout thrown from inside waitUntilRunning.
+  const timeoutReason = (): EnsureRunningResult => ({
+    ok: false,
+    reason: `warehouse ${warehouseId} did not reach RUNNING within ${Math.round(
+      maxMs / 1000,
+    )}s`,
+  });
+
+  while (true) {
+    const state = await getWarehouseState(client, warehouseId);
+
+    // Terminal: a deleted/deleting warehouse genuinely can't reach RUNNING.
+    if (state === "DELETED" || state === "DELETING") {
+      return { ok: false, reason: `warehouse ${warehouseId} is ${state}` };
+    }
+
+    if (state === "RUNNING") return { ok: true };
+
+    // Out of budget before we could even (re)start it → sanitized timeout fatal.
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) return timeoutReason();
+
+    // Stopped/stopping won't come up on its own — nudge it, and ride out the
+    // stale pre-start STOPPED reading. STARTING (or any other non-RUNNING state)
+    // is already coming up, so wait without a redundant start.
+    const startedByUs = state === "STOPPED" || state === "STOPPING";
+    if (startedByUs) {
+      await startWarehouse(client, warehouseId);
+    }
+
+    let final: WarehouseState;
+    try {
+      final = await waitUntilRunning(client, warehouseId, {
+        maxMs: remaining,
+        signal,
+        treatStoppedAsTransient: startedByUs,
+        report: reportOnce,
+      });
+    } catch (err) {
+      // A genuine wait-timeout becomes the sanitized timeout fatal here, so the
+      // raw "(last state: …)" detail never escapes. Every other error
+      // (connectivity, auth, abort) propagates to the caller's preflight catch,
+      // which degrades connectivity and sanitizes the rest.
+      if (err instanceof Error && err.name === WAREHOUSE_WAIT_TIMEOUT) {
+        return timeoutReason();
+      }
+      throw err;
+    }
+
+    if (final === "RUNNING") return { ok: true };
+
+    // A deleted/deleting warehouse surfaced mid-wait is terminal.
+    if (final === "DELETED" || final === "DELETING") {
+      return { ok: false, reason: `warehouse ${warehouseId} is ${final}` };
+    }
+
+    // Otherwise `final` is a STOPPED/STOPPING regression (only reachable when we
+    // did NOT start it this pass — a STARTING→STOPPED drop). Loop: the next pass
+    // re-reads, restarts it, and keeps waiting under the same deadline.
+  }
+}
+
+/**
+ * Build a sanitized fatal message for a blocking-preflight error that is neither
+ * connectivity (degraded) nor a clean {@link ensureRunning} decision — i.e. an
+ * auth, permission, bad-warehouse-id, or SDK-config failure. Deliberately does
+ * NOT embed {@link getErrorDiagnostic} (which can leak SDK/host internals,
+ * CWE-209): the actionable next step is the same regardless of the raw text, and
+ * the full diagnostic is already available via debug logging.
+ */
+function sanitizedPreflightFatal(warehouseId: string): string {
+  return `warehouse ${warehouseId} is not accessible (check the warehouse ID, permissions, and authentication)`;
 }
 
 /**
@@ -429,6 +572,11 @@ export function inferParameterTypes(
  *   immediately), "blocking" waits for a starting warehouse and starts (then
  *   waits for) a stopped one, treating only a deleted/deleting warehouse as
  *   fatal. Defaults to "non-blocking".
+ * @param options.report - optional sink for the one-time "still waiting for the
+ *   warehouse" notice during a blocking cold start. The CLI `--wait` path passes
+ *   a console printer so a multi-minute wait isn't silent; dev/non-CLI callers
+ *   omit it and fall back to `logger.debug` (quiet on stdout). Caller-supplied so
+ *   the library stays pure.
  * @returns an array of query schemas
  */
 export async function generateQueriesFromDescribe(
@@ -438,12 +586,16 @@ export async function generateQueriesFromDescribe(
     noCache?: boolean;
     concurrency?: number;
     mode?: PreflightMode;
+    report?: (msg: string) => void;
   } = {},
 ): Promise<QueryGenerationResult> {
   const {
     noCache = false,
     concurrency: rawConcurrency = 10,
     mode = "non-blocking",
+    // Default to debug logging so a dev/watch caller that doesn't wire a reporter
+    // stays quiet on stdout but the notice is still discoverable with DEBUG on.
+    report = (msg: string) => logger.debug("%s", msg),
   } = options;
   const concurrency =
     typeof rawConcurrency === "number" && Number.isFinite(rawConcurrency)
@@ -601,43 +753,40 @@ export async function generateQueriesFromDescribe(
         if (decision === "fatal") {
           fatalMessage = `warehouse ${warehouseId} is ${state}`;
         }
-        if (decision === "startWaitProceed") {
-          // Stopped/stopping warehouse: nudge it out of the stopped state, then
-          // poll to RUNNING. treatStoppedAsTransient rides out the stale
-          // pre-start STOPPED/STOPPING reading the start hasn't propagated past
-          // yet — only DELETED/DELETING (or the deadline) ends the wait early.
-          await startWarehouse(client, warehouseId);
-          const final = await waitUntilRunning(client, warehouseId, {
+        // Both "start a stopped warehouse then wait" and "wait for a starting
+        // one" collapse into a single readiness owner: ensureRunning starts the
+        // warehouse if needed, polls to RUNNING under one deadline, restarts on a
+        // STARTING→STOPPED regression, and treats only a deleted warehouse or a
+        // genuine timeout as fatal (with a sanitized message — no raw SDK text).
+        if (decision === "startWaitProceed" || decision === "waitThenProceed") {
+          const result = await ensureRunning(client, warehouseId, {
             maxMs: PREFLIGHT_WAIT_MAX_MS,
-            treatStoppedAsTransient: true,
+            report,
           });
-          if (final === "RUNNING") {
+          if (result.ok) {
             decision = "proceed";
           } else {
             decision = "fatal";
-            fatalMessage = `warehouse ${warehouseId} did not reach RUNNING (now ${final})`;
-          }
-        }
-        if (decision === "waitThenProceed") {
-          const final = await waitUntilRunning(client, warehouseId, {
-            maxMs: PREFLIGHT_WAIT_MAX_MS,
-          });
-          if (final === "RUNNING") {
-            decision = "proceed";
-          } else {
-            decision = "fatal";
-            fatalMessage = `warehouse ${warehouseId} did not reach RUNNING (now ${final})`;
+            fatalMessage = result.reason;
           }
         }
       } catch (err) {
         if (isConnectivityError(err)) {
           // Warehouse unreachable (transient outage): degrade silently like a
-          // per-query connectivity failure — never fail a build on a blip.
+          // per-query connectivity failure — never fail a build on a blip. The
+          // raw diagnostic is still available at debug level for investigation.
+          logger.debug("Warehouse preflight connectivity failure: %O", err);
           decision = "degradeAll";
         } else {
-          // Auth, bad warehouse id, malformed config, or a timed-out wait: fatal.
+          // Auth, bad warehouse id, or malformed SDK config: fatal. Keep the
+          // user-facing message sanitized (no raw SDK/host diagnostic dump,
+          // CWE-209) and route the full diagnostic to debug logging instead.
+          logger.debug(
+            "Warehouse preflight fatal: %s",
+            getErrorDiagnostic(err),
+          );
           decision = "fatal";
-          fatalMessage = `warehouse ${warehouseId}: ${getErrorDiagnostic(err)}`;
+          fatalMessage = sanitizedPreflightFatal(warehouseId);
         }
       }
     }

--- a/packages/appkit/src/type-generator/tests/generate-queries.test.ts
+++ b/packages/appkit/src/type-generator/tests/generate-queries.test.ts
@@ -720,15 +720,21 @@ describe("generateQueriesFromDescribe", () => {
       },
     );
 
-    test("STOPPED + blocking — start succeeds but warehouse never reaches RUNNING is fatal", async () => {
+    test("STOPPED + blocking — start succeeds but warehouse becomes DELETED mid-wait is fatal", async () => {
       vi.useFakeTimers();
       try {
         mocks.readdir.mockResolvedValue(["a.sql"]);
         mocks.readFile.mockResolvedValue("SELECT id FROM a");
         // Preflight sees STOPPED → start fires, but the warehouse then reports
         // DELETED (a genuinely terminal state even with treatStoppedAsTransient).
-        // The wait resolves non-RUNNING → fatal; schemas still written.
+        // ensureRunning surfaces the deleted state as the fatal reason; schemas
+        // are still written so the .d.ts exists before the caller throws.
+        //
+        // Two STOPPED reads precede DELETED: the executor probes once (for
+        // decidePreflight → startWaitProceed), then ensureRunning re-reads STOPPED
+        // (and starts the warehouse) before its wait surfaces DELETED.
         mocks.getWarehouse
+          .mockReturnValueOnce({ state: "STOPPED" })
           .mockReturnValueOnce({ state: "STOPPED" })
           .mockReturnValue({ state: "DELETED" });
 
@@ -741,11 +747,10 @@ describe("generateQueriesFromDescribe", () => {
         expect(mocks.startWarehouse).toHaveBeenCalledTimes(1);
         expect(mocks.executeStatement).not.toHaveBeenCalled();
         expect(syntaxErrors).toEqual([]);
+        // A deleted warehouse is reported as terminal (not a generic timeout),
+        // and the message carries no raw SDK/host diagnostic text.
         expect(fatalErrors).toEqual([
-          {
-            name: "a",
-            message: "warehouse wh-123 did not reach RUNNING (now DELETED)",
-          },
+          { name: "a", message: "warehouse wh-123 is DELETED" },
         ]);
         expect(schemas[0].type).toContain("result: unknown");
       } finally {
@@ -901,6 +906,134 @@ describe("generateQueriesFromDescribe", () => {
       expect(schemas[0].type).toBe(CACHED_GOOD_TYPE);
       expect(syntaxErrors).toEqual([]);
       expect(fatalErrors).toEqual([]);
+    });
+
+    test("STARTING→STOPPED regression + blocking — restarts the warehouse and proceeds once RUNNING (NOT fatal)", async () => {
+      vi.useFakeTimers();
+      try {
+        mocks.readdir.mockResolvedValue(["a.sql"]);
+        mocks.readFile.mockResolvedValue("SELECT id FROM a");
+        // The regression the unified ensureRunning fixes: a warehouse seen
+        // STARTING drops back to STOPPED mid-wait. The old code treated that
+        // non-RUNNING final state as fatal. Now it must (re)start the warehouse
+        // and keep waiting under the same deadline, then describe once RUNNING.
+        //
+        // Probe sequence (the executor probes once for decidePreflight, then
+        // ensureRunning owns the rest):
+        //   1) STARTING  — executor's preflight probe → waitThenProceed
+        //   2) STARTING  — ensureRunning's initial read (no start; it's coming up)
+        //   3) STOPPED   — waitUntilRunning's first poll surfaces the regression
+        //                  (terminal with treatStoppedAsTransient off) → loop
+        //   4) STOPPED   — ensureRunning re-reads → now startWarehouse fires
+        //   5) STOPPED   — stale post-start read, ridden out (transient on)
+        //   6) RUNNING   — warehouse is up → proceed → DESCRIBE
+        mocks.getWarehouse
+          .mockReturnValueOnce({ state: "STARTING" })
+          .mockReturnValueOnce({ state: "STARTING" })
+          .mockReturnValueOnce({ state: "STOPPED" })
+          .mockReturnValueOnce({ state: "STOPPED" })
+          .mockReturnValueOnce({ state: "STOPPED" })
+          .mockReturnValue({ state: "RUNNING" });
+        mocks.executeStatement.mockResolvedValue(
+          succeededResult([["id", "INT", null]]),
+        );
+
+        const promise = generateQueriesFromDescribe("/queries", "wh-123", {
+          mode: "blocking",
+        });
+        await vi.runAllTimersAsync();
+        const { schemas, syntaxErrors, fatalErrors } = await promise;
+
+        // Exactly one (re)start — the regression triggers a single restart, not
+        // one per poll — and DESCRIBE runs after the warehouse reaches RUNNING.
+        expect(mocks.startWarehouse).toHaveBeenCalledTimes(1);
+        expect(mocks.startWarehouse).toHaveBeenCalledWith({ id: "wh-123" });
+        expect(mocks.executeStatement).toHaveBeenCalledTimes(1);
+        expect(schemas).toHaveLength(1);
+        expect(schemas[0].type).toContain("id: number");
+        // The regression is NOT fatal: it recovered and described.
+        expect(syntaxErrors).toEqual([]);
+        expect(fatalErrors).toEqual([]);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    test("blocking — a genuine wait-timeout is a distinct, sanitized fatal (no raw SDK/host text)", async () => {
+      vi.useFakeTimers();
+      try {
+        mocks.readdir.mockResolvedValue(["a.sql"]);
+        mocks.readFile.mockResolvedValue("SELECT id FROM a");
+        // The warehouse is STARTING forever — it never reaches RUNNING, so the
+        // 5-minute preflight budget elapses. This is the only non-deleted fatal:
+        // a genuine timeout. (No start: a STARTING warehouse is already coming up.)
+        mocks.getWarehouse.mockReturnValue({ state: "STARTING" });
+
+        const promise = generateQueriesFromDescribe("/queries", "wh-123", {
+          mode: "blocking",
+        });
+        // Drive the polling/backoff clock until the deadline trips and the wait
+        // throws its (caught) timeout.
+        await vi.runAllTimersAsync();
+        const { schemas, syntaxErrors, fatalErrors } = await promise;
+
+        expect(mocks.executeStatement).not.toHaveBeenCalled();
+        expect(syntaxErrors).toEqual([]);
+        // Distinct, sanitized timeout message: seconds only, derived from the
+        // 5-minute ceiling — never the raw "(last state: …)" diagnostic.
+        expect(fatalErrors).toEqual([
+          {
+            name: "a",
+            message: "warehouse wh-123 did not reach RUNNING within 300s",
+          },
+        ]);
+        // Belt-and-suspenders: the surfaced message leaks none of the raw
+        // wait-timeout internals (its "(last state: …)" detail or the raw `Nms`
+        // budget) nor any host/SDK URL.
+        const message = fatalErrors[0].message;
+        expect(message).not.toContain("last state");
+        expect(message).not.toMatch(/within \d+ms/);
+        expect(message).not.toMatch(/https?:\/\//);
+        expect(schemas[0].type).toContain("result: unknown");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    test("blocking cold start — emits the reporter line exactly once", async () => {
+      vi.useFakeTimers();
+      try {
+        mocks.readdir.mockResolvedValue(["a.sql"]);
+        mocks.readFile.mockResolvedValue("SELECT id FROM a");
+        // Cold start: STOPPED → start → a couple of waiting reads → RUNNING. The
+        // CLI `--wait` path threads a `report` sink; it must fire exactly once
+        // (before the first wait), even though the warehouse is polled several
+        // times and ensureRunning may loop.
+        mocks.getWarehouse
+          .mockReturnValueOnce({ state: "STOPPED" })
+          .mockReturnValueOnce({ state: "STOPPED" })
+          .mockReturnValueOnce({ state: "STARTING" })
+          .mockReturnValue({ state: "RUNNING" });
+        mocks.executeStatement.mockResolvedValue(
+          succeededResult([["id", "INT", null]]),
+        );
+
+        const report = vi.fn();
+        const promise = generateQueriesFromDescribe("/queries", "wh-123", {
+          mode: "blocking",
+          report,
+        });
+        await vi.runAllTimersAsync();
+        const { fatalErrors } = await promise;
+
+        expect(fatalErrors).toEqual([]);
+        // Exactly one line, and it's the "still waiting" notice for this warehouse.
+        expect(report).toHaveBeenCalledTimes(1);
+        expect(report.mock.calls[0][0]).toContain("wh-123");
+        expect(report.mock.calls[0][0]).toContain("RUNNING");
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 });

--- a/packages/appkit/src/type-generator/tests/warehouse-status.test.ts
+++ b/packages/appkit/src/type-generator/tests/warehouse-status.test.ts
@@ -164,6 +164,60 @@ describe("waitUntilRunning", () => {
     expect(get).not.toHaveBeenCalled();
   });
 
+  test("report fires exactly once, before the first wait", async () => {
+    // STARTING then RUNNING: the first poll commits us to a wait, so report
+    // fires once before the first backoff sleep; the second poll (post-sleep)
+    // resolves RUNNING and must NOT report again.
+    const get = vi
+      .fn()
+      .mockResolvedValueOnce(stateResponse("STARTING"))
+      .mockResolvedValueOnce(stateResponse("RUNNING"));
+    const client = makeClient(get);
+    const report = vi.fn();
+
+    const promise = waitUntilRunning(client, "wh-1", { maxMs: 60000, report });
+
+    // After the first poll resolves but before advancing the clock (no sleep
+    // elapsed yet), report must already have fired exactly once.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(report).toHaveBeenCalledTimes(1);
+    expect(report.mock.calls[0][0]).toContain("wh-1");
+    expect(report.mock.calls[0][0]).toContain("RUNNING");
+    // get has been called once (first poll); the wait is parked on its backoff.
+    expect(get).toHaveBeenCalledTimes(1);
+
+    // Let the backoff elapse so the second poll fires and resolves RUNNING.
+    await vi.advanceTimersByTimeAsync(1000);
+    await expect(promise).resolves.toBe("RUNNING");
+    // Still exactly one report across the whole wait.
+    expect(report).toHaveBeenCalledTimes(1);
+  });
+
+  test("report does NOT fire when the warehouse is already RUNNING", async () => {
+    // First poll is RUNNING, so no wait happens — the notice would be spurious.
+    const get = vi.fn().mockResolvedValue(stateResponse("RUNNING"));
+    const client = makeClient(get);
+    const report = vi.fn();
+
+    await expect(
+      waitUntilRunning(client, "wh-1", { maxMs: 60000, report }),
+    ).resolves.toBe("RUNNING");
+    expect(report).not.toHaveBeenCalled();
+  });
+
+  test("report does NOT fire when the first read is already terminal", async () => {
+    // STOPPED (terminal with the flag off) resolves on the first poll without
+    // waiting, so the "still waiting" notice must not fire.
+    const get = vi.fn().mockResolvedValue(stateResponse("STOPPED"));
+    const client = makeClient(get);
+    const report = vi.fn();
+
+    await expect(
+      waitUntilRunning(client, "wh-1", { maxMs: 60000, report }),
+    ).resolves.toBe("STOPPED");
+    expect(report).not.toHaveBeenCalled();
+  });
+
   test("stops promptly when aborted mid-wait", async () => {
     const get = vi.fn().mockResolvedValue(stateResponse("STARTING"));
     const client = makeClient(get);

--- a/packages/appkit/src/type-generator/warehouse-status.ts
+++ b/packages/appkit/src/type-generator/warehouse-status.ts
@@ -17,6 +17,15 @@ export type WarehouseState =
 const INITIAL_POLL_MS = 1000;
 const MAX_POLL_MS = 15000;
 
+/**
+ * `name` on the Error {@link waitUntilRunning} throws when its deadline elapses
+ * before the warehouse reaches RUNNING. Exported so callers can distinguish a
+ * genuine wait-timeout (worth a dedicated, sanitized message) from any other
+ * failure surfaced during polling (connectivity/auth), without string-matching
+ * the message — whose `(last state: …)` detail should never reach end users.
+ */
+export const WAREHOUSE_WAIT_TIMEOUT = "WarehouseWaitTimeoutError";
+
 /** States from which the warehouse will not transition to RUNNING on its own. */
 const NOT_COMING_UP: ReadonlySet<WarehouseState> = new Set<WarehouseState>([
   "STOPPED",
@@ -116,6 +125,13 @@ export async function startWarehouse(
  * down): the next deadline/abort check throws an `AbortError`, and a pending
  * backoff sleep resolves immediately rather than holding the process open.
  *
+ * Pass `opts.report` to surface a single "still waiting" line to the caller (a
+ * cold start can take minutes; without it a `--wait` build looks hung). It is
+ * invoked EXACTLY ONCE, before the first poll/sleep, and only when the first
+ * read is not already RUNNING/terminal — i.e. only when we're actually about to
+ * wait. The library stays pure: the message is handed to a caller-supplied sink
+ * (console for the CLI, `logger.debug`/no-op for dev), never written here.
+ *
  * @throws Error if `maxMs` elapses before the warehouse reaches RUNNING.
  * @throws Error (`name === "AbortError"`) if `opts.signal` is or becomes aborted.
  */
@@ -127,9 +143,10 @@ export async function waitUntilRunning(
     pollMs?: number;
     signal?: AbortSignal;
     treatStoppedAsTransient?: boolean;
+    report?: (msg: string) => void;
   },
 ): Promise<WarehouseState> {
-  const { maxMs, signal, treatStoppedAsTransient } = opts;
+  const { maxMs, signal, treatStoppedAsTransient, report } = opts;
   const start = Date.now();
   let pollMs = opts.pollMs ?? INITIAL_POLL_MS;
 
@@ -139,6 +156,11 @@ export async function waitUntilRunning(
     ? NEVER_COMING_UP
     : NOT_COMING_UP;
 
+  // Fire the "still waiting" notice at most once, and only once we know the first
+  // read settled into an actual wait (not already RUNNING/terminal). Hoisted so
+  // the guard survives every loop iteration.
+  let reported = false;
+
   while (true) {
     throwIfAborted(signal);
 
@@ -146,10 +168,19 @@ export async function waitUntilRunning(
     if (state === "RUNNING") return "RUNNING";
     if (terminalStates.has(state)) return state;
 
-    if (Date.now() - start >= maxMs) {
-      throw new Error(
-        `Warehouse ${warehouseId} did not reach RUNNING within ${maxMs}ms (last state: ${state})`,
+    // First non-terminal read: we're committing to wait, so tell the caller once
+    // before the very first backoff sleep. Subsequent polls stay quiet.
+    if (!reported) {
+      reported = true;
+      report?.(
+        `Waiting for warehouse ${warehouseId} to reach RUNNING (up to ${Math.round(
+          maxMs / 1000,
+        )}s)…`,
       );
+    }
+
+    if (Date.now() - start >= maxMs) {
+      throw timeoutError(warehouseId, maxMs, state);
     }
 
     await delay(pollMs, signal);
@@ -158,9 +189,7 @@ export async function waitUntilRunning(
     // Re-check the deadline after sleeping so we don't issue another poll past
     // the budget purely because we napped through it.
     if (Date.now() - start >= maxMs) {
-      throw new Error(
-        `Warehouse ${warehouseId} did not reach RUNNING within ${maxMs}ms (last state: ${state})`,
-      );
+      throw timeoutError(warehouseId, maxMs, state);
     }
 
     pollMs = Math.min(pollMs * 2, MAX_POLL_MS);
@@ -173,4 +202,23 @@ function throwIfAborted(signal?: AbortSignal): void {
   const error = new Error("The warehouse wait was aborted.");
   error.name = "AbortError";
   throw error;
+}
+
+/**
+ * Build the deadline-elapsed error, tagged with {@link WAREHOUSE_WAIT_TIMEOUT}
+ * so callers can recognise a genuine timeout (vs. a connectivity/auth failure
+ * thrown mid-poll) without parsing the message. The message keeps the last
+ * observed state for debug/log use; callers that surface text to end users
+ * should compose their own sanitized message instead.
+ */
+function timeoutError(
+  warehouseId: string,
+  maxMs: number,
+  lastState: WarehouseState,
+): Error {
+  const error = new Error(
+    `Warehouse ${warehouseId} did not reach RUNNING within ${maxMs}ms (last state: ${lastState})`,
+  );
+  error.name = WAREHOUSE_WAIT_TIMEOUT;
+  return error;
 }

--- a/packages/shared/src/cli/commands/generate-types.ts
+++ b/packages/shared/src/cli/commands/generate-types.ts
@@ -73,6 +73,12 @@ async function runGenerateTypes(
           warehouseId: resolvedWarehouseId,
           noCache,
           mode,
+          // Surface the blocking-mode cold-start wait so a `--wait` run (CI or a
+          // deliberate refresh) isn't silent for up to ~5 minutes while the
+          // warehouse warms up. The generator only ever invokes this once, and
+          // only in blocking mode, so it's a no-op for the default non-blocking
+          // path. Print to stdout so it interleaves with the other progress.
+          report: (msg) => console.log(msg),
         });
         console.log(`Generated query types: ${resolvedOutFile}`);
       }

--- a/packages/shared/src/cli/commands/type-generator.d.ts
+++ b/packages/shared/src/cli/commands/type-generator.d.ts
@@ -10,6 +10,11 @@ declare module "@databricks/appkit/type-generator" {
     // "blocking" waits for a startable warehouse and treats a stopped one as
     // fatal.
     mode?: "non-blocking" | "blocking";
+    // Optional sink for the blocking-mode cold-start "still waiting" notice,
+    // invoked at most once (and only in blocking mode). The CLI passes a console
+    // printer so a `--wait` run isn't silent during a multi-minute warehouse
+    // warm-up.
+    report?: (msg: string) => void;
   }): Promise<void>;
 
   export class TypegenSyntaxError extends Error {


### PR DESCRIPTION
PR1 of the stacked typegen-hardening plan — hardens the non-blocking typegen redesign (#406). **Readiness correctness only (F1 + F3 + F6).**

## What & why

- **F1 — single `ensureRunning` owner.** Collapses the two blocking-preflight branches (`startWaitProceed` / `waitThenProceed`) into one routine: a `STARTING→STOPPED` regression now **restarts and waits** instead of going fatal; only `DELETED`/`DELETING` or a genuine wait-timeout are fatal. Fatal/timeout messages are **sanitized** (raw `getErrorDiagnostic` text moves to `logger.debug`, closing a CWE-209 info leak).
- **F3 — cold-start feedback.** `waitUntilRunning` gained a caller-supplied `report` hook that fires once before the wait, so a cold-start `--wait` build is no longer silent for up to 5 minutes. The CLI prints one line to stdout; dev/non-CLI callers default to `logger.debug` (the library stays pure).
- **F6 — docs.** `docs/docs/development/type-generation.md` now states the bounded 5-minute ceiling and the correct failure contract (deleted/deleting **or** timeout).

Does **not** touch F2/F4/F5 — those are separate PRs in the stack.

## Verification

- `pnpm exec vitest run packages/appkit/src/type-generator packages/shared/src/cli` — **476 passed** (+6 new: sanitized-timeout, start-on-regression, reporter-fires-once)
- `pnpm -r typecheck` — clean
- `pnpm check` (biome) — exit 0 (pre-existing warnings only)
- `pnpm build` + `pnpm docs:build` — green

8 files changed, +443 / −38.

This pull request and its description were written by Isaac.
