### PR TITLE
fix(appkit): ownership-guard the typegen spawn lock with a token [F4]

### DIFF
--- a/packages/shared/src/cli/commands/generate-types.test.ts
+++ b/packages/shared/src/cli/commands/generate-types.test.ts
@@ -38,8 +38,12 @@ const {
         unref,
       }),
     ),
-    acquireSpawnLock: vi.fn(() => true),
-    releaseSpawnLock: vi.fn(),
+    // Typed params so `.mock.calls` carry the (lockPath, token[, staleMs]) tuple
+    // the token-plumbing assertions read.
+    acquireSpawnLock: vi.fn(
+      (_lockPath: string, _token: string, _staleMs?: number) => true,
+    ),
+    releaseSpawnLock: vi.fn((_lockPath: string, _token: string) => {}),
     getSpawnLockPath: vi.fn(lockPathOf),
   };
 });
@@ -70,7 +74,7 @@ import { generateTypesCommand, resolveTypegenMode } from "./generate-types";
 
 /**
  * Drive the real commander command the way the bin does, so argv parsing
- * (`--wait`, `--worker-lock <path>` → camelCase, positionals) is exercised
+ * (`--wait`, `--worker-token <token>` → camelCase, positionals) is exercised
  * end-to-end. `from: "user"` means args are the user-supplied tokens only.
  */
 async function runCli(args: string[]): Promise<void> {
@@ -142,10 +146,15 @@ describe("generate-types foreground spawn orchestration", () => {
     );
 
     // Exactly one detached worker, re-invoking this CLI with --wait and the
-    // worker lock, forwarding the same positional targets.
+    // worker token, forwarding the same positional targets.
     expect(spawn).toHaveBeenCalledTimes(1);
     const [bin, argv, opts] = spawn.mock.calls[0];
     expect(bin).toBe(process.execPath);
+    // The same per-acquisition token written into the lock is handed to the
+    // worker (the lock PATH is no longer forwarded — the worker re-derives it).
+    const token = acquireSpawnLock.mock.calls[0][1];
+    expect(typeof token).toBe("string");
+    expect(token.length).toBeGreaterThan(0);
     // The parent's node/loader flags (process.execArgv — e.g. tsx's
     // --require/--import) are forwarded before the CLI entry so a worker spawned
     // from a source/tsx run can still execute the .ts. Everything from the entry
@@ -157,8 +166,8 @@ describe("generate-types foreground spawn orchestration", () => {
       process.argv[1], // CLI entry
       "generate-types",
       "--wait",
-      "--worker-lock",
-      getSpawnLockPath(tmpRoot),
+      "--worker-token",
+      token,
       tmpRoot,
       outFile,
       "wh-123",
@@ -215,17 +224,19 @@ describe("generate-types foreground spawn orchestration", () => {
     expect(spawn).not.toHaveBeenCalled();
   });
 
-  test("worker invocation (--worker-lock): runs blocking generate, releases lock, does NOT spawn", async () => {
+  test("worker invocation (--worker-token): runs blocking generate, releases its lock by derived path + token, does NOT spawn", async () => {
+    // The worker re-derives the lock path from its rootDir positional and
+    // releases with the token it was handed.
     const lockPath = getSpawnLockPath(tmpRoot);
 
-    await runCli([tmpRoot, "--worker-lock", lockPath]);
+    await runCli([tmpRoot, "--worker-token", "tok-xyz"]);
 
     // A worker is always blocking — it does the real DESCRIBE lifecycle.
     expect(generateFromEntryPoint).toHaveBeenCalledWith(
       expect.objectContaining({ mode: "blocking" }),
     );
-    // It releases the SAME lock it was handed.
-    expect(releaseSpawnLock).toHaveBeenCalledWith(lockPath);
+    // It releases the lock it owns: the derived path AND its ownership token.
+    expect(releaseSpawnLock).toHaveBeenCalledWith(lockPath, "tok-xyz");
     // It must never spawn another worker (recursion would never terminate).
     expect(spawn).not.toHaveBeenCalled();
     expect(acquireSpawnLock).not.toHaveBeenCalled();

--- a/packages/shared/src/cli/commands/generate-types.ts
+++ b/packages/shared/src/cli/commands/generate-types.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { Command, Option } from "commander";
@@ -29,13 +30,14 @@ interface GenerateTypesOptions {
   noCache?: boolean;
   wait?: boolean;
   /**
-   * Internal: present only on the detached worker invocation. Carries the path
-   * of the single-flight lock this worker must release when it finishes. Its
-   * presence is what marks an invocation as "the worker" — workers always run
-   * with `--wait`, so they never spawn another worker (only non-blocking runs
-   * spawn), which terminates the recursion.
+   * Internal: present only on the detached worker invocation. Carries the
+   * ownership token of the single-flight lock this worker must release when it
+   * finishes (the lock PATH is derived from `rootDir`, so it isn't forwarded
+   * separately). Its presence is what marks an invocation as "the worker" —
+   * workers always run with `--wait`, so they never spawn another worker (only
+   * non-blocking runs spawn), which terminates the recursion.
    */
-  workerLock?: string;
+  workerToken?: string;
 }
 
 /**
@@ -124,9 +126,10 @@ async function runGenerateTypes(
  * after the foreground non-blocking generate has already written degraded types.
  *
  * Re-invokes THIS CLI (`process.execPath` + `process.argv[1]` — the bin entry
- * that launched us) with `generate-types --wait --worker-lock <lockPath>` plus
- * the same positional target options the foreground used, so the worker writes
- * to the same out file / reads the same query folder. The worker is:
+ * that launched us) with `generate-types --wait --worker-token <token>` plus the
+ * same positional target options the foreground used, so the worker writes to
+ * the same out file / reads the same query folder (and re-derives the lock path
+ * from rootDir). The worker is:
  *  - `detached: true` + `.unref()` so it outlives this process (install/dev-setup
  *    can finish and exit while the worker keeps warming the warehouse).
  *  - `stdio: "ignore"` so it never holds the parent's pipes open or interleaves
@@ -135,13 +138,16 @@ async function runGenerateTypes(
  * Spawning is wrapped so any failure is non-fatal: the caller still has degraded
  * types and exits 0.
  *
- * @param lockPath - the acquired single-flight lock; passed to the worker so it
- *   releases the SAME lock when it finishes.
+ * @param token - the ownership token the foreground wrote into the lock; handed
+ *   to the worker (via `--worker-token`) so it releases only the lock it owns.
+ *   The lock PATH is NOT forwarded — the worker re-derives it from the `rootDir`
+ *   positional (deterministic via getSpawnLockPath), so the token is the single
+ *   release credential.
  * @param targets - the foreground's positional args, forwarded verbatim.
  * @returns true if the worker was spawned, false if spawning threw.
  */
 export function spawnTypegenWorker(
-  lockPath: string,
+  token: string,
   targets: { rootDir?: string; outFile?: string; warehouseId?: string },
 ): boolean {
   // The script the runtime launched us with (the `appkit` bin shim). Re-running
@@ -151,7 +157,8 @@ export function spawnTypegenWorker(
   // Forward the positionals in declaration order (rootDir, outFile,
   // warehouseId). Stop at the first undefined so we never pass a literal
   // "undefined" — commander would treat it as a positional value. (rootDir is
-  // effectively always set by commander's default, but guard anyway.)
+  // effectively always set by commander's default, and the worker needs it to
+  // re-derive the lock path, but guard anyway.)
   const positionals: string[] = [];
   for (const value of [targets.rootDir, targets.outFile, targets.warehouseId]) {
     if (value === undefined) break;
@@ -169,8 +176,8 @@ export function spawnTypegenWorker(
     cliEntry,
     "generate-types",
     "--wait",
-    "--worker-lock",
-    lockPath,
+    "--worker-token",
+    token,
     ...positionals,
   ];
 
@@ -200,9 +207,10 @@ export function spawnTypegenWorker(
  *     blocking worker behind the single-flight lock. If the lock is already held
  *     by a live worker, skip (single-flight) with a one-line note. Either way the
  *     foreground returns normally (exit 0).
- *  3. If this IS the worker (`--worker-lock` present), it ran blocking above and
- *     releases the lock here (and via a process-exit guard, so a hard failure /
- *     process.exit still frees it).
+ *  3. If this IS the worker (`--worker-token` present), it ran blocking above and
+ *     releases the lock here — by re-deriving the lock path from rootDir and
+ *     unlinking only if the lock still carries its token (and via a process-exit
+ *     guard, so a hard failure / process.exit still frees it).
  */
 async function generateTypesAction(
   rootDir: string | undefined,
@@ -210,21 +218,29 @@ async function generateTypesAction(
   warehouseId: string | undefined,
   options: GenerateTypesOptions,
 ) {
-  const isWorker = typeof options.workerLock === "string";
+  const workerToken = options.workerToken;
+  const isWorker = typeof workerToken === "string";
+
+  // A worker releases the lock by its derived PATH + the ownership TOKEN it was
+  // handed: the unlink only happens if the on-disk lock still carries that token,
+  // so a worker whose lock was stolen as stale can't delete the new owner's lock.
+  // The path is re-derived from the same rootDir the foreground used.
+  const workerLockPath = isWorker
+    ? getSpawnLockPath(rootDir || process.cwd())
+    : undefined;
 
   // A worker must always free its lock, even if the blocking generate throws or
   // calls process.exit (TypegenFatalError → exit 1). The exit handler covers the
   // process.exit / uncaught paths; the finally covers the normal return.
-  if (isWorker && options.workerLock) {
-    const lockPath = options.workerLock;
-    process.once("exit", () => releaseSpawnLock(lockPath));
+  if (isWorker && workerLockPath && workerToken) {
+    process.once("exit", () => releaseSpawnLock(workerLockPath, workerToken));
   }
 
   try {
     await runGenerateTypes(rootDir, outFile, warehouseId, options);
   } finally {
-    if (isWorker && options.workerLock) {
-      releaseSpawnLock(options.workerLock);
+    if (isWorker && workerLockPath && workerToken) {
+      releaseSpawnLock(workerLockPath, workerToken);
     }
   }
 
@@ -234,9 +250,12 @@ async function generateTypesAction(
   if (!isWorker && resolveTypegenMode(options) === "non-blocking") {
     const resolvedRootDir = rootDir || process.cwd();
     const lockPath = getSpawnLockPath(resolvedRootDir);
+    // A fresh per-acquisition credential: written into the lock body and handed
+    // to the worker so only it can release this lock.
+    const token = randomUUID();
 
-    if (acquireSpawnLock(lockPath)) {
-      spawnTypegenWorker(lockPath, { rootDir, outFile, warehouseId });
+    if (acquireSpawnLock(lockPath, token)) {
+      spawnTypegenWorker(token, { rootDir, outFile, warehouseId });
     } else {
       console.log("Type refresh already in progress, skipping.");
     }
@@ -257,12 +276,13 @@ export const generateTypesCommand = new Command("generate-types")
     "--wait",
     "Wait for warehouse readiness instead of degrading (use for CI)",
   )
-  // Internal: marks the detached background worker and carries the lock it must
-  // release. Hidden from --help; users should never pass it.
+  // Internal: marks the detached background worker and carries the ownership
+  // token it must present to release the lock. Hidden from --help; users should
+  // never pass it.
   .addOption(
     new Option(
-      "--worker-lock <path>",
-      "Internal: detached worker lock path",
+      "--worker-token <token>",
+      "Internal: detached worker lock ownership token",
     ).hideHelp(),
   )
   .addHelpText(

--- a/packages/shared/src/cli/commands/spawn-lock.test.ts
+++ b/packages/shared/src/cli/commands/spawn-lock.test.ts
@@ -37,57 +37,109 @@ describe("spawn-lock", () => {
 
   test("acquire creates the lock (and its parent dirs) and returns true", () => {
     const nested = path.join(tmpRoot, "node_modules", ".databricks", "lock");
-    expect(acquireSpawnLock(nested)).toBe(true);
+    expect(acquireSpawnLock(nested, "tok-1")).toBe(true);
     expect(fs.existsSync(nested)).toBe(true);
-    // Body records pid for debugging.
-    expect(fs.readFileSync(nested, "utf8")).toContain(String(process.pid));
+    // Body records pid (debugging) and the ownership token.
+    const body = fs.readFileSync(nested, "utf8");
+    expect(body).toContain(String(process.pid));
+    expect(body).toContain("tok-1");
   });
 
   test("acquire returns false when a FRESH lock is already held (single-flight)", () => {
-    expect(acquireSpawnLock(lockPath)).toBe(true);
+    expect(acquireSpawnLock(lockPath, "tok-a")).toBe(true);
     // Second caller sees a fresh lock and backs off.
-    expect(acquireSpawnLock(lockPath)).toBe(false);
+    expect(acquireSpawnLock(lockPath, "tok-b")).toBe(false);
     // The original lock file is untouched.
     expect(fs.existsSync(lockPath)).toBe(true);
   });
 
-  test("acquire STEALS a stale lock (older than staleMs) and recreates it", () => {
-    fs.writeFileSync(lockPath, "99999 0\n");
+  test("acquire STEALS a stale lock (older than staleMs) and recreates it with the new token", () => {
+    fs.writeFileSync(lockPath, "99999 0 old-token\n");
     // Backdate mtime well beyond the stale window.
     const old = new Date(Date.now() - (SPAWN_LOCK_STALE_MS + 60_000));
     fs.utimesSync(lockPath, old, old);
 
-    expect(acquireSpawnLock(lockPath)).toBe(true);
-    // Re-created with our pid — proves it was stolen, not just observed.
-    expect(fs.readFileSync(lockPath, "utf8")).toContain(String(process.pid));
+    expect(acquireSpawnLock(lockPath, "new-token")).toBe(true);
+    // Re-created with our pid + token — proves it was stolen, not just observed,
+    // and that the displaced owner's token no longer authorizes a release.
+    const body = fs.readFileSync(lockPath, "utf8");
+    expect(body).toContain(String(process.pid));
+    expect(body).toContain("new-token");
+    expect(body).not.toContain("old-token");
   });
 
   test("a custom staleMs governs the fresh/stale boundary", () => {
-    fs.writeFileSync(lockPath, "1 0\n");
+    fs.writeFileSync(lockPath, "1 0 held\n");
     const fiveSecAgo = new Date(Date.now() - 5_000);
     fs.utimesSync(lockPath, fiveSecAgo, fiveSecAgo);
 
     // 10s window: 5s-old lock is still fresh → not acquired.
-    expect(acquireSpawnLock(lockPath, 10_000)).toBe(false);
+    expect(acquireSpawnLock(lockPath, "tok", 10_000)).toBe(false);
     // 1s window: 5s-old lock is stale → stolen.
-    expect(acquireSpawnLock(lockPath, 1_000)).toBe(true);
+    expect(acquireSpawnLock(lockPath, "tok", 1_000)).toBe(true);
   });
 
-  test("release unlinks the lock", () => {
-    acquireSpawnLock(lockPath);
+  test("release unlinks the lock when the token matches", () => {
+    acquireSpawnLock(lockPath, "tok-r");
     expect(fs.existsSync(lockPath)).toBe(true);
-    releaseSpawnLock(lockPath);
+    releaseSpawnLock(lockPath, "tok-r");
     expect(fs.existsSync(lockPath)).toBe(false);
   });
 
   test("release is a no-op (no throw) when the lock is already gone", () => {
-    expect(() => releaseSpawnLock(lockPath)).not.toThrow();
+    expect(() => releaseSpawnLock(lockPath, "tok")).not.toThrow();
   });
 
   test("release then re-acquire works (full single-flight cycle)", () => {
-    expect(acquireSpawnLock(lockPath)).toBe(true);
-    expect(acquireSpawnLock(lockPath)).toBe(false); // held
-    releaseSpawnLock(lockPath);
-    expect(acquireSpawnLock(lockPath)).toBe(true); // freed → re-acquirable
+    expect(acquireSpawnLock(lockPath, "tok-1")).toBe(true);
+    expect(acquireSpawnLock(lockPath, "tok-2")).toBe(false); // held
+    releaseSpawnLock(lockPath, "tok-1");
+    expect(acquireSpawnLock(lockPath, "tok-3")).toBe(true); // freed → re-acquirable
+  });
+
+  // --- F4 ownership-guard tests ---------------------------------------------
+
+  test("release does NOT unlink when the token does not match (ownership guard)", () => {
+    acquireSpawnLock(lockPath, "owner-token");
+    // A caller without the right token must not be able to delete the lock.
+    releaseSpawnLock(lockPath, "wrong-token");
+    expect(fs.existsSync(lockPath)).toBe(true);
+    // The rightful owner still can.
+    releaseSpawnLock(lockPath, "owner-token");
+    expect(fs.existsSync(lockPath)).toBe(false);
+  });
+
+  test("release on a foreign/arbitrary path is a no-op (the file survives)", () => {
+    // A stray release must never unlink a file it doesn't own, even if the path
+    // exists and the token happens to appear nowhere in it.
+    const foreign = path.join(tmpRoot, "not-a-lock.txt");
+    fs.writeFileSync(foreign, "important unrelated contents\n");
+
+    releaseSpawnLock(foreign, "any-token");
+
+    expect(fs.existsSync(foreign)).toBe(true);
+    expect(fs.readFileSync(foreign, "utf8")).toBe(
+      "important unrelated contents\n",
+    );
+  });
+
+  test("a stale-steal then the displaced owner's release does not delete the NEW owner's lock", () => {
+    // Worker A holds the lock.
+    expect(acquireSpawnLock(lockPath, "token-A")).toBe(true);
+    // Time passes; the lock goes stale and worker B steals it (recreates with B's
+    // token). Backdate so the steal path runs.
+    const old = new Date(Date.now() - (SPAWN_LOCK_STALE_MS + 60_000));
+    fs.utimesSync(lockPath, old, old);
+    expect(acquireSpawnLock(lockPath, "token-B")).toBe(true);
+
+    // Worker A finally finishes and releases with ITS token — must NOT delete the
+    // lock B now owns.
+    releaseSpawnLock(lockPath, "token-A");
+    expect(fs.existsSync(lockPath)).toBe(true);
+    expect(fs.readFileSync(lockPath, "utf8")).toContain("token-B");
+
+    // B's own release still works.
+    releaseSpawnLock(lockPath, "token-B");
+    expect(fs.existsSync(lockPath)).toBe(false);
   });
 });

--- a/packages/shared/src/cli/commands/spawn-lock.ts
+++ b/packages/shared/src/cli/commands/spawn-lock.ts
@@ -42,19 +42,25 @@ export function getSpawnLockPath(rootDir: string): string {
  * Atomic create via `fs.writeFileSync(lockPath, ..., { flag: "wx" })` — `wx`
  * fails (EEXIST) if the file already exists, so the create itself is the
  * mutual-exclusion primitive (no check-then-create race between two foreground
- * processes). The lock body records pid + timestamp purely for debugging.
+ * processes). The lock body is `${pid} ${ts} ${token}`: pid + timestamp for
+ * debugging, and the caller-supplied `token` as the ownership credential that
+ * {@link releaseSpawnLock} checks before unlinking.
  *
  * On EEXIST we stat the existing lock:
  *  - fresh (mtime within {@link staleMs}) → a worker is in flight, return false.
- *  - stale (mtime older than staleMs) → presumed orphaned; unlink and recreate.
- *    The recreate also uses `wx`, so if a competing process steals it first we
- *    lose the race cleanly and return false.
+ *  - stale (mtime older than staleMs) → presumed orphaned; unlink and recreate
+ *    with OUR token (so the displaced owner's release no longer matches and
+ *    can't delete our freshly-stolen lock). The recreate also uses `wx`, so if a
+ *    competing process steals it first we lose the race cleanly and return false.
  *
  * Any unexpected error (permission, ENOENT on a missing parent dir we couldn't
  * create, …) is swallowed and reported as "not acquired": failing to take the
  * lock must never break the foreground — at worst we skip the background refresh.
  *
  * @param lockPath - path returned by {@link getSpawnLockPath}.
+ * @param token - a per-acquisition random credential written into the lock body.
+ *   The same token must be handed to {@link releaseSpawnLock} (and, across
+ *   processes, to the spawned worker that releases on the foreground's behalf).
  * @param staleMs - age beyond which a held lock is stolen. Defaults to
  *   {@link SPAWN_LOCK_STALE_MS}.
  * @returns true if this caller now owns the lock (and must release it), false if
@@ -62,9 +68,10 @@ export function getSpawnLockPath(rootDir: string): string {
  */
 export function acquireSpawnLock(
   lockPath: string,
+  token: string,
   staleMs: number = SPAWN_LOCK_STALE_MS,
 ): boolean {
-  const body = `${process.pid} ${Date.now()}\n`;
+  const body = `${process.pid} ${Date.now()} ${token}\n`;
 
   try {
     fs.mkdirSync(path.dirname(lockPath), { recursive: true });
@@ -111,18 +118,41 @@ export function acquireSpawnLock(
 }
 
 /**
- * Release the spawn lock. Unlink, ignoring ENOENT (already gone — e.g. it was
- * stolen as stale by another process, or never existed). Any other error is
- * swallowed: a failed release at worst leaves a stale lock that the next caller
- * will steal after {@link SPAWN_LOCK_STALE_MS}.
+ * Release the spawn lock — but ONLY if it still belongs to this caller, i.e. its
+ * body carries `token`. This is the ownership guard: a worker whose lock was
+ * stolen as stale (and recreated with the new owner's token) must NOT delete the
+ * new owner's lock, and a stray call with a foreign/arbitrary path must not
+ * unlink a file it doesn't own.
+ *
+ * Reads the body first; unlinks only on a token match. A missing lock (ENOENT)
+ * or any read/unlink error is a silent no-op: releasing is best-effort, and a
+ * leftover lock is reclaimed by the next caller's stale-steal after
+ * {@link SPAWN_LOCK_STALE_MS}.
  *
  * @param lockPath - path returned by {@link getSpawnLockPath}.
+ * @param token - the credential this caller wrote in {@link acquireSpawnLock}.
+ *   The unlink happens only if the on-disk body contains exactly this token.
  */
-export function releaseSpawnLock(lockPath: string): void {
+export function releaseSpawnLock(lockPath: string, token: string): void {
+  let body: string;
+  try {
+    body = fs.readFileSync(lockPath, "utf8");
+  } catch {
+    // ENOENT (already gone / stolen) or any read error — nothing to release.
+    return;
+  }
+
+  // Ownership check: only the writer of this token may unlink. Match on the
+  // whitespace-delimited token field so a token can't be a substring of the pid
+  // or timestamp by accident.
+  if (!body.split(/\s+/).includes(token)) {
+    return;
+  }
+
   try {
     fs.unlinkSync(lockPath);
   } catch {
-    // ENOENT or any other error — releasing is best-effort.
+    // Raced with a stale-steal or already gone — best-effort, swallow.
   }
 }
 


### PR DESCRIPTION
PR4 of the typegen review-fix stack. Independent of PR1/PR2/PR3 (branches off
`main`). Scope: make spawn-lock release ownership-checked (F4).

## The bug
The single-flight spawn lock was released by path alone — any process (a worker
whose lock had been stolen as stale, or a stray `releaseSpawnLock` call) could
unlink a lock it no longer owned, deleting a live worker's lock.

## Changes
- **`spawn-lock.ts`** — `acquireSpawnLock(lockPath, token)` writes
  `${pid} ${ts} ${token}`; a stale-steal recreates with the new owner's token.
  `releaseSpawnLock(lockPath, token)` reads the body and unlinks **only** when it
  carries that token (whitespace-delimited match); otherwise it's a no-op.
- **`generate-types.ts`** — the foreground mints a random token (`randomUUID`),
  passes it to `acquireSpawnLock` and to the worker via `--worker-token`
  (replacing `--worker-lock`); the worker re-derives the lock path from its
  `rootDir` positional and releases with the token. Worker argv keeps
  `...process.execArgv` + `--wait`.

## Acceptance criteria (asserted)
- A worker can release only a lock whose body carries its token; release on a
  foreign/arbitrary path is a no-op (the file survives).
- A stale-steal writes a new token, so the displaced worker's release does not
  delete the new owner's lock.
- Single-flight still holds for the normal (non-stale) path; the token is plumbed
  into the worker argv.

## Checks
`pnpm test` (shared CLI), `pnpm -r typecheck`, `pnpm check`,
`pnpm --filter shared build:package` all green.

## Note
Touches `generate-types.ts`, which PR3 (`--no-cache`) also edits. Branched
independently off `main`, so the two will textually conflict at merge — expected
and resolved at merge time.

This pull request and its description were written by Isaac.