### PR TITLE
chore: add schema for UC Metric Views on Analytics plugin

### DIFF
--- a/docs/static/schemas/metric-source.schema.json
+++ b/docs/static/schemas/metric-source.schema.json
@@ -8,7 +8,7 @@
       "description": "Reference to the JSON Schema for validation",
       "type": "string"
     },
-    "metrics": {
+    "metricViews": {
       "description": "Metric view declarations, keyed by metric key. Each entry names the UC metric view to query and the executor it runs as.",
       "type": "object",
       "propertyNames": {
@@ -42,5 +42,5 @@
     }
   },
   "additionalProperties": false,
-  "description": "Schema for AppKit metric.json — declares Unity Catalog Metric View sources for the analytics plugin's metric-view path. Each entry under 'metrics' binds a metric key to a UC metric view FQN and an executor ('app_service_principal' shared cache, or 'user' per-user cache). Object form (rather than bare string) at v1 enables future per-entry option growth without breaking changes."
+  "description": "Schema for AppKit metric.json — declares Unity Catalog Metric View sources for the analytics plugin's metric-view path. Each entry under 'metricViews' binds a metric key to a UC metric view FQN and an executor ('app_service_principal' shared cache, or 'user' per-user cache). Object form (rather than bare string) at v1 enables future per-entry option growth without breaking changes."
 }

--- a/docs/static/schemas/metric-source.schema.json
+++ b/docs/static/schemas/metric-source.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://databricks.github.io/appkit/schemas/metric-source.schema.json",
+  "title": "AppKit Metric Source Configuration",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "description": "Reference to the JSON Schema for validation",
+      "type": "string"
+    },
+    "sp": {
+      "description": "Metric views queried as the service principal. Cache scope is shared across all users.",
+      "type": "object",
+      "propertyNames": {
+        "type": "string",
+        "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
+        "description": "Metric key. Must be a valid identifier (letters, digits, underscores; cannot start with a digit). Becomes the route key in POST /api/analytics/metric/:key, the hook argument in useMetricView('<key>', ...), and the MetricRegistry augmentation key."
+      },
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "source": {
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_][a-zA-Z0-9_-]*\\.[a-zA-Z0-9_][a-zA-Z0-9_-]*\\.[a-zA-Z0-9_][a-zA-Z0-9_-]*$",
+            "description": "Three-part Unity Catalog FQN of the metric view: <catalog>.<schema>.<metric_view>",
+            "examples": [
+              "appkit_demo.public.revenue_metrics",
+              "main.analytics.customer_metrics"
+            ]
+          }
+        },
+        "required": ["source"],
+        "additionalProperties": false,
+        "description": "A single metric view source declaration. v1 only accepts the 'source' field; future per-entry options (cacheTtl, defaultFilter, allowlists) ship as additive properties."
+      }
+    },
+    "obo": {
+      "description": "Metric views queried as the requesting user (on-behalf-of). Cache scope is per-user.",
+      "type": "object",
+      "propertyNames": {
+        "type": "string",
+        "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
+        "description": "Metric key. Must be a valid identifier (letters, digits, underscores; cannot start with a digit). Becomes the route key in POST /api/analytics/metric/:key, the hook argument in useMetricView('<key>', ...), and the MetricRegistry augmentation key."
+      },
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "source": {
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_][a-zA-Z0-9_-]*\\.[a-zA-Z0-9_][a-zA-Z0-9_-]*\\.[a-zA-Z0-9_][a-zA-Z0-9_-]*$",
+            "description": "Three-part Unity Catalog FQN of the metric view: <catalog>.<schema>.<metric_view>",
+            "examples": [
+              "appkit_demo.public.revenue_metrics",
+              "main.analytics.customer_metrics"
+            ]
+          }
+        },
+        "required": ["source"],
+        "additionalProperties": false,
+        "description": "A single metric view source declaration. v1 only accepts the 'source' field; future per-entry options (cacheTtl, defaultFilter, allowlists) ship as additive properties."
+      }
+    }
+  },
+  "additionalProperties": false,
+  "description": "Schema for AppKit metric.json — declares Unity Catalog Metric View sources for the analytics plugin's metric-view path. Each entry under sp/obo binds a metric key to a UC metric view FQN. Object form (rather than bare string) at v1 enables future per-entry option growth without breaking changes."
+}

--- a/docs/static/schemas/metric-source.schema.json
+++ b/docs/static/schemas/metric-source.schema.json
@@ -8,8 +8,8 @@
       "description": "Reference to the JSON Schema for validation",
       "type": "string"
     },
