### PR TITLE
fix(shared): add scaffolding rule to treat init output as starter code

### DIFF
--- a/packages/shared/src/cli/commands/plugin/validate/validate-manifest.test.ts
+++ b/packages/shared/src/cli/commands/plugin/validate/validate-manifest.test.ts
@@ -967,6 +967,7 @@ describe("validate-manifest", () => {
       // Pins the canonical content of TEMPLATE_SCAFFOLDING.rules so changes
       // to the must/should/never strings are explicit and reviewed.
       expect(TEMPLATE_SCAFFOLDING.rules.must).toEqual([
+        "Treat `databricks apps init` output as starter code, not requirements; adapt or replace it to match the requested app",
         "Keep all secrets and credentials only in app.yaml, databricks.yml, and/or .env",
       ]);
       expect(TEMPLATE_SCAFFOLDING.rules.should).toEqual([

--- a/packages/shared/src/schemas/manifest.ts
+++ b/packages/shared/src/schemas/manifest.ts
@@ -1099,6 +1099,7 @@ export const TEMPLATE_SCAFFOLDING = {
   },
   rules: {
     must: [
+      "Treat `databricks apps init` output as starter code, not requirements; adapt or replace it to match the requested app",
       "Keep all secrets and credentials only in app.yaml, databricks.yml, and/or .env",
     ],
     should: ["ask user when in doubt of resource to use for plugin"],

--- a/template/appkit.plugins.json
+++ b/template/appkit.plugins.json
@@ -358,6 +358,7 @@
     },
     "rules": {
       "must": [
+        "Treat `databricks apps init` output as starter code, not requirements; adapt or replace it to match the requested app",
         "Keep all secrets and credentials only in app.yaml, databricks.yml, and/or .env"
       ],
       "should": [


### PR DESCRIPTION
## What

Adds a `must` rule to the template manifest's scaffolding ruleset (`TEMPLATE_SCAFFOLDING.rules.must`):

> Treat `databricks apps init` output as starter code, not requirements; adapt or replace it to match the requested app

## Why

The scaffolding rules steer the AI agent that drives `databricks apps init`. Without this directive, an agent can treat the generated starter app as a fixed spec and build around it, rather than adapting/replacing it to match what the user actually asked for. This makes the "scaffold is a starting point" expectation explicit.

## How

- Edits the **canonical source** — `packages/shared/src/schemas/manifest.ts` (`TEMPLATE_SCAFFOLDING.rules.must`). The rule is **117 chars**, within the schema's 120-char `SCAFFOLDING_RULE_MAX_LENGTH`.
- Updates the pinning test `validate-manifest.test.ts` (`toEqual` on `rules.must`).
- Regenerates `template/appkit.plugins.json` via `pnpm sync:template` (the JSON is a generated artifact — not hand-edited).

## Verification

- `validate-manifest.test.ts` — 61 passed (includes the schema-parse + pinning tests)
- `sync.test.ts` — 25 passed
- `pnpm --filter shared typecheck` — clean

Draft for review of the rule wording before merge.

This pull request and its description were written by Isaac.
