### PR TITLE
ci(template): verify lockfile uses only public npm registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,8 @@ jobs:
         run: pnpm run check:licenses
       - name: Check template deps are pinned
         run: pnpm exec tsx tools/check-template-deps.ts
+      - name: Check template lockfile uses only public npm registry
+        run: pnpm exec tsx tools/check-template-lock-registry.ts
 
   test:
     name: Unit Tests

--- a/template/package-lock.json
+++ b/template/package-lock.json
@@ -8218,7 +8218,7 @@
     },
     "node_modules/clsx": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "resolved": "https://npm-proxy.dev.databricks.com/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "license": "MIT",
       "engines": {
@@ -11440,7 +11440,7 @@
     },
     "node_modules/lucide-react": {
       "version": "0.546.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.546.0.tgz",
+      "resolved": "https://npm-proxy.dev.databricks.com/lucide-react/-/lucide-react-0.546.0.tgz",
       "integrity": "sha512-Z94u6fKT43lKeYHiVyvyR8fT7pwCzDu7RyMPpTvh054+xahSgj4HFQ+NmflvzdXsoAjYGdCguGaFKYuvq0ThCQ==",
       "license": "ISC",
       "peerDependencies": {

--- a/template/package-lock.json
+++ b/template/package-lock.json
@@ -8218,7 +8218,7 @@
     },
     "node_modules/clsx": {
       "version": "2.1.1",
-      "resolved": "https://npm-proxy.dev.databricks.com/clsx/-/clsx-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "license": "MIT",
       "engines": {
@@ -11440,7 +11440,7 @@
     },
     "node_modules/lucide-react": {
       "version": "0.546.0",
-      "resolved": "https://npm-proxy.dev.databricks.com/lucide-react/-/lucide-react-0.546.0.tgz",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.546.0.tgz",
       "integrity": "sha512-Z94u6fKT43lKeYHiVyvyR8fT7pwCzDu7RyMPpTvh054+xahSgj4HFQ+NmflvzdXsoAjYGdCguGaFKYuvq0ThCQ==",
       "license": "ISC",
       "peerDependencies": {

--- a/tools/check-template-lock-registry.ts
+++ b/tools/check-template-lock-registry.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env tsx
+/**
+ * Validates that template/package-lock.json resolves every dependency from the
+ * public npm registry, and nothing else.
+ *
+ * The template is the app scaffold shipped to users via `databricks apps init`,
+ * and its lockfile pins exactly where each dependency is fetched from (the
+ * `resolved` field on every package entry). If a private/internal registry
+ * (Artifactory, JFrog, GitHub Packages, Verdaccio, an internal mirror) ever
+ * leaks in — e.g. because the lockfile was regenerated on a machine with a
+ * custom `.npmrc` — scaffolded apps would either fail `npm install` (no access)
+ * or silently pull from a non-public source. This check fails CI before that
+ * ships.
+ *
+ * The single https + host rule on each `resolved` URL also rejects non-registry
+ * source types (`git+ssh://`, `file:`, `http://`, links), since none of those
+ * satisfy "https URL whose host is registry.npmjs.org".
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dirname, "..");
+const ALLOWED_REGISTRY_HOST = "registry.npmjs.org";
+
+const errors: string[] = [];
+
+// --- Lockfile resolved URLs (core check) ---
+// lockfileVersion 3: dependencies live only in the `packages` map. Entries
+// without a `resolved` field are the root ("") and workspace/link entries —
+// they are not registry fetches, so skip them.
+const lock = JSON.parse(
+  readFileSync(join(ROOT, "template/package-lock.json"), "utf-8"),
+);
+
+const packages: Record<string, { resolved?: string }> = lock.packages ?? {};
+for (const [pkgKey, entry] of Object.entries(packages)) {
+  const resolved = entry.resolved;
+  if (!resolved) continue;
+
+  let url: URL | undefined;
+  try {
+    url = new URL(resolved);
+  } catch {
+    // Not a parseable URL (e.g. a bare path) — treat as non-public.
+  }
+
+  if (url?.protocol !== "https:" || url.host !== ALLOWED_REGISTRY_HOST) {
+    errors.push(
+      `Non-public registry in template/package-lock.json: "${pkgKey || "<root>"}" ` +
+        `resolves to ${resolved} (expected https://${ALLOWED_REGISTRY_HOST}/...).`,
+    );
+  }
+}
+
+// --- Template .npmrc (belt-and-suspenders) ---
+// No template/.npmrc exists today; only validate it if one is added later.
+const npmrcPath = join(ROOT, "template/.npmrc");
+if (existsSync(npmrcPath)) {
+  const lines = readFileSync(npmrcPath, "utf-8").split(/\r?\n/);
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#") || line.startsWith(";")) continue;
+
+    // `registry=...` or scoped `@scope:registry=...`
+    const registryMatch = line.match(
+      /^(?:@[\w-]+\/?[\w-]*:)?registry\s*=\s*(.+)$/,
+    );
+    if (registryMatch) {
+      const value = registryMatch[1].trim().replace(/\/+$/, "");
+      if (value !== `https://${ALLOWED_REGISTRY_HOST}`) {
+        errors.push(
+          `Non-public registry in template/.npmrc: "${line}" ` +
+            `(expected https://${ALLOWED_REGISTRY_HOST}/).`,
+        );
+      }
+      continue;
+    }
+
+    // `//<host>/...:_authToken=...` style auth lines.
+    const authMatch = line.match(/^\/\/([^/]+)\/.*:_authToken\s*=/);
+    if (authMatch && authMatch[1] !== ALLOWED_REGISTRY_HOST) {
+      errors.push(
+        `Auth token for non-public registry in template/.npmrc: "${line}".`,
+      );
+    }
+  }
+}
+
+if (errors.length) {
+  for (const e of errors) console.error(e);
+  process.exit(1);
+}
+
+console.log(
+  `✓ template/package-lock.json references only the public npm registry`,
+);


### PR DESCRIPTION
## What

Adds a required CI check that fails if `template/package-lock.json` resolves any dependency from a non-public registry.

## Why

The `template/` directory is the app scaffold shipped to users via `databricks apps init`, and its `package-lock.json` pins exactly where each dependency is fetched from (the `resolved` field on every package entry). If a private/internal registry (Artifactory, JFrog, GitHub Packages, Verdaccio, an internal mirror) ever leaks into that lockfile — for example because it was regenerated on a machine with a custom `.npmrc` — scaffolded apps would either fail `npm install` (no access) or silently pull from a non-public source.

Today the lockfile is clean (1003 `resolved` entries, all `https://registry.npmjs.org/`), but nothing enforced it. This check closes that gap.

## How

New `tools/check-template-lock-registry.ts` (follows the existing `check-template-deps.ts` pattern):

- Iterates the `packages` map of `template/package-lock.json` (lockfileVersion 3) and requires every `resolved` URL to be `https://` with host `registry.npmjs.org`. Entries without `resolved` (root + workspace/link) are skipped. The single https+host rule also rejects non-registry sources like `git+ssh://`, `file:`, and `http://`.
- If `template/.npmrc` is ever added (none exists today), flags any private `registry=`/scoped-registry line or `_authToken=` line; absence is handled silently.

Wired as a new step in the existing required `lint_and_typecheck` job, next to `check-template-deps`, so it runs on every PR and blocks merge.

## Verification

- Happy path: current lockfile → exit 0.
- Injected JFrog URL and `git+ssh://` entry → both flagged, exit 1.
- Private `.npmrc` `registry=`/`_authToken=` flagged; legitimate `@scope:registry=https://registry.npmjs.org/` not flagged → exit 1.
- Missing `.npmrc` → exit 0, no error.
- Biome clean.

<img width="1527" height="168" alt="image" src="https://github.com/user-attachments/assets/8a4aec1a-9456-4924-8a99-f49d80a50dea" />
