### PR TITLE
fix(appkit): keep SSE generator alive for a grace window so reconnection resumes

### DIFF
--- a/packages/appkit/src/stream/defaults.ts
+++ b/packages/appkit/src/stream/defaults.ts
@@ -6,4 +6,5 @@ export const streamDefaults = {
   maxPersistentBuffers: 10000, // 10000 buffers
   heartbeatInterval: 10 * 1000, // 10 seconds
   maxActiveStreams: 1000, // 1000 streams
+  disconnectGraceMs: 15_000, // 15 seconds
 } as const;

--- a/packages/appkit/src/stream/stream-manager.ts
+++ b/packages/appkit/src/stream/stream-manager.ts
@@ -77,13 +77,7 @@ export class StreamManager {
 
   // abort all active operations
   abortAll(): void {
-    // clear any pending disconnect-grace timers so they can't fire late
-    for (const entry of this.streamRegistry.values()) {
-      if (entry.disconnectGraceTimer) {
-        clearTimeout(entry.disconnectGraceTimer);
-        entry.disconnectGraceTimer = undefined;
-      }
-    }
+    // pending disconnect-grace timers are cleared by streamRegistry.clear() below
     this.activeOperations.forEach((operation) => {
       if (operation.heartbeat) clearInterval(operation.heartbeat);
       operation.controller.abort(
@@ -428,9 +422,7 @@ export class StreamManager {
   // stopping background polling loops for genuinely abandoned streams.
   private _scheduleGraceAbort(streamEntry: StreamEntry): void {
     // clear any existing grace timer to avoid stacking
-    if (streamEntry.disconnectGraceTimer) {
-      clearTimeout(streamEntry.disconnectGraceTimer);
-    }
+    this._clearGraceTimer(streamEntry);
 
     const timer = setTimeout(() => {
       streamEntry.disconnectGraceTimer = undefined;

--- a/packages/appkit/src/stream/stream-manager.ts
+++ b/packages/appkit/src/stream/stream-manager.ts
@@ -119,8 +119,7 @@ export class StreamManager {
       }
     }
 
-    // A client is (re)attaching: cancel any pending disconnect-grace abort so
-    // a reconnection within the grace window resumes the live generator.
+    // a reconnecting client cancels the pending disconnect-grace abort
     this._clearGraceTimer(streamEntry);
 
     // add client to stream entry
@@ -148,10 +147,7 @@ export class StreamManager {
       streamEntry.clients.delete(res);
       this.activeOperations.delete(streamOperation);
 
-      // When no clients remain, don't abort immediately — start a grace timer
-      // so a reconnecting client can resume the stream. Only truly-abandoned
-      // streams (no reconnect within the window) get their generator aborted,
-      // which stops background polling loops (e.g. jobs runAndWait).
+      // grace-abort instead of aborting now, so a reconnect can resume
       if (streamEntry.clients.size === 0 && !streamEntry.isCompleted) {
         this._scheduleGraceAbort(streamEntry);
       }
@@ -237,11 +233,7 @@ export class StreamManager {
       this.activeOperations.delete(streamOperation);
       streamEntry.clients.delete(res);
 
-      // When no clients remain, don't abort the generator immediately — start a
-      // grace timer so a reconnecting client (e.g. SSE resume with
-      // Last-Event-ID) can keep the stream alive. Polling loops (e.g. jobs
-      // runAndWait) of truly-abandoned streams are still stopped, just
-      // `disconnectGraceMs` later instead of instantly.
+      // grace-abort instead of aborting now, so a reconnect can resume
       if (streamEntry.clients.size === 0 && !streamEntry.isCompleted) {
         this._scheduleGraceAbort(streamEntry);
       }
@@ -415,13 +407,9 @@ export class StreamManager {
     }
   }
 
-  // Schedule a delayed abort for a stream whose last client just disconnected.
-  // If a client reconnects within the grace window, the timer is cleared in
-  // `_attachToExistingStream` and the generator keeps running so reconnection
-  // can resume. Otherwise the generator is aborted once the window expires,
-  // stopping background polling loops for genuinely abandoned streams.
+  // abort the generator after the grace window unless a client reconnects first
   private _scheduleGraceAbort(streamEntry: StreamEntry): void {
-    // clear any existing grace timer to avoid stacking
+    // clear any existing timer to avoid stacking
     this._clearGraceTimer(streamEntry);
 
     const timer = setTimeout(() => {

--- a/packages/appkit/src/stream/stream-manager.ts
+++ b/packages/appkit/src/stream/stream-manager.ts
@@ -18,6 +18,7 @@ export class StreamManager {
   private sseWriter: SSEWriter;
   private maxEventSize: number;
   private bufferTTL: number;
+  private disconnectGraceMs: number;
 
   constructor(options?: StreamConfig) {
     this.streamRegistry = new StreamRegistry(
@@ -26,6 +27,8 @@ export class StreamManager {
     this.sseWriter = new SSEWriter();
     this.maxEventSize = options?.maxEventSize ?? streamDefaults.maxEventSize;
     this.bufferTTL = options?.bufferTTL ?? streamDefaults.bufferTTL;
+    this.disconnectGraceMs =
+      options?.disconnectGraceMs ?? streamDefaults.disconnectGraceMs;
     this.activeOperations = new Set();
   }
 
@@ -74,6 +77,13 @@ export class StreamManager {
 
   // abort all active operations
   abortAll(): void {
+    // clear any pending disconnect-grace timers so they can't fire late
+    for (const entry of this.streamRegistry.values()) {
+      if (entry.disconnectGraceTimer) {
+        clearTimeout(entry.disconnectGraceTimer);
+        entry.disconnectGraceTimer = undefined;
+      }
+    }
     this.activeOperations.forEach((operation) => {
       if (operation.heartbeat) clearInterval(operation.heartbeat);
       operation.controller.abort(
@@ -115,6 +125,10 @@ export class StreamManager {
       }
     }
 
+    // A client is (re)attaching: cancel any pending disconnect-grace abort so
+    // a reconnection within the grace window resumes the live generator.
+    this._clearGraceTimer(streamEntry);
+
     // add client to stream entry
     streamEntry.clients.add(res);
     streamEntry.lastAccess = Date.now();
@@ -140,11 +154,12 @@ export class StreamManager {
       streamEntry.clients.delete(res);
       this.activeOperations.delete(streamOperation);
 
-      // Stop the generator when no clients remain
+      // When no clients remain, don't abort immediately — start a grace timer
+      // so a reconnecting client can resume the stream. Only truly-abandoned
+      // streams (no reconnect within the window) get their generator aborted,
+      // which stops background polling loops (e.g. jobs runAndWait).
       if (streamEntry.clients.size === 0 && !streamEntry.isCompleted) {
-        streamEntry.abortController.abort(
-          new DOMException("All clients disconnected", "AbortError"),
-        );
+        this._scheduleGraceAbort(streamEntry);
       }
 
       // cleanup if stream is completed and no clients are connected
@@ -228,12 +243,13 @@ export class StreamManager {
       this.activeOperations.delete(streamOperation);
       streamEntry.clients.delete(res);
 
-      // Stop the generator when no clients remain so polling loops
-      // (e.g. jobs runAndWait) don't keep running in the background.
+      // When no clients remain, don't abort the generator immediately — start a
+      // grace timer so a reconnecting client (e.g. SSE resume with
+      // Last-Event-ID) can keep the stream alive. Polling loops (e.g. jobs
+      // runAndWait) of truly-abandoned streams are still stopped, just
+      // `disconnectGraceMs` later instead of instantly.
       if (streamEntry.clients.size === 0 && !streamEntry.isCompleted) {
-        abortController.abort(
-          new DOMException("Client disconnected", "AbortError"),
-        );
+        this._scheduleGraceAbort(streamEntry);
       }
     });
 
@@ -285,6 +301,9 @@ export class StreamManager {
 
         streamEntry.isCompleted = true;
 
+        // no late grace abort should fire on a completed stream
+        this._clearGraceTimer(streamEntry);
+
         // close all clients
         this._closeAllClients(streamEntry);
 
@@ -300,6 +319,7 @@ export class StreamManager {
         if (errorCode === SSEErrorCode.STREAM_ABORTED) {
           logger.info("Stream aborted by client (code=%s)", errorCode);
           streamEntry.isCompleted = true;
+          this._clearGraceTimer(streamEntry);
           this._closeAllClients(streamEntry);
           this._cleanupStream(streamEntry);
           return;
@@ -328,6 +348,7 @@ export class StreamManager {
           true,
         );
         streamEntry.isCompleted = true;
+        this._clearGraceTimer(streamEntry);
       }
     });
   }
@@ -397,6 +418,39 @@ export class StreamManager {
       if (!client.writableEnded) {
         client.end();
       }
+    }
+  }
+
+  // Schedule a delayed abort for a stream whose last client just disconnected.
+  // If a client reconnects within the grace window, the timer is cleared in
+  // `_attachToExistingStream` and the generator keeps running so reconnection
+  // can resume. Otherwise the generator is aborted once the window expires,
+  // stopping background polling loops for genuinely abandoned streams.
+  private _scheduleGraceAbort(streamEntry: StreamEntry): void {
+    // clear any existing grace timer to avoid stacking
+    if (streamEntry.disconnectGraceTimer) {
+      clearTimeout(streamEntry.disconnectGraceTimer);
+    }
+
+    const timer = setTimeout(() => {
+      streamEntry.disconnectGraceTimer = undefined;
+      if (streamEntry.clients.size === 0 && !streamEntry.isCompleted) {
+        streamEntry.abortController.abort(
+          new DOMException("Client disconnected (grace expired)", "AbortError"),
+        );
+      }
+    }, this.disconnectGraceMs);
+
+    // never keep the process alive solely for a grace timer
+    timer.unref?.();
+    streamEntry.disconnectGraceTimer = timer;
+  }
+
+  // clear a pending disconnect-grace timer, if any
+  private _clearGraceTimer(streamEntry: StreamEntry): void {
+    if (streamEntry.disconnectGraceTimer) {
+      clearTimeout(streamEntry.disconnectGraceTimer);
+      streamEntry.disconnectGraceTimer = undefined;
     }
   }
 

--- a/packages/appkit/src/stream/stream-registry.ts
+++ b/packages/appkit/src/stream/stream-registry.ts
@@ -41,19 +41,24 @@ export class StreamRegistry {
     return this.streams.getSize();
   }
 
-  // get all streams currently in the registry
-  values(): StreamEntry[] {
-    return this.streams.getAll();
-  }
-
   clear(): void {
     const allStreams = this.streams.getAll();
 
     for (const stream of allStreams) {
+      this._clearGraceTimer(stream);
       stream.abortController.abort("Server shutdown");
     }
 
     this.streams.clear();
+  }
+
+  // clear a pending disconnect-grace timer so a removed stream can't keep its
+  // entry (and event buffer) alive until the timer fires
+  private _clearGraceTimer(stream: StreamEntry): void {
+    if (stream.disconnectGraceTimer) {
+      clearTimeout(stream.disconnectGraceTimer);
+      stream.disconnectGraceTimer = undefined;
+    }
   }
 
   // evict the oldest stream from the registry
@@ -88,6 +93,7 @@ export class StreamRegistry {
           }
         }
       }
+      this._clearGraceTimer(oldestStream);
       oldestStream.abortController.abort("Stream evicted");
       this.streams.remove(oldestStream.streamId);
     }

--- a/packages/appkit/src/stream/stream-registry.ts
+++ b/packages/appkit/src/stream/stream-registry.ts
@@ -52,8 +52,7 @@ export class StreamRegistry {
     this.streams.clear();
   }
 
-  // clear a pending disconnect-grace timer so a removed stream can't keep its
-  // entry (and event buffer) alive until the timer fires
+  // clear a pending grace timer so a removed stream isn't pinned until it fires
   private _clearGraceTimer(stream: StreamEntry): void {
     if (stream.disconnectGraceTimer) {
       clearTimeout(stream.disconnectGraceTimer);

--- a/packages/appkit/src/stream/stream-registry.ts
+++ b/packages/appkit/src/stream/stream-registry.ts
@@ -41,6 +41,11 @@ export class StreamRegistry {
     return this.streams.getSize();
   }
 
+  // get all streams currently in the registry
+  values(): StreamEntry[] {
+    return this.streams.getAll();
+  }
+
   clear(): void {
     const allStreams = this.streams.getAll();
 

--- a/packages/appkit/src/stream/tests/stream.test.ts
+++ b/packages/appkit/src/stream/tests/stream.test.ts
@@ -194,7 +194,8 @@ describe("StreamManager", () => {
       expect(streamManager.getActiveCount()).toBe(0);
     });
 
-    test("should abort generator when last client disconnects", async () => {
+    test("should abort generator after grace window when last client disconnects", async () => {
+      vi.useFakeTimers();
       const { mockRes } = createMockResponse();
       let closeHandler: (() => void) | undefined;
 
@@ -220,15 +221,191 @@ describe("StreamManager", () => {
       const streamPromise = streamManager.stream(mockRes as any, generator);
 
       // Let the generator yield "start" and enter the signal wait
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await vi.advanceTimersByTimeAsync(10);
 
-      // Simulate client disconnect
+      // Simulate client disconnect — abort should NOT fire immediately
       if (closeHandler) closeHandler();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(signalAborted).toBe(false);
 
+      // After the grace window elapses with no reconnect, the generator aborts
+      await vi.advanceTimersByTimeAsync(15_000);
       await streamPromise;
 
       expect(signalAborted).toBe(true);
       expect(streamManager.getActiveCount()).toBe(0);
+
+      vi.useRealTimers();
+    });
+  });
+
+  describe("disconnect grace window", () => {
+    test("does NOT abort the generator if a client reconnects within the grace window", async () => {
+      vi.useFakeTimers();
+      const streamId = "grace-reconnect-123";
+
+      const { mockRes: mockRes1, events: events1 } = createMockResponse();
+      let closeHandler1: (() => void) | undefined;
+      mockRes1.on.mockImplementation((event: string, handler: () => void) => {
+        if (event === "close") closeHandler1 = handler;
+      });
+
+      // Finite generator that emits one event, then waits on a manual gate
+      // before emitting the rest — mirrors the reconnect demo's pacing.
+      let releaseRest: (() => void) | undefined;
+      const restGate = new Promise<void>((resolve) => {
+        releaseRest = resolve;
+      });
+
+      async function* generator(signal: AbortSignal) {
+        yield { type: "tick", count: 1 };
+        await restGate;
+        if (signal.aborted) return;
+        yield { type: "tick", count: 2 };
+        yield { type: "tick", count: 3 };
+      }
+
+      const streamPromise = streamManager.stream(mockRes1 as any, generator, {
+        streamId,
+      });
+
+      // first event emitted
+      await vi.advanceTimersByTimeAsync(0);
+      const eventIds = events1
+        .filter((e) => e.startsWith("id: "))
+        .map((e) => e.replace("id: ", "").replace("\n", ""));
+      expect(eventIds.length).toBe(1);
+
+      // client disconnects (clients -> 0) while the generator is still active
+      if (closeHandler1) closeHandler1();
+
+      // reconnect well within the 15s grace window
+      await vi.advanceTimersByTimeAsync(3_000);
+      const { mockRes: mockRes2, events: events2 } = createMockResponse({
+        "last-event-id": eventIds[0],
+      });
+      mockRes2.on.mockImplementation(() => {});
+
+      const reconnectPromise = streamManager.stream(
+        mockRes2 as any,
+        async function* () {
+          yield { type: "should-not-run" };
+        },
+        { streamId },
+      );
+
+      // release the rest of the original generator now that we've reconnected
+      releaseRest?.();
+      await vi.advanceTimersByTimeAsync(0);
+      await Promise.all([streamPromise, reconnectPromise]);
+
+      // The reconnecting client must receive the subsequent events — proving
+      // the generator was NOT aborted during the disconnect.
+      const reconnectData = events2
+        .filter((e) => e.startsWith("data: "))
+        .map((e) => e.replace("data: ", "").replace("\n\n", ""));
+      expect(reconnectData.some((d) => d.includes('"count":2'))).toBe(true);
+      expect(reconnectData.some((d) => d.includes('"count":3'))).toBe(true);
+      // the placeholder generator passed on reconnect must never run
+      expect(events2.some((e) => e.includes("should-not-run"))).toBe(false);
+
+      vi.useRealTimers();
+    });
+
+    test("aborts the generator when no client reconnects within the grace window", async () => {
+      vi.useFakeTimers();
+      const { mockRes } = createMockResponse();
+      let closeHandler: (() => void) | undefined;
+      mockRes.on.mockImplementation((event: string, handler: () => void) => {
+        if (event === "close") closeHandler = handler;
+      });
+
+      let signalAborted = false;
+      async function* generator(signal: AbortSignal) {
+        yield { type: "start" };
+        await new Promise<void>((resolve) => {
+          if (signal.aborted) return resolve();
+          signal.addEventListener("abort", () => resolve(), { once: true });
+        });
+        signalAborted = signal.aborted;
+      }
+
+      const streamPromise = streamManager.stream(mockRes as any, generator);
+      await vi.advanceTimersByTimeAsync(0);
+
+      if (closeHandler) closeHandler();
+
+      // Just before the window expires, the generator is still alive.
+      await vi.advanceTimersByTimeAsync(14_999);
+      expect(signalAborted).toBe(false);
+
+      // Crossing the window aborts the abandoned generator (jobs cleanup).
+      await vi.advanceTimersByTimeAsync(1);
+      await streamPromise;
+      expect(signalAborted).toBe(true);
+
+      vi.useRealTimers();
+    });
+
+    test("respects a custom disconnectGraceMs", async () => {
+      vi.useFakeTimers();
+      const customManager = new StreamManager({ disconnectGraceMs: 1_000 });
+      const { mockRes } = createMockResponse();
+      let closeHandler: (() => void) | undefined;
+      mockRes.on.mockImplementation((event: string, handler: () => void) => {
+        if (event === "close") closeHandler = handler;
+      });
+
+      let signalAborted = false;
+      async function* generator(signal: AbortSignal) {
+        yield { type: "start" };
+        await new Promise<void>((resolve) => {
+          if (signal.aborted) return resolve();
+          signal.addEventListener("abort", () => resolve(), { once: true });
+        });
+        signalAborted = signal.aborted;
+      }
+
+      const streamPromise = customManager.stream(mockRes as any, generator);
+      await vi.advanceTimersByTimeAsync(0);
+      if (closeHandler) closeHandler();
+
+      await vi.advanceTimersByTimeAsync(999);
+      expect(signalAborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      await streamPromise;
+      expect(signalAborted).toBe(true);
+
+      vi.useRealTimers();
+    });
+
+    test("stream completion clears the pending grace timer (no late abort)", async () => {
+      vi.useFakeTimers();
+      const { mockRes } = createMockResponse();
+      let closeHandler: (() => void) | undefined;
+      mockRes.on.mockImplementation((event: string, handler: () => void) => {
+        if (event === "close") closeHandler = handler;
+      });
+
+      const abortSpy = vi.fn();
+
+      async function* generator(signal: AbortSignal) {
+        signal.addEventListener("abort", abortSpy, { once: true });
+        yield { type: "only" };
+        // generator finishes here -> stream becomes completed
+      }
+
+      const streamPromise = streamManager.stream(mockRes as any, generator);
+      await streamPromise;
+
+      // Stream has completed. A late close handler must not schedule an abort,
+      // and any timer that might have been pending must not fire.
+      if (closeHandler) closeHandler();
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      expect(abortSpy).not.toHaveBeenCalled();
+
+      vi.useRealTimers();
     });
   });
 

--- a/packages/appkit/src/stream/types.ts
+++ b/packages/appkit/src/stream/types.ts
@@ -49,11 +49,7 @@ export interface StreamEntry {
   lastAccess: number;
   abortController: AbortController;
   traceContext: Context;
-  /**
-   * Pending timer that aborts the generator once the disconnect grace window
-   * elapses with no clients. Cleared if a client reconnects, or when the
-   * stream completes/errors. Undefined while at least one client is connected.
-   */
+  // pending grace-window abort, set while the last client is disconnected
   disconnectGraceTimer?: NodeJS.Timeout;
 }
 

--- a/packages/appkit/src/stream/types.ts
+++ b/packages/appkit/src/stream/types.ts
@@ -49,6 +49,12 @@ export interface StreamEntry {
   lastAccess: number;
   abortController: AbortController;
   traceContext: Context;
+  /**
+   * Pending timer that aborts the generator once the disconnect grace window
+   * elapses with no clients. Cleared if a client reconnects, or when the
+   * stream completes/errors. Undefined while at least one client is connected.
+   */
+  disconnectGraceTimer?: NodeJS.Timeout;
 }
 
 export interface StreamOperation {

--- a/packages/shared/src/execute.ts
+++ b/packages/shared/src/execute.ts
@@ -11,6 +11,13 @@ export interface StreamConfig {
   maxPersistentBuffers?: number;
   heartbeatInterval?: number;
   maxActiveStreams?: number;
+  /**
+   * How long (ms) an idle stream's generator is kept alive after the last
+   * client disconnects, so a reconnecting client can resume. If no client
+   * reconnects within this window, the abandoned stream's generator is
+   * aborted (e.g. to stop background polling loops like jobs runAndWait).
+   */
+  disconnectGraceMs?: number;
 }
 
 /** Retry configuration for the RetryInterceptor. Uses exponential backoff with full jitter between attempts. */

--- a/packages/shared/src/execute.ts
+++ b/packages/shared/src/execute.ts
@@ -11,12 +11,8 @@ export interface StreamConfig {
   maxPersistentBuffers?: number;
   heartbeatInterval?: number;
   maxActiveStreams?: number;
-  /**
-   * How long (ms) an idle stream's generator is kept alive after the last
-   * client disconnects, so a reconnecting client can resume. If no client
-   * reconnects within this window, the abandoned stream's generator is
-   * aborted (e.g. to stop background polling loops like jobs runAndWait).
-   */
+  // ms to keep a generator alive after the last client disconnects, so a
+  // reconnecting client can resume before the stream is aborted
   disconnectGraceMs?: number;
 }
 


### PR DESCRIPTION
## Root cause

Commit `4e923408` ("feat(jobs): add HTTP routes, validation, streaming, and review fixes") added an immediate `abortController.abort(...)` to **both** `res.on("close")` handlers in `packages/appkit/src/stream/stream-manager.ts` (in `_createNewStream` and `_attachToExistingStream`): the moment the last client disconnected (`clients.size === 0`), the generator was aborted and the stream marked completed.

That broke SSE reconnection. The dev-playground reconnect demo streams a **finite** generator (counts 1..5, 3s apart) and the client deliberately disconnects after message 2, then reconnects ~3s later with `Last-Event-ID`. With the immediate abort, the generator was killed during the brief disconnect and the stream became `isCompleted`, so on reconnect `_attachToExistingStream` just called `res.end()` — reconnection delivered nothing and the counter stuck at 2. The same hazard applies to any stream a client momentarily drops.

## Fix: disconnect grace window

On last-client disconnect we no longer abort immediately. Instead we schedule a delayed abort via a new `_scheduleGraceAbort(streamEntry)` helper (shared by both close handlers):

- Default **15s**, configurable via `StreamConfig.disconnectGraceMs` (added to `packages/shared/src/execute.ts`; default in `stream/defaults.ts`, wired through the `StreamManager` constructor like `bufferTTL`).
- A new `disconnectGraceTimer?: NodeJS.Timeout` lives on `StreamEntry`. The timer is `unref()`'d so it never keeps the process alive.
- When a client (re)attaches in `_attachToExistingStream`, the pending grace timer is cleared **before** the client is added — so a reconnect within the window cancels the abort and the live generator keeps running. Reconnection then replays buffered events and resumes new ones.
- The grace timer is also cleared on stream completion/error and in `abortAll()`, so timers never leak or fire late.

## Abandoned-stream cleanup preserved

The original intent of `4e923408` still holds: a truly-abandoned stream (no client reconnects within the window) still has its generator aborted — just `disconnectGraceMs` later instead of instantly — so background polling loops (e.g. jobs `runAndWait`) are still stopped.

## Tests

Added to `packages/appkit/src/stream/tests/stream.test.ts` (fake timers):
- Reconnect within the grace window → generator NOT aborted, reconnecting client receives subsequent events (core regression test).
- No reconnect within the window → generator IS aborted after `disconnectGraceMs` (jobs-cleanup behavior).
- Custom `disconnectGraceMs` is honored.
- Stream completion clears the pending grace timer (no late abort fires).
- Updated the existing "abort on last-client disconnect" test to assert the abort happens after the grace window rather than immediately.

All `appkit` tests pass (`vitest run --project appkit`: 2143 passed), plus `pnpm build`, `pnpm -r typecheck`, and Biome on changed files are clean.

## Note on sequencing with #438

This touches the same two `res.on("close")` handlers in `stream-manager.ts` as PR #438, so the two will need sequencing / a rebase when both land.

This pull request and its description were written by Isaac.