### PR TITLE
fix(appkit-ui): escape heatmap tooltip values to prevent XSS

### DIFF
--- a/packages/appkit-ui/src/react/charts/__tests__/options.test.ts
+++ b/packages/appkit-ui/src/react/charts/__tests__/options.test.ts
@@ -12,6 +12,9 @@ import {
 interface EChartsOption {
   title?: { text?: string };
   legend?: unknown;
+  tooltip?: {
+    formatter?: (params: { data: [number, number, number] }) => string;
+  };
   xAxis: { type: string; data?: unknown[] };
   yAxis: { type: string; data?: unknown[] };
   series: Array<{
@@ -645,5 +648,29 @@ describe("buildHeatmapOption", () => {
     const opt = asOption(buildHeatmapOption(ctx));
 
     expect(opt.series[0].data).toEqual(ctx.heatmapData);
+  });
+
+  test("tooltip formatter renders labels and values", () => {
+    const ctx = createHeatmapContext();
+    const opt = asOption(buildHeatmapOption(ctx));
+
+    const output = opt.tooltip?.formatter?.({ data: [1, 2, 25] });
+    expect(output).toBe("10AM, Wed: 25");
+  });
+
+  test("tooltip formatter escapes HTML in category values (XSS)", () => {
+    const ctx = {
+      ...createHeatmapContext(),
+      xData: ["<img src=x onerror=alert(1)>", "10AM"],
+      yAxisData: ["<script>alert(2)</script>", "Tue"],
+    };
+    const opt = asOption(buildHeatmapOption(ctx));
+
+    const output = opt.tooltip?.formatter?.({ data: [0, 0, 10] });
+    expect(output).not.toContain("<");
+    expect(output).not.toContain(">");
+    expect(output).toBe(
+      "&lt;img src=x onerror=alert(1)&gt;, &lt;script&gt;alert(2)&lt;/script&gt;: 10",
+    );
   });
 });

--- a/packages/appkit-ui/src/react/charts/__tests__/utils.test.ts
+++ b/packages/appkit-ui/src/react/charts/__tests__/utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import {
   createTimeSeriesData,
+  escapeHtml,
   formatLabel,
   sortTimeSeriesAscending,
   toChartArray,
@@ -126,6 +127,39 @@ describe("formatLabel", () => {
 
   test("handles mixed camelCase and snake_case", () => {
     expect(formatLabel("total_spendAmount")).toBe("Total Spend Amount");
+  });
+});
+
+describe("escapeHtml", () => {
+  test("escapes all five HTML special characters", () => {
+    expect(escapeHtml("&")).toBe("&amp;");
+    expect(escapeHtml("<")).toBe("&lt;");
+    expect(escapeHtml(">")).toBe("&gt;");
+    expect(escapeHtml('"')).toBe("&quot;");
+    expect(escapeHtml("'")).toBe("&#39;");
+  });
+
+  test("escapes all special characters in a combined string", () => {
+    expect(escapeHtml(`<img src="x" onerror='alert(1)'>&`)).toBe(
+      "&lt;img src=&quot;x&quot; onerror=&#39;alert(1)&#39;&gt;&amp;",
+    );
+  });
+
+  test("escapes ampersand first so generated entities are not double-encoded", () => {
+    // "&" is replaced before "<" and ">", so the entities produced by
+    // escaping "<" and ">" keep their single "&" prefix.
+    expect(escapeHtml("<&>")).toBe("&lt;&amp;&gt;");
+  });
+
+  test("double-escapes pre-escaped input (expected for raw data)", () => {
+    // escapeHtml assumes raw, unescaped input; already-escaped entities
+    // are escaped again. This is intentional for untrusted data.
+    expect(escapeHtml("&amp;")).toBe("&amp;amp;");
+  });
+
+  test("leaves safe strings unchanged", () => {
+    expect(escapeHtml("hello world 123")).toBe("hello world 123");
+    expect(escapeHtml("")).toBe("");
   });
 });
 

--- a/packages/appkit-ui/src/react/charts/options.ts
+++ b/packages/appkit-ui/src/react/charts/options.ts
@@ -1,5 +1,10 @@
 import type { ChartType } from "./types";
-import { createTimeSeriesData, formatLabel, truncateLabel } from "./utils";
+import {
+  createTimeSeriesData,
+  escapeHtml,
+  formatLabel,
+  truncateLabel,
+} from "./utils";
 
 // ============================================================================
 // Option Builder Types
@@ -189,9 +194,11 @@ export function buildHeatmapOption(
       trigger: "item",
       formatter: (params: { data: [number, number, number] }) => {
         const [xIdx, yIdx, value] = params.data;
-        const xLabel = ctx.xData[xIdx] ?? xIdx;
-        const yLabel = ctx.yAxisData[yIdx] ?? yIdx;
-        return `${xLabel}, ${yLabel}: ${value}`;
+        // Function formatter output is injected as raw HTML into the
+        // tooltip DOM, so data-derived labels must be escaped.
+        const xLabel = escapeHtml(String(ctx.xData[xIdx] ?? xIdx));
+        const yLabel = escapeHtml(String(ctx.yAxisData[yIdx] ?? yIdx));
+        return `${xLabel}, ${yLabel}: ${escapeHtml(String(value))}`;
       },
     },
     grid: {

--- a/packages/appkit-ui/src/react/charts/utils.ts
+++ b/packages/appkit-ui/src/react/charts/utils.ts
@@ -56,6 +56,21 @@ export function formatLabel(field: string): string {
 }
 
 /**
+ * Escapes HTML special characters to prevent XSS.
+ * Required for ECharts function formatters: unlike string-template
+ * formatters, their return values are injected as raw HTML into the
+ * tooltip DOM.
+ */
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
  * Truncates a label to a maximum length with ellipsis.
  */
 export function truncateLabel(value: string, maxLength = 15): string {

--- a/packages/appkit-ui/src/react/charts/utils.ts
+++ b/packages/appkit-ui/src/react/charts/utils.ts
@@ -60,6 +60,10 @@ export function formatLabel(field: string): string {
  * Required for ECharts function formatters: unlike string-template
  * formatters, their return values are injected as raw HTML into the
  * tooltip DOM.
+ *
+ * Only for HTML tooltip contexts; do NOT use on canvas-rendered
+ * axis/series label formatters — canvas text is not HTML and would
+ * display literal entities (e.g. "&amp;").
  */
 export function escapeHtml(value: string): string {
   return value


### PR DESCRIPTION
## Summary

Fixes a high-severity XSS vulnerability in the heatmap chart tooltip (`packages/appkit-ui/src/react/charts/options.ts`).

### Vulnerability

The heatmap tooltip used an ECharts **function** formatter that returned a string built from raw data values:

```ts
return `${xLabel}, ${yLabel}: ${value}`;
```

ECharts HTML-encodes *string-template* formatters (e.g. `"{b}: {c}"`), but strings returned from *function* formatters are injected as **raw HTML** into the tooltip DOM. Since heatmap category values come from warehouse query results (tenant-supplied data), a value like `<img src=x onerror=alert(1)>` would execute arbitrary script when a user hovers the cell. The canvas renderer does not mitigate this — tooltips are always HTML DOM elements.

### Fix

- Added an `escapeHtml` helper to `charts/utils.ts` that escapes `& < > " '`.
- The heatmap tooltip formatter now escapes the x label, y label, and value before interpolation.

An audit of the rest of the charts directory found no other function formatters returning interpolated HTML — the remaining function formatters are axis/series label formatters rendered on canvas (not tooltip DOM).

### Tests

Added regression tests in `charts/__tests__/options.test.ts`:
- Builds heatmap options with malicious category values (`<img src=x onerror=alert(1)>`, `<script>alert(2)</script>`) and asserts the tooltip formatter output contains no raw `<`/`>` and matches the fully escaped string.
- A baseline test asserting normal labels/values still render correctly.

Verified with `pnpm build`, `pnpm -r typecheck`, `pnpm check:fix`, and the appkit-ui chart test suite (171 tests passing).

This pull request and its description were written by Isaac.