-    "sp": {
-      "description": "Metric views queried as the service principal. Cache scope is shared across all users.",
+    "metrics": {
+      "description": "Metric view declarations, keyed by metric key. Each entry names the UC metric view to query and the executor it runs as.",
       "type": "object",
       "propertyNames": {
         "type": "string",
@@ -27,40 +27,20 @@
               "appkit_demo.public.revenue_metrics",
               "main.analytics.customer_metrics"
             ]
-          }
-        },
-        "required": ["source"],
-        "additionalProperties": false,
-        "description": "A single metric view source declaration. v1 only accepts the 'source' field; future per-entry options (cacheTtl, defaultFilter, allowlists) ship as additive properties."
-      }
-    },
-    "obo": {
-      "description": "Metric views queried as the requesting user (on-behalf-of). Cache scope is per-user.",
-      "type": "object",
-      "propertyNames": {
-        "type": "string",
-        "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
-        "description": "Metric key. Must be a valid identifier (letters, digits, underscores; cannot start with a digit). Becomes the route key in POST /api/analytics/metric/:key, the hook argument in useMetricView('<key>', ...), and the MetricRegistry augmentation key."
-      },
-      "additionalProperties": {
-        "type": "object",
-        "properties": {
-          "source": {
+          },
+          "executor": {
+            "default": "service_principal",
             "type": "string",
-            "pattern": "^[a-zA-Z0-9_][a-zA-Z0-9_-]*\\.[a-zA-Z0-9_][a-zA-Z0-9_-]*\\.[a-zA-Z0-9_][a-zA-Z0-9_-]*$",
-            "description": "Three-part Unity Catalog FQN of the metric view: <catalog>.<schema>.<metric_view>",
-            "examples": [
-              "appkit_demo.public.revenue_metrics",
-              "main.analytics.customer_metrics"
-            ]
+            "enum": ["service_principal", "user"],
+            "description": "Who the metric view is queried as. 'service_principal' (default) runs as the app service principal with a cache shared across all users; 'user' runs on-behalf-of the requesting user with a per-user cache."
           }
         },
         "required": ["source"],
         "additionalProperties": false,
-        "description": "A single metric view source declaration. v1 only accepts the 'source' field; future per-entry options (cacheTtl, defaultFilter, allowlists) ship as additive properties."
+        "description": "A single metric view source declaration: the UC FQN to query and the executor to query it as. Future per-entry options (cacheTtl, defaultFilter, allowlists) ship as additive properties."
       }
     }
   },
   "additionalProperties": false,
-  "description": "Schema for AppKit metric.json — declares Unity Catalog Metric View sources for the analytics plugin's metric-view path. Each entry under sp/obo binds a metric key to a UC metric view FQN. Object form (rather than bare string) at v1 enables future per-entry option growth without breaking changes."
+  "description": "Schema for AppKit metric.json — declares Unity Catalog Metric View sources for the analytics plugin's metric-view path. Each entry under 'metrics' binds a metric key to a UC metric view FQN and an executor ('service_principal' shared cache, or 'user' per-user cache). Object form (rather than bare string) at v1 enables future per-entry option growth without breaking changes."
 }

--- a/docs/static/schemas/metric-source.schema.json
+++ b/docs/static/schemas/metric-source.schema.json
@@ -29,10 +29,10 @@
             ]
           },
           "executor": {
-            "default": "service_principal",
+            "default": "app_service_principal",
             "type": "string",
-            "enum": ["service_principal", "user"],
-            "description": "Who the metric view is queried as. 'service_principal' (default) runs as the app service principal with a cache shared across all users; 'user' runs on-behalf-of the requesting user with a per-user cache."
+            "enum": ["app_service_principal", "user"],
+            "description": "Who the metric view is queried as. 'app_service_principal' (default) runs as the app service principal with a cache shared across all users; 'user' runs on-behalf-of the requesting user with a per-user cache."
           }
         },
         "required": ["source"],
@@ -42,5 +42,5 @@
     }
   },
   "additionalProperties": false,
-  "description": "Schema for AppKit metric.json — declares Unity Catalog Metric View sources for the analytics plugin's metric-view path. Each entry under 'metrics' binds a metric key to a UC metric view FQN and an executor ('service_principal' shared cache, or 'user' per-user cache). Object form (rather than bare string) at v1 enables future per-entry option growth without breaking changes."
+  "description": "Schema for AppKit metric.json — declares Unity Catalog Metric View sources for the analytics plugin's metric-view path. Each entry under 'metrics' binds a metric key to a UC metric view FQN and an executor ('app_service_principal' shared cache, or 'user' per-user cache). Object form (rather than bare string) at v1 enables future per-entry option growth without breaking changes."
 }

--- a/packages/shared/src/schemas/metric-source.test.ts
+++ b/packages/shared/src/schemas/metric-source.test.ts
@@ -9,7 +9,6 @@ describe("metricSourceSchema", () => {
       sp: {
         revenue: { source: "appkit_demo.public.revenue_metrics" },
       },
-      obo: {},
     };
     expect(metricSourceSchema.safeParse(config).success).toBe(true);
   });

--- a/packages/shared/src/schemas/metric-source.test.ts
+++ b/packages/shared/src/schemas/metric-source.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "vitest";
+import { metricSourceSchema } from "./metric-source";
+
+describe("metricSourceSchema", () => {
+  test("accepts a valid SP-only configuration", () => {
+    const config = {
+      $schema:
+        "https://databricks.github.io/appkit/schemas/metric-source.schema.json",
+      sp: {
+        revenue: { source: "appkit_demo.public.revenue_metrics" },
+      },
+      obo: {},
+    };
+    expect(metricSourceSchema.safeParse(config).success).toBe(true);
+  });
+
+  test("accepts mixed sp + obo lanes", () => {
+    const config = {
+      sp: { revenue: { source: "demo.public.revenue" } },
+      obo: { customer: { source: "demo.public.customer_metrics" } },
+    };
+    expect(metricSourceSchema.safeParse(config).success).toBe(true);
+  });
+
+  test("accepts an empty configuration", () => {
+    expect(metricSourceSchema.safeParse({}).success).toBe(true);
+    expect(metricSourceSchema.safeParse({ sp: {}, obo: {} }).success).toBe(
+      true,
+    );
+  });
+
+  test("accepts metric keys with underscores", () => {
+    const config = {
+      sp: { customer_metrics: { source: "demo.public.customer_metrics" } },
+    };
+    expect(metricSourceSchema.safeParse(config).success).toBe(true);
+  });
+
+  test("rejects a bare-string entry (must be an object)", () => {
+    const config = {
+      sp: { revenue: "demo.public.revenue" },
+    };
+    expect(metricSourceSchema.safeParse(config).success).toBe(false);
+  });
+
+  test("rejects an entry without source", () => {
+    const config = {
+      sp: { revenue: {} },
+    };
+    expect(metricSourceSchema.safeParse(config).success).toBe(false);
+  });
+
+  test("rejects unknown fields on entries", () => {
+    const config = {
+      sp: {
+        revenue: {
+          source: "a.b.c",
+          ttl: 5, // future option, not in v1
+        },
+      },
+    };
+    expect(metricSourceSchema.safeParse(config).success).toBe(false);
+  });
+
+  test("rejects unknown top-level keys", () => {
+    expect(metricSourceSchema.safeParse({ foo: 1 }).success).toBe(false);
+    expect(
+      metricSourceSchema.safeParse({ sp: {}, obo: {}, unknown: {} }).success,
+    ).toBe(false);
+  });
+
+  test("rejects metric keys that start with a digit", () => {
+    const config = {
+      sp: { "1bad": { source: "a.b.c" } },
+    };
+    expect(metricSourceSchema.safeParse(config).success).toBe(false);
+  });
+
+  test("rejects metric keys containing a hyphen", () => {
+    const config = {
+      sp: { "bad-key": { source: "a.b.c" } },
+    };
+    expect(metricSourceSchema.safeParse(config).success).toBe(false);
+  });
+
+  test("rejects a non-three-part FQN", () => {
+    const cases = [
+      "revenue", // single token
+      "demo.revenue", // two parts
+      "four.parts.really.bad",
+      ".starts.with.dot",
+      "ends.with.dot.",
+    ];
+    for (const source of cases) {
+      const config = { sp: { revenue: { source } } };
+      expect(metricSourceSchema.safeParse(config).success).toBe(false);
+    }
+  });
+});

--- a/packages/shared/src/schemas/metric-source.test.ts
+++ b/packages/shared/src/schemas/metric-source.test.ts
@@ -2,56 +2,82 @@ import { describe, expect, test } from "vitest";
 import { metricSourceSchema } from "./metric-source";
 
 describe("metricSourceSchema", () => {
-  test("accepts a valid SP-only configuration", () => {
+  test("accepts a minimal configuration and defaults executor to service_principal", () => {
     const config = {
       $schema:
         "https://databricks.github.io/appkit/schemas/metric-source.schema.json",
-      sp: {
+      metrics: {
         revenue: { source: "appkit_demo.public.revenue_metrics" },
+      },
+    };
+    const result = metricSourceSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    expect(result.data?.metrics?.revenue.executor).toBe("service_principal");
+  });
+
+  test("accepts explicit executor values", () => {
+    const config = {
+      metrics: {
+        revenue: {
+          source: "demo.public.revenue",
+          executor: "service_principal",
+        },
+        my_orders: { source: "main.sales.orders_by_user", executor: "user" },
+      },
+    };
+    const result = metricSourceSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    expect(result.data?.metrics?.my_orders.executor).toBe("user");
+  });
+
+  test("accepts an empty configuration", () => {
+    expect(metricSourceSchema.safeParse({}).success).toBe(true);
+    expect(metricSourceSchema.safeParse({ metrics: {} }).success).toBe(true);
+  });
+
+  test("accepts metric keys with underscores", () => {
+    const config = {
+      metrics: {
+        customer_metrics: { source: "demo.public.customer_metrics" },
       },
     };
     expect(metricSourceSchema.safeParse(config).success).toBe(true);
   });
 
-  test("accepts mixed sp + obo lanes", () => {
+  test("rejects the legacy sp/obo lane shape", () => {
     const config = {
       sp: { revenue: { source: "demo.public.revenue" } },
-      obo: { customer: { source: "demo.public.customer_metrics" } },
+      obo: { my_orders: { source: "main.sales.orders_by_user" } },
     };
-    expect(metricSourceSchema.safeParse(config).success).toBe(true);
+    expect(metricSourceSchema.safeParse(config).success).toBe(false);
   });
 
-  test("accepts an empty configuration", () => {
-    expect(metricSourceSchema.safeParse({}).success).toBe(true);
-    expect(metricSourceSchema.safeParse({ sp: {}, obo: {} }).success).toBe(
-      true,
-    );
-  });
-
-  test("accepts metric keys with underscores", () => {
-    const config = {
-      sp: { customer_metrics: { source: "demo.public.customer_metrics" } },
-    };
-    expect(metricSourceSchema.safeParse(config).success).toBe(true);
+  test("rejects invalid executor values", () => {
+    for (const executor of ["sp", "obo", "app_service_principal", "USER"]) {
+      const config = {
+        metrics: { revenue: { source: "a.b.c", executor } },
+      };
+      expect(metricSourceSchema.safeParse(config).success).toBe(false);
+    }
   });
 
   test("rejects a bare-string entry (must be an object)", () => {
     const config = {
-      sp: { revenue: "demo.public.revenue" },
+      metrics: { revenue: "demo.public.revenue" },
     };
     expect(metricSourceSchema.safeParse(config).success).toBe(false);
   });
 
   test("rejects an entry without source", () => {
     const config = {
-      sp: { revenue: {} },
+      metrics: { revenue: {} },
     };
     expect(metricSourceSchema.safeParse(config).success).toBe(false);
   });
 
   test("rejects unknown fields on entries", () => {
     const config = {
-      sp: {
+      metrics: {
         revenue: {
           source: "a.b.c",
           ttl: 5, // future option, not in v1
@@ -64,20 +90,20 @@ describe("metricSourceSchema", () => {
   test("rejects unknown top-level keys", () => {
     expect(metricSourceSchema.safeParse({ foo: 1 }).success).toBe(false);
     expect(
-      metricSourceSchema.safeParse({ sp: {}, obo: {}, unknown: {} }).success,
+      metricSourceSchema.safeParse({ metrics: {}, unknown: {} }).success,
     ).toBe(false);
   });
 
   test("rejects metric keys that start with a digit", () => {
     const config = {
-      sp: { "1bad": { source: "a.b.c" } },
+      metrics: { "1bad": { source: "a.b.c" } },
     };
     expect(metricSourceSchema.safeParse(config).success).toBe(false);
   });
 
   test("rejects metric keys containing a hyphen", () => {
     const config = {
-      sp: { "bad-key": { source: "a.b.c" } },
+      metrics: { "bad-key": { source: "a.b.c" } },
     };
     expect(metricSourceSchema.safeParse(config).success).toBe(false);
   });
@@ -91,7 +117,7 @@ describe("metricSourceSchema", () => {
       "ends.with.dot.",
     ];
     for (const source of cases) {
-      const config = { sp: { revenue: { source } } };
+      const config = { metrics: { revenue: { source } } };
       expect(metricSourceSchema.safeParse(config).success).toBe(false);
     }
   });

--- a/packages/shared/src/schemas/metric-source.test.ts
+++ b/packages/shared/src/schemas/metric-source.test.ts
@@ -6,20 +6,20 @@ describe("metricSourceSchema", () => {
     const config = {
       $schema:
         "https://databricks.github.io/appkit/schemas/metric-source.schema.json",
-      metrics: {
+      metricViews: {
         revenue: { source: "appkit_demo.public.revenue_metrics" },
       },
     };
     const result = metricSourceSchema.safeParse(config);
     expect(result.success).toBe(true);
-    expect(result.data?.metrics?.revenue.executor).toBe(
+    expect(result.data?.metricViews?.revenue.executor).toBe(
       "app_service_principal",
     );
   });
 
   test("accepts explicit executor values", () => {
     const config = {
-      metrics: {
+      metricViews: {
         revenue: {
           source: "demo.public.revenue",
           executor: "app_service_principal",
@@ -29,17 +29,19 @@ describe("metricSourceSchema", () => {
     };
     const result = metricSourceSchema.safeParse(config);
     expect(result.success).toBe(true);
-    expect(result.data?.metrics?.my_orders.executor).toBe("user");
+    expect(result.data?.metricViews?.my_orders.executor).toBe("user");
   });
 
   test("accepts an empty configuration", () => {
     expect(metricSourceSchema.safeParse({}).success).toBe(true);
-    expect(metricSourceSchema.safeParse({ metrics: {} }).success).toBe(true);
+    expect(metricSourceSchema.safeParse({ metricViews: {} }).success).toBe(
+      true,
+    );
   });
 
   test("accepts metric keys with underscores", () => {
     const config = {
-      metrics: {
+      metricViews: {
         customer_metrics: { source: "demo.public.customer_metrics" },
       },
     };
@@ -57,7 +59,7 @@ describe("metricSourceSchema", () => {
   test("rejects invalid executor values", () => {
     for (const executor of ["sp", "obo", "service_principal", "USER"]) {
       const config = {
-        metrics: { revenue: { source: "a.b.c", executor } },
+        metricViews: { revenue: { source: "a.b.c", executor } },
       };
       expect(metricSourceSchema.safeParse(config).success).toBe(false);
     }
@@ -65,21 +67,21 @@ describe("metricSourceSchema", () => {
 
   test("rejects a bare-string entry (must be an object)", () => {
     const config = {
-      metrics: { revenue: "demo.public.revenue" },
+      metricViews: { revenue: "demo.public.revenue" },
     };
     expect(metricSourceSchema.safeParse(config).success).toBe(false);
   });
 
   test("rejects an entry without source", () => {
     const config = {
-      metrics: { revenue: {} },
+      metricViews: { revenue: {} },
     };
     expect(metricSourceSchema.safeParse(config).success).toBe(false);
   });
 
   test("rejects unknown fields on entries", () => {
     const config = {
-      metrics: {
+      metricViews: {
         revenue: {
           source: "a.b.c",
           ttl: 5, // future option, not in v1
@@ -92,20 +94,20 @@ describe("metricSourceSchema", () => {
   test("rejects unknown top-level keys", () => {
     expect(metricSourceSchema.safeParse({ foo: 1 }).success).toBe(false);
     expect(
-      metricSourceSchema.safeParse({ metrics: {}, unknown: {} }).success,
+      metricSourceSchema.safeParse({ metricViews: {}, unknown: {} }).success,
     ).toBe(false);
   });
 
   test("rejects metric keys that start with a digit", () => {
     const config = {
-      metrics: { "1bad": { source: "a.b.c" } },
+      metricViews: { "1bad": { source: "a.b.c" } },
     };
     expect(metricSourceSchema.safeParse(config).success).toBe(false);
   });
 
   test("rejects metric keys containing a hyphen", () => {
     const config = {
-      metrics: { "bad-key": { source: "a.b.c" } },
+      metricViews: { "bad-key": { source: "a.b.c" } },
     };
     expect(metricSourceSchema.safeParse(config).success).toBe(false);
   });
@@ -119,7 +121,7 @@ describe("metricSourceSchema", () => {
       "ends.with.dot.",
     ];
     for (const source of cases) {
-      const config = { metrics: { revenue: { source } } };
+      const config = { metricViews: { revenue: { source } } };
       expect(metricSourceSchema.safeParse(config).success).toBe(false);
     }
   });

--- a/packages/shared/src/schemas/metric-source.test.ts
+++ b/packages/shared/src/schemas/metric-source.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 import { metricSourceSchema } from "./metric-source";
 
 describe("metricSourceSchema", () => {
-  test("accepts a minimal configuration and defaults executor to service_principal", () => {
+  test("accepts a minimal configuration and defaults executor to app_service_principal", () => {
     const config = {
       $schema:
         "https://databricks.github.io/appkit/schemas/metric-source.schema.json",
@@ -12,7 +12,9 @@ describe("metricSourceSchema", () => {
     };
     const result = metricSourceSchema.safeParse(config);
     expect(result.success).toBe(true);
-    expect(result.data?.metrics?.revenue.executor).toBe("service_principal");
+    expect(result.data?.metrics?.revenue.executor).toBe(
+      "app_service_principal",
+    );
   });
 
   test("accepts explicit executor values", () => {
@@ -20,7 +22,7 @@ describe("metricSourceSchema", () => {
       metrics: {
         revenue: {
           source: "demo.public.revenue",
-          executor: "service_principal",
+          executor: "app_service_principal",
         },
         my_orders: { source: "main.sales.orders_by_user", executor: "user" },
       },
@@ -53,7 +55,7 @@ describe("metricSourceSchema", () => {
   });
 
   test("rejects invalid executor values", () => {
-    for (const executor of ["sp", "obo", "app_service_principal", "USER"]) {
+    for (const executor of ["sp", "obo", "service_principal", "USER"]) {
       const config = {
         metrics: { revenue: { source: "a.b.c", executor } },
       };

--- a/packages/shared/src/schemas/metric-source.ts
+++ b/packages/shared/src/schemas/metric-source.ts
@@ -7,7 +7,7 @@
  * `metric.json` declares UC Metric Views under a single `metrics` map.
  * Each entry binds a metric key to a UC metric view FQN plus the executor
  * the query runs as:
- * - `executor: "service_principal"` (default) — queried as the app service
+ * - `executor: "app_service_principal"` (default) — queried as the app service
  *   principal (cache scope shared across all users).
  * - `executor: "user"` — queried as the requesting user (on-behalf-of;
  *   cache scope per-user).
@@ -27,9 +27,9 @@ export const metricKeySchema = z
   );
 
 export const metricExecutorSchema = z
-  .enum(["service_principal", "user"])
+  .enum(["app_service_principal", "user"])
   .describe(
-    "Who the metric view is queried as. 'service_principal' (default) runs as the app service principal with a cache shared across all users; 'user' runs on-behalf-of the requesting user with a per-user cache.",
+    "Who the metric view is queried as. 'app_service_principal' (default) runs as the app service principal with a cache shared across all users; 'user' runs on-behalf-of the requesting user with a per-user cache.",
   );
 
 /**
@@ -53,7 +53,7 @@ export const metricEntrySchema = z
           "main.analytics.customer_metrics",
         ],
       }),
-    executor: metricExecutorSchema.default("service_principal"),
+    executor: metricExecutorSchema.default("app_service_principal"),
   })
   .strict()
   .describe(
@@ -75,7 +75,7 @@ export const metricSourceSchema = z
   })
   .strict()
   .describe(
-    "Schema for AppKit metric.json — declares Unity Catalog Metric View sources for the analytics plugin's metric-view path. Each entry under 'metrics' binds a metric key to a UC metric view FQN and an executor ('service_principal' shared cache, or 'user' per-user cache). Object form (rather than bare string) at v1 enables future per-entry option growth without breaking changes.",
+    "Schema for AppKit metric.json — declares Unity Catalog Metric View sources for the analytics plugin's metric-view path. Each entry under 'metrics' binds a metric key to a UC metric view FQN and an executor ('app_service_principal' shared cache, or 'user' per-user cache). Object form (rather than bare string) at v1 enables future per-entry option growth without breaking changes.",
   );
 
 export type MetricKey = z.infer<typeof metricKeySchema>;

--- a/packages/shared/src/schemas/metric-source.ts
+++ b/packages/shared/src/schemas/metric-source.ts
@@ -1,0 +1,87 @@
+/**
+ * Zod-authoring module for the AppKit metric-source schema.
+ *
+ * Single source of truth for `metric.json` — the opt-in config that activates
+ * the analytics plugin's metric-view path. The JSON Schema artifact published
+ * at the docs URL is emitted from this schema via
+ * `tools/generate-json-schema.ts` and lives only in `docs/static/schemas/`
+ * (no package-internal copies).
+ *
+ * `metric.json` declares Unity Catalog Metric View sources. Each entry under
+ * `sp`/`obo` binds a metric key to a UC metric view FQN:
+ * - `sp` entries are queried as the service principal (cache scope shared
+ *   across all users).
+ * - `obo` entries are queried as the requesting user (on-behalf-of; cache
+ *   scope per-user).
+ *
+ * Entries are objects (rather than bare strings) at v1 so future per-entry
+ * options (cacheTtl, defaultFilter, allowlists) can ship as additive
+ * properties without a breaking change.
+ */
+
+import { z } from "zod";
+
+// ── Metric key ───────────────────────────────────────────────────────────
+
+export const metricKeySchema = z
+  .string()
+  .regex(/^[a-zA-Z_][a-zA-Z0-9_]*$/)
+  .describe(
+    "Metric key. Must be a valid identifier (letters, digits, underscores; cannot start with a digit). Becomes the route key in POST /api/analytics/metric/:key, the hook argument in useMetricView('<key>', ...), and the MetricRegistry augmentation key.",
+  );
+
+// ── Metric entry (single source declaration) ─────────────────────────────
+
+export const metricEntrySchema = z
+  .object({
+    source: z
+      .string()
+      .regex(
+        /^[a-zA-Z0-9_][a-zA-Z0-9_-]*\.[a-zA-Z0-9_][a-zA-Z0-9_-]*\.[a-zA-Z0-9_][a-zA-Z0-9_-]*$/,
+      )
+      .describe(
+        "Three-part Unity Catalog FQN of the metric view: <catalog>.<schema>.<metric_view>",
+      )
+      .meta({
+        examples: [
+          "appkit_demo.public.revenue_metrics",
+          "main.analytics.customer_metrics",
+        ],
+      }),
+  })
+  .strict()
+  .describe(
+    "A single metric view source declaration. v1 only accepts the 'source' field; future per-entry options (cacheTtl, defaultFilter, allowlists) ship as additive properties.",
+  );
+
+// ── Metric source config (root) ──────────────────────────────────────────
+
+export const metricSourceSchema = z
+  .object({
+    $schema: z
+      .string()
+      .optional()
+      .describe("Reference to the JSON Schema for validation"),
+    sp: z
+      .record(metricKeySchema, metricEntrySchema)
+      .optional()
+      .describe(
+        "Metric views queried as the service principal. Cache scope is shared across all users.",
+      ),
+    obo: z
+      .record(metricKeySchema, metricEntrySchema)
+      .optional()
+      .describe(
+        "Metric views queried as the requesting user (on-behalf-of). Cache scope is per-user.",
+      ),
+  })
+  .strict()
+  .describe(
+    "Schema for AppKit metric.json — declares Unity Catalog Metric View sources for the analytics plugin's metric-view path. Each entry under sp/obo binds a metric key to a UC metric view FQN. Object form (rather than bare string) at v1 enables future per-entry option growth without breaking changes.",
+  );
+
+// ── Inferred types ───────────────────────────────────────────────────────
+
+export type MetricKey = z.infer<typeof metricKeySchema>;
+export type MetricEntry = z.infer<typeof metricEntrySchema>;
+export type MetricSource = z.infer<typeof metricSourceSchema>;

--- a/packages/shared/src/schemas/metric-source.ts
+++ b/packages/shared/src/schemas/metric-source.ts
@@ -4,12 +4,17 @@
  * Single source of truth for `metric.json`
  * the config that activates the Analytics' metric-view path.
  *
- * `metric.json` declares UC Metric Views.
- * Each entry under `sp`/`obo` binds a metric key to a UC metric view FQN:
- * - `sp` entries are queried as the service principal (cache scope shared
- *   across all users).
- * - `obo` entries are queried as the requesting user (on-behalf-of; cache
- *   scope per-user).
+ * `metric.json` declares UC Metric Views under a single `metrics` map.
+ * Each entry binds a metric key to a UC metric view FQN plus the executor
+ * the query runs as:
+ * - `executor: "service_principal"` (default) — queried as the app service
+ *   principal (cache scope shared across all users).
+ * - `executor: "user"` — queried as the requesting user (on-behalf-of;
+ *   cache scope per-user).
+ *
+ * A single map (rather than per-executor sections) makes metric keys unique
+ * by construction — the same key cannot be declared twice with different
+ * executors.
  */
 
 import { z } from "zod";
@@ -21,10 +26,16 @@ export const metricKeySchema = z
     "Metric key. Must be a valid identifier (letters, digits, underscores; cannot start with a digit). Becomes the route key in POST /api/analytics/metric/:key, the hook argument in useMetricView('<key>', ...), and the MetricRegistry augmentation key.",
   );
 
+export const metricExecutorSchema = z
+  .enum(["service_principal", "user"])
+  .describe(
+    "Who the metric view is queried as. 'service_principal' (default) runs as the app service principal with a cache shared across all users; 'user' runs on-behalf-of the requesting user with a per-user cache.",
+  );
+
 /**
  * @note Entries are objects (rather than bare strings) at v1 so future per-entry
  * options (cacheTtl, defaultFilter, allowlists) can ship as additive
- * properties without a breaking change.
+ * properties without a breaking change. `executor` is the first such option.
  */
 export const metricEntrySchema = z
   .object({
@@ -42,10 +53,11 @@ export const metricEntrySchema = z
           "main.analytics.customer_metrics",
         ],
       }),
+    executor: metricExecutorSchema.default("service_principal"),
   })
   .strict()
   .describe(
-    "A single metric view source declaration. v1 only accepts the 'source' field; future per-entry options (cacheTtl, defaultFilter, allowlists) ship as additive properties.",
+    "A single metric view source declaration: the UC FQN to query and the executor to query it as. Future per-entry options (cacheTtl, defaultFilter, allowlists) ship as additive properties.",
   );
 
 export const metricSourceSchema = z
@@ -54,24 +66,19 @@ export const metricSourceSchema = z
       .string()
       .optional()
       .describe("Reference to the JSON Schema for validation"),
-    sp: z
+    metrics: z
       .record(metricKeySchema, metricEntrySchema)
       .optional()
       .describe(
-        "Metric views queried as the service principal. Cache scope is shared across all users.",
-      ),
-    obo: z
-      .record(metricKeySchema, metricEntrySchema)
-      .optional()
-      .describe(
-        "Metric views queried as the requesting user (on-behalf-of). Cache scope is per-user.",
+        "Metric view declarations, keyed by metric key. Each entry names the UC metric view to query and the executor it runs as.",
       ),
   })
   .strict()
   .describe(
-    "Schema for AppKit metric.json — declares Unity Catalog Metric View sources for the analytics plugin's metric-view path. Each entry under sp/obo binds a metric key to a UC metric view FQN. Object form (rather than bare string) at v1 enables future per-entry option growth without breaking changes.",
+    "Schema for AppKit metric.json — declares Unity Catalog Metric View sources for the analytics plugin's metric-view path. Each entry under 'metrics' binds a metric key to a UC metric view FQN and an executor ('service_principal' shared cache, or 'user' per-user cache). Object form (rather than bare string) at v1 enables future per-entry option growth without breaking changes.",
   );
 
 export type MetricKey = z.infer<typeof metricKeySchema>;
+export type MetricExecutor = z.infer<typeof metricExecutorSchema>;
 export type MetricEntry = z.infer<typeof metricEntrySchema>;
 export type MetricSource = z.infer<typeof metricSourceSchema>;

--- a/packages/shared/src/schemas/metric-source.ts
+++ b/packages/shared/src/schemas/metric-source.ts
@@ -4,7 +4,7 @@
  * Single source of truth for `metric.json`
  * the config that activates the Analytics' metric-view path.
  *
- * `metric.json` declares UC Metric Views under a single `metrics` map.
+ * `metric.json` declares UC Metric Views under a single `metricViews` map.
  * Each entry binds a metric key to a UC metric view FQN plus the executor
  * the query runs as:
  * - `executor: "app_service_principal"` (default) — queried as the app service
@@ -66,7 +66,7 @@ export const metricSourceSchema = z
       .string()
       .optional()
       .describe("Reference to the JSON Schema for validation"),
-    metrics: z
+    metricViews: z
       .record(metricKeySchema, metricEntrySchema)
       .optional()
       .describe(
@@ -75,7 +75,7 @@ export const metricSourceSchema = z
   })
   .strict()
   .describe(
-    "Schema for AppKit metric.json — declares Unity Catalog Metric View sources for the analytics plugin's metric-view path. Each entry under 'metrics' binds a metric key to a UC metric view FQN and an executor ('app_service_principal' shared cache, or 'user' per-user cache). Object form (rather than bare string) at v1 enables future per-entry option growth without breaking changes.",
+    "Schema for AppKit metric.json — declares Unity Catalog Metric View sources for the analytics plugin's metric-view path. Each entry under 'metricViews' binds a metric key to a UC metric view FQN and an executor ('app_service_principal' shared cache, or 'user' per-user cache). Object form (rather than bare string) at v1 enables future per-entry option growth without breaking changes.",
   );
 
 export type MetricKey = z.infer<typeof metricKeySchema>;

--- a/packages/shared/src/schemas/metric-source.ts
+++ b/packages/shared/src/schemas/metric-source.ts
@@ -1,27 +1,18 @@
 /**
- * Zod-authoring module for the AppKit metric-source schema.
+ * AppKit metric-source schema.
  *
- * Single source of truth for `metric.json` — the opt-in config that activates
- * the analytics plugin's metric-view path. The JSON Schema artifact published
- * at the docs URL is emitted from this schema via
- * `tools/generate-json-schema.ts` and lives only in `docs/static/schemas/`
- * (no package-internal copies).
+ * Single source of truth for `metric.json`
+ * the config that activates the Analytics' metric-view path.
  *
- * `metric.json` declares Unity Catalog Metric View sources. Each entry under
- * `sp`/`obo` binds a metric key to a UC metric view FQN:
+ * `metric.json` declares UC Metric Views.
+ * Each entry under `sp`/`obo` binds a metric key to a UC metric view FQN:
  * - `sp` entries are queried as the service principal (cache scope shared
  *   across all users).
  * - `obo` entries are queried as the requesting user (on-behalf-of; cache
  *   scope per-user).
- *
- * Entries are objects (rather than bare strings) at v1 so future per-entry
- * options (cacheTtl, defaultFilter, allowlists) can ship as additive
- * properties without a breaking change.
  */
 
 import { z } from "zod";
-
-// ── Metric key ───────────────────────────────────────────────────────────
 
 export const metricKeySchema = z
   .string()
@@ -30,8 +21,11 @@ export const metricKeySchema = z
     "Metric key. Must be a valid identifier (letters, digits, underscores; cannot start with a digit). Becomes the route key in POST /api/analytics/metric/:key, the hook argument in useMetricView('<key>', ...), and the MetricRegistry augmentation key.",
   );
 
-// ── Metric entry (single source declaration) ─────────────────────────────
-
+/**
+ * @note Entries are objects (rather than bare strings) at v1 so future per-entry
+ * options (cacheTtl, defaultFilter, allowlists) can ship as additive
+ * properties without a breaking change.
+ */
 export const metricEntrySchema = z
   .object({
     source: z
@@ -53,8 +47,6 @@ export const metricEntrySchema = z
   .describe(
     "A single metric view source declaration. v1 only accepts the 'source' field; future per-entry options (cacheTtl, defaultFilter, allowlists) ship as additive properties.",
   );
-
-// ── Metric source config (root) ──────────────────────────────────────────
 
 export const metricSourceSchema = z
   .object({
@@ -79,8 +71,6 @@ export const metricSourceSchema = z
   .describe(
     "Schema for AppKit metric.json — declares Unity Catalog Metric View sources for the analytics plugin's metric-view path. Each entry under sp/obo binds a metric key to a UC metric view FQN. Object form (rather than bare string) at v1 enables future per-entry option growth without breaking changes.",
   );
-
-// ── Inferred types ───────────────────────────────────────────────────────
 
 export type MetricKey = z.infer<typeof metricKeySchema>;
 export type MetricEntry = z.infer<typeof metricEntrySchema>;

--- a/tools/generate-json-schema.ts
+++ b/tools/generate-json-schema.ts
@@ -14,6 +14,7 @@ import {
   pluginManifestSchema,
   templatePluginsManifestSchema,
 } from "../packages/shared/src/schemas/manifest";
+import { metricSourceSchema } from "../packages/shared/src/schemas/metric-source";
 import { formatWithBiome } from "./format-with-biome";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -28,11 +29,17 @@ const TEMPLATE_OUT_PATH = path.join(
   DOCS_SCHEMAS_DIR,
   "template-plugins.schema.json",
 );
+const METRIC_SOURCE_OUT_PATH = path.join(
+  DOCS_SCHEMAS_DIR,
+  "metric-source.schema.json",
+);
 
 const PLUGIN_SCHEMA_ID =
   "https://databricks.github.io/appkit/schemas/plugin-manifest.schema.json";
 const TEMPLATE_SCHEMA_ID =
   "https://databricks.github.io/appkit/schemas/template-plugins.schema.json";
+const METRIC_SOURCE_SCHEMA_ID =
+  "https://databricks.github.io/appkit/schemas/metric-source.schema.json";
 
 function emit(
   schema: z.ZodType,
@@ -91,9 +98,15 @@ async function main(): Promise<void> {
     TEMPLATE_SCHEMA_ID,
     "AppKit Template Plugins Manifest",
   );
+  const metricSourceJson = emit(
+    metricSourceSchema,
+    METRIC_SOURCE_SCHEMA_ID,
+    "AppKit Metric Source Configuration",
+  );
 
   writeJson(PLUGIN_OUT_PATH, pluginJson);
   writeJson(TEMPLATE_OUT_PATH, templateJson);
+  writeJson(METRIC_SOURCE_OUT_PATH, metricSourceJson);
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## What

PR1 of the metric-views delivery stack: the **schema contract for `metric.json`** — the opt-in config that activates the analytics metric-view path. Ships in the `shared` package.

This is the typed contract **only** — no runtime, CLI, hook, UI, or demo. It lands inert: nothing executes until an app actually ships a `config/queries/metric.json`.

## Why now / why it's safe

This re-ships part of [#341](https://github.com/databricks/appkit/pull/341) (a ~15k-line mega-PR) as a small, reviewable increment. The feature is opt-in and dormant (every metric-view code path gates on `metric.json` existing), and these are all new files — so it lands on `main` without touching any existing behavior.

## What's in it — 4 files, +267

| File | Purpose |
|---|---|
| `packages/shared/src/schemas/metric-source.ts` | Zod source of truth — `metricSourceSchema` + inferred `MetricSource`/`MetricExecutor` types |
| `tools/generate-json-schema.ts` | extended (+13) to emit the JSON Schema artifact |
| `docs/static/schemas/metric-source.schema.json` | generated, published JSON Schema (powers editor `$schema` autocomplete + validation) |
| `packages/shared/src/schemas/metric-source.test.ts` | 13 `safeParse` validation cases |

### The `metric.json` contract

```json
{
  "$schema": "https://databricks.github.io/appkit/schemas/metric-source.schema.json",
  "metricViews": {
    "revenue":   { "source": "main.analytics.revenue" },
    "my_orders": { "source": "main.sales.orders_by_user", "executor": "user" }
  }
}
```

- Top-level `{ $schema?, metricViews? }`, closed (rejects unknown keys).
- `metricViews` is a single map of *metric key* → entry. One map (rather than per-executor sections) makes metric keys **unique by construction** — the route key space can't collide.
- **metric key**: identifier pattern `^[a-zA-Z_][a-zA-Z0-9_]*$` — becomes the route key (`POST /api/analytics/metric/:key`), the `useMetricView('<key>', …)` argument, and the `MetricRegistry` augmentation key.
- **source**: three-part Unity Catalog FQN `<catalog>.<schema>.<metric_view>`.
- **executor**: `"app_service_principal"` (default) runs as the app service principal with a shared cache; `"user"` runs on-behalf-of the requesting user with a per-user cache. Defaulting to `app_service_principal` matches plain `<key>.sql` queries executing as SP.
- Entries are objects (not bare strings) so future per-entry options (`cacheTtl`, `defaultFilter`, allowlists) are additive — `executor` is the first such option.

> **Shape revision (review feedback):** the original proposal used top-level `sp`/`obo` lane sections, mirroring the `<key>.sql` / `<key>.obo.sql` query-file convention. Per review discussion this was reshaped to the entity-first `metricViews` map with a per-entry `executor` — clearer naming, execution mode as an attribute rather than a taxonomy, and the cross-lane duplicate-key rule (previously unexpressible in the schema, enforced post-parse) becomes unrepresentable.

## Reconciliation note (for reviewers comparing against #341)

#341 authored this **JSON-Schema-first** (hand-written `.schema.json` → generated `.ts` via a `generate-schema-types.ts` tool). Since #341's base, `main` adopted a **Zod-first** convention in the manifest refactor (#261): Zod is the single source of truth and the JSON Schema is *generated from it* via `tools/generate-json-schema.ts`. This PR re-expresses the contract in main's current idiom. Consequences vs. the #341 reference:

- **No `*.generated.ts`** — the inferred `MetricSource` type replaces it.
- **No `ajv` / `ajv-formats`** — validation rides the Zod schema directly via `safeParse`, matching `validate-manifest.ts`.
- **No package-internal `.schema.json`** — the generated JSON lives only in `docs/static/schemas/`, exactly like the manifest schemas.

Note the *shape* also differs from #341 (see revision note above): downstream slices (runtime, typegen, CLI) port their config-reading layer against this revised contract.

## Testing

- `pnpm build && pnpm docs:build` ✅
- `pnpm check:fix && pnpm -r typecheck` ✅
- `pnpm test` ✅ — `metric-source.ts` at 100% coverage. The generator is deterministic (re-running produces no diff) and does not drift the existing manifest/template schemas. Tests include rejection of the legacy `sp`/`obo` shape and verification that the `executor` default materializes on parse.

## Stack context

Part of re-shipping #341 as a stacked chain (merge order PR0 → PR1 → PR3 → PR4 → PR2 → PR5 → PR6):

- **PR0** ✅ landed as #427 — trim `x-forwarded-user` in core OBO path
- **PR1** ← this PR — `metric.json` schema
- PR3 typegen · PR4 CLI · PR2 runtime · PR5 UI · PR6 demo + docs

Only hard dependency on this PR: **PR4 (`appkit metric sync` CLI) imports this schema** and will validate via the Standard Schema interface (no Ajv).

---

This pull request and its description were written by Isaac.
