### PR TITLE
feat(appkit): add global uncaughtException/unhandledRejection handlers

### DIFF
--- a/packages/appkit/src/plugins/server/index.ts
+++ b/packages/appkit/src/plugins/server/index.ts
@@ -23,13 +23,6 @@ dotenv.config({ path: path.resolve(process.cwd(), "./.env") });
 
 const logger = createLogger("server");
 
-/**
- * Guards process-level lifecycle handlers (signals + global error handlers)
- * to a single registration per process, regardless of how many server
- * instances start. Avoids stacking listeners on the shared `process` object.
- */
-let processHandlersRegistered = false;
-
 /** Dev-only: try `requested` then consecutive ports (see `get-port` `portNumbers`). */
 const devListenPortSpan = 100;
 
@@ -167,7 +160,12 @@ export class ServerPlugin extends Plugin {
     // attach server to remote tunnel controller
     this.remoteTunnelController.setServer(server);
 
-    this._registerProcessHandlers();
+    // The first server to start installs the shared process-level handlers;
+    // every started server then participates in shutdown.
+    if (ServerPlugin.startedServers.size === 0) {
+      ServerPlugin._installProcessHandlers();
+    }
+    ServerPlugin.startedServers.add(this);
 
     if (process.env.NODE_ENV === "development") {
       const allRoutes = getRoutes(this.serverApplication._router.stack);
@@ -405,7 +403,15 @@ export class ServerPlugin extends Plugin {
   }
 
   /**
-   * Register process-level lifecycle handlers exactly once.
+   * Servers that have started and participate in process-level lifecycle.
+   * The set being empty is the "install once" latch: the first `start()`
+   * installs the shared `process` handlers, and registration stays lazy
+   * (importing this module attaches nothing). Avoids a module-level flag.
+   */
+  private static readonly startedServers = new Set<ServerPlugin>();
+
+  /**
+   * Install process-level lifecycle handlers exactly once per process.
    *
    * Beyond SIGTERM/SIGINT, this wires up global error handlers so an
    * unhandled async error no longer crashes the Node process silently in
@@ -416,20 +422,22 @@ export class ServerPlugin extends Plugin {
    * - `unhandledRejection` — log at error level for visibility without
    *   forcing an exit, matching how the codebase isolates non-fatal errors.
    *
-   * Guarded module-wide so repeated `start()` calls (e.g. in tests, or
-   * multiple server instances) don't stack listeners on the shared
-   * `process` object.
+   * Handlers shut down every started server, not just the first — they live
+   * on the shared `process` object, so the single registration covers all.
    */
-  private _registerProcessHandlers() {
-    if (processHandlersRegistered) return;
-    processHandlersRegistered = true;
+  private static _installProcessHandlers() {
+    const shutdownAll = (exitCode?: number) => {
+      for (const server of ServerPlugin.startedServers) {
+        void server._gracefulShutdown(exitCode);
+      }
+    };
 
-    process.on("SIGTERM", () => this._gracefulShutdown());
-    process.on("SIGINT", () => this._gracefulShutdown());
+    process.on("SIGTERM", () => shutdownAll());
+    process.on("SIGINT", () => shutdownAll());
 
     process.on("uncaughtException", (error: Error, origin) => {
       logger.error("Uncaught exception (%s), shutting down: %O", origin, error);
-      this._gracefulShutdown(1);
+      shutdownAll(1);
     });
 
     process.on("unhandledRejection", (reason) => {

--- a/packages/appkit/src/plugins/server/index.ts
+++ b/packages/appkit/src/plugins/server/index.ts
@@ -23,6 +23,13 @@ dotenv.config({ path: path.resolve(process.cwd(), "./.env") });
 
 const logger = createLogger("server");
 
+/**
+ * Guards process-level lifecycle handlers (signals + global error handlers)
+ * to a single registration per process, regardless of how many server
+ * instances start. Avoids stacking listeners on the shared `process` object.
+ */
+let processHandlersRegistered = false;
+
 /** Dev-only: try `requested` then consecutive ports (see `get-port` `portNumbers`). */
 const devListenPortSpan = 100;
 
@@ -160,8 +167,7 @@ export class ServerPlugin extends Plugin {
     // attach server to remote tunnel controller
     this.remoteTunnelController.setServer(server);
 
-    process.on("SIGTERM", () => this._gracefulShutdown());
-    process.on("SIGINT", () => this._gracefulShutdown());
+    this._registerProcessHandlers();
 
     if (process.env.NODE_ENV === "development") {
       const allRoutes = getRoutes(this.serverApplication._router.stack);
@@ -398,7 +404,40 @@ export class ServerPlugin extends Plugin {
     }
   }
 
-  private async _gracefulShutdown() {
+  /**
+   * Register process-level lifecycle handlers exactly once.
+   *
+   * Beyond SIGTERM/SIGINT, this wires up global error handlers so an
+   * unhandled async error no longer crashes the Node process silently in
+   * production:
+   * - `uncaughtException` — the process is in an undefined state, so we log
+   *   the error and run the same graceful shutdown the signal handlers use,
+   *   then exit non-zero (handled inside `_gracefulShutdown`).
+   * - `unhandledRejection` — log at error level for visibility without
+   *   forcing an exit, matching how the codebase isolates non-fatal errors.
+   *
+   * Guarded module-wide so repeated `start()` calls (e.g. in tests, or
+   * multiple server instances) don't stack listeners on the shared
+   * `process` object.
+   */
+  private _registerProcessHandlers() {
+    if (processHandlersRegistered) return;
+    processHandlersRegistered = true;
+
+    process.on("SIGTERM", () => this._gracefulShutdown());
+    process.on("SIGINT", () => this._gracefulShutdown());
+
+    process.on("uncaughtException", (error: Error, origin) => {
+      logger.error("Uncaught exception (%s), shutting down: %O", origin, error);
+      this._gracefulShutdown(1);
+    });
+
+    process.on("unhandledRejection", (reason) => {
+      logger.error("Unhandled promise rejection: %O", reason);
+    });
+  }
+
+  private async _gracefulShutdown(exitCode = 0) {
     logger.info("Starting graceful shutdown...");
 
     if (this.viteDevServer) {
@@ -433,7 +472,7 @@ export class ServerPlugin extends Plugin {
     if (this.server) {
       this.server.close(() => {
         logger.debug("Server closed gracefully");
-        process.exit(0);
+        process.exit(exitCode);
       });
 
       // 3. timeout to force shutdown after 15 seconds
@@ -442,7 +481,7 @@ export class ServerPlugin extends Plugin {
         process.exit(1);
       }, 15000);
     } else {
-      process.exit(0);
+      process.exit(exitCode);
     }
   }
 

--- a/packages/appkit/src/plugins/server/index.ts
+++ b/packages/appkit/src/plugins/server/index.ts
@@ -23,6 +23,10 @@ dotenv.config({ path: path.resolve(process.cwd(), "./.env") });
 
 const logger = createLogger("server");
 
+// Registered once per process; repeated start() calls (e.g. in tests) must not
+// stack handlers on the shared `process`.
+let processHandlersRegistered = false;
+
 /** Dev-only: try `requested` then consecutive ports (see `get-port` `portNumbers`). */
 const devListenPortSpan = 100;
 
@@ -160,12 +164,7 @@ export class ServerPlugin extends Plugin {
     // attach server to remote tunnel controller
     this.remoteTunnelController.setServer(server);
 
-    // The first server to start installs the shared process-level handlers;
-    // every started server then participates in shutdown.
-    if (ServerPlugin.startedServers.size === 0) {
-      ServerPlugin._installProcessHandlers();
-    }
-    ServerPlugin.startedServers.add(this);
+    this._registerProcessHandlers();
 
     if (process.env.NODE_ENV === "development") {
       const allRoutes = getRoutes(this.serverApplication._router.stack);
@@ -402,44 +401,16 @@ export class ServerPlugin extends Plugin {
     }
   }
 
-  /**
-   * Servers that have started and participate in process-level lifecycle.
-   * The set being empty is the "install once" latch: the first `start()`
-   * installs the shared `process` handlers, and registration stays lazy
-   * (importing this module attaches nothing). Avoids a module-level flag.
-   */
-  private static readonly startedServers = new Set<ServerPlugin>();
+  private _registerProcessHandlers() {
+    if (processHandlersRegistered) return;
+    processHandlersRegistered = true;
 
-  /**
-   * Install process-level lifecycle handlers exactly once per process.
-   *
-   * Beyond SIGTERM/SIGINT, this wires up global error handlers so an
-   * unhandled async error no longer crashes the Node process silently in
-   * production:
-   * - `uncaughtException` — the process is in an undefined state, so we log
-   *   the error and run the same graceful shutdown the signal handlers use,
-   *   then exit non-zero (handled inside `_gracefulShutdown`).
-   * - `unhandledRejection` — log at error level for visibility without
-   *   forcing an exit, matching how the codebase isolates non-fatal errors.
-   *
-   * Handlers shut down every started server, not just the first — they live
-   * on the shared `process` object, so the single registration covers all.
-   */
-  private static _installProcessHandlers() {
-    const shutdownAll = (exitCode?: number) => {
-      for (const server of ServerPlugin.startedServers) {
-        void server._gracefulShutdown(exitCode);
-      }
-    };
-
-    process.on("SIGTERM", () => shutdownAll());
-    process.on("SIGINT", () => shutdownAll());
-
+    process.on("SIGTERM", () => this._gracefulShutdown());
+    process.on("SIGINT", () => this._gracefulShutdown());
     process.on("uncaughtException", (error: Error, origin) => {
       logger.error("Uncaught exception (%s), shutting down: %O", origin, error);
-      shutdownAll(1);
+      this._gracefulShutdown(1);
     });
-
     process.on("unhandledRejection", (reason) => {
       logger.error("Unhandled promise rejection: %O", reason);
     });


### PR DESCRIPTION
## Problem

The server bootstrap registers `SIGTERM`/`SIGINT` handlers but had no global
`uncaughtException` / `unhandledRejection` handlers. An unhandled async error
would crash the Node process silently in production — no structured log, no
graceful drain of in-flight work.

## What changed

In `packages/appkit/src/plugins/server/index.ts`, the signal handlers are now
registered via a new `_registerProcessHandlers()` method (called from `start()`
in the same spot SIGTERM/SIGINT were wired), which also adds:

- **`uncaughtException`** — logs the error (with `origin`) via the existing
  `server` logger, then runs the *same* `_gracefulShutdown()` path the signal
  handlers use (drain plugins, close server) and exits non-zero. `_gracefulShutdown`
  now takes an `exitCode` (default `0`) so the success path stays `0` while a
  fatal exception exits `1`.
- **`unhandledRejection`** — logs at error level for visibility, without forcing
  an exit, matching how the codebase isolates non-fatal errors (Node best practice).

A module-level `processHandlersRegistered` guard ensures handlers are registered
exactly once per process, regardless of how many server instances start or how
many times `start()` runs. This also removes the pre-existing
`MaxListenersExceededWarning` that repeated `start()` calls produced in tests.

## Verification

- `pnpm --filter=@databricks/appkit typecheck` — pass
- `vitest run server.test.ts` — 30/30 pass (and the MaxListeners warning is gone)
- `vitest run server.integration.test.ts` — 8/8 pass
- `biome check` on the changed file — clean

This pull request and its description were written by Isaac.