### PR TITLE
test(playground): exercise SSE reconnect Last-Event-ID replay

### DIFF
--- a/apps/dev-playground/client/src/components/reconnect/connection-status.tsx
+++ b/apps/dev-playground/client/src/components/reconnect/connection-status.tsx
@@ -49,7 +49,12 @@ export function ConnectionStatus({
       <Timeline status={status} messageCount={messageCount} />
 
       <div className="flex items-center justify-center gap-2">
-        <h2 className="text-4xl font-bold text-foreground">{messageCount}</h2>
+        <h2
+          data-testid="message-count"
+          className="text-4xl font-bold text-foreground"
+        >
+          {messageCount}
+        </h2>
         <p className="text-base text-muted-foreground">/ 5 messages received</p>
       </div>
     </Card>

--- a/apps/dev-playground/tests/reconnect.spec.ts
+++ b/apps/dev-playground/tests/reconnect.spec.ts
@@ -45,3 +45,87 @@ test.describe("Reconnect Route Tests", () => {
     await newStreamRequestPromise;
   });
 });
+
+/**
+ * RECONNECT-REPLAY scenario.
+ *
+ * The happy-path tests above mock `/api/reconnect/stream` (see
+ * `setupMockAPI`), so they replay a static, all-at-once SSE body and never
+ * touch the real server. That is why a `Last-Event-ID` replay regression in
+ * the StreamManager ring buffer could (and did) go undetected for weeks: the
+ * connection was never actually dropped mid-stream.
+ *
+ * These tests run against the REAL dev-playground server (no stream mock) and
+ * force a mid-stream disconnect, asserting the client recovers ALL messages
+ * with no duplicates and no gaps — i.e. the server replayed exactly the
+ * buffered events the client missed.
+ */
+test.describe("Reconnect Route Tests - Last-Event-ID replay (recovery)", () => {
+  // Reads the message-count headline ("N / 5 messages received").
+  const readMessageCount = async (page: import("@playwright/test").Page) => {
+    const container = page.locator("div").filter({
+      has: page.getByText("/ 5 messages received"),
+    });
+    const text = await container.locator("h2").first().textContent();
+    return Number.parseInt(text ?? "0", 10);
+  };
+
+  test("recovers all messages with no gaps or duplicates after a mid-stream network drop", async ({
+    page,
+    context,
+  }) => {
+    // Identify this as the reconnect-replay scenario for triage.
+    test.info().annotations.push({
+      type: "scenario",
+      description: "reconnect-replay: mid-stream drop -> Last-Event-ID replay",
+    });
+
+    // NOTE: intentionally NOT calling setupMockAPI — we exercise the real
+    // server SSE stream + StreamManager ring buffer.
+    await page.goto("/reconnect", { waitUntil: "domcontentloaded" });
+
+    const messageCount = page.locator("div").filter({
+      has: page.getByText("/ 5 messages received"),
+    });
+
+    // Wait until SOME (not all) messages have arrived, then drop the network
+    // mid-stream. The server yields 1 message every ~3s, so >=1 and <5 leaves
+    // room to interrupt before completion.
+    await expect
+      .poll(() => readMessageCount(page), {
+        timeout: 20000,
+        message: "expected at least one message before forcing disconnect",
+      })
+      .toBeGreaterThanOrEqual(1);
+
+    expect(await readMessageCount(page)).toBeLessThan(5);
+
+    // Force a client-side disconnect mid-stream: this aborts the in-flight
+    // fetch with a network error, triggering the hook's reconnect path which
+    // re-requests the same streamId with a Last-Event-ID header.
+    await context.setOffline(true);
+    await page.waitForTimeout(1500);
+    await context.setOffline(false);
+
+    // After reconnection + replay, the stream must complete with all 5
+    // messages. Web-first assertion polls until the headline reads "5".
+    await expect(messageCount.locator("h2")).toHaveText("5", {
+      timeout: 40000,
+    });
+
+    // Status should land on a terminal/healthy state, never "Error".
+    await expect(
+      page.locator('[data-slot="badge"]').filter({ hasText: "Error" }),
+    ).toHaveCount(0);
+
+    // Verify NO gaps and NO duplicates: the rendered stream must contain
+    // exactly one "Message k/5" card for each k in 1..5. This is what proves
+    // Last-Event-ID replay delivered the missed events without re-delivering
+    // ones the client already had.
+    for (let k = 1; k <= 5; k++) {
+      await expect(
+        page.getByText(`Message ${k}/5`, { exact: true }),
+      ).toHaveCount(1, { timeout: 5000 });
+    }
+  });
+});

--- a/apps/dev-playground/tests/reconnect.spec.ts
+++ b/apps/dev-playground/tests/reconnect.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 import { setupMockAPI } from "./utils/test-utils";
 
 test.describe("Reconnect Route Tests", () => {
@@ -24,10 +24,7 @@ test.describe("Reconnect Route Tests", () => {
       page.locator('[data-slot="badge"]').filter({ hasText: "Reconnected" }),
     ).toBeVisible({ timeout: 5000 });
 
-    const messageCountContainer = page.locator("div").filter({
-      has: page.getByText("/ 5 messages received"),
-    });
-    await expect(messageCountContainer.locator("h2")).toHaveText("5", {
+    await expect(page.getByTestId("message-count")).toHaveText("5", {
       timeout: 5000,
     });
   });
@@ -62,11 +59,8 @@ test.describe("Reconnect Route Tests", () => {
  */
 test.describe("Reconnect Route Tests - Last-Event-ID replay (recovery)", () => {
   // Reads the message-count headline ("N / 5 messages received").
-  const readMessageCount = async (page: import("@playwright/test").Page) => {
-    const container = page.locator("div").filter({
-      has: page.getByText("/ 5 messages received"),
-    });
-    const text = await container.locator("h2").first().textContent();
+  const readMessageCount = async (page: Page) => {
+    const text = await page.getByTestId("message-count").textContent();
     return Number.parseInt(text ?? "0", 10);
   };
 
@@ -84,21 +78,25 @@ test.describe("Reconnect Route Tests - Last-Event-ID replay (recovery)", () => {
     // server SSE stream + StreamManager ring buffer.
     await page.goto("/reconnect", { waitUntil: "domcontentloaded" });
 
-    const messageCount = page.locator("div").filter({
-      has: page.getByText("/ 5 messages received"),
-    });
+    const messageCount = page.getByTestId("message-count");
 
     // Wait until SOME (not all) messages have arrived, then drop the network
-    // mid-stream. The server yields 1 message every ~3s, so >=1 and <5 leaves
-    // room to interrupt before completion.
+    // mid-stream. The server yields 1 message every ~3s, so the [1, 5) window
+    // leaves room to interrupt before completion. Polling the range as a single
+    // predicate keeps the read atomic — there's no gap between checking the
+    // lower and upper bound where the count could slip to 5.
     await expect
-      .poll(() => readMessageCount(page), {
-        timeout: 20000,
-        message: "expected at least one message before forcing disconnect",
-      })
-      .toBeGreaterThanOrEqual(1);
-
-    expect(await readMessageCount(page)).toBeLessThan(5);
+      .poll(
+        async () => {
+          const count = await readMessageCount(page);
+          return count >= 1 && count < 5;
+        },
+        {
+          timeout: 20000,
+          message: "expected to catch the stream mid-flight (1 <= count < 5)",
+        },
+      )
+      .toBe(true);
 
     // Force a client-side disconnect mid-stream: this aborts the in-flight
     // fetch with a network error, triggering the hook's reconnect path which
@@ -109,7 +107,7 @@ test.describe("Reconnect Route Tests - Last-Event-ID replay (recovery)", () => {
 
     // After reconnection + replay, the stream must complete with all 5
     // messages. Web-first assertion polls until the headline reads "5".
-    await expect(messageCount.locator("h2")).toHaveText("5", {
+    await expect(messageCount).toHaveText("5", {
       timeout: 40000,
     });
 


### PR DESCRIPTION
## Why

The existing reconnect E2E tests in `apps/dev-playground/tests/reconnect.spec.ts` only cover the **happy path**. They install `setupMockAPI`, which fulfills `/api/reconnect/stream` with a static SSE body delivering all 5 messages at once — the connection is never actually dropped. As a result, the real server reconnection path (StreamManager ring-buffer replay via `Last-Event-ID`, `packages/appkit/src/stream/stream-manager.ts`) was never exercised end-to-end. That blind spot is exactly why a real reconnect regression could survive ~6 weeks: a broken replay would still pass every existing test.

## What

Adds one recovery test (kept alongside, not replacing, the happy-path tests) in a separate `describe` block so it runs against the **real** dev-playground server (no stream mock):

- Loads `/reconnect`, waits until *some* (≥1, <5) messages have arrived.
- Forces a client-side disconnect mid-stream with `context.setOffline(true)` then `setOffline(false)`, which aborts the in-flight SSE fetch and triggers the client's reconnect with a `Last-Event-ID` header against the same `streamId`.
- Asserts the stream completes with all 5 messages (headline reads `5`), status never reaches `Error`, and the rendered list contains **exactly one** `Message k/5` card for each `k` in 1..5 — i.e. no gaps and no duplicates, which is what proves the server replayed the buffered events the client missed.

Assertions use Playwright web-first / `expect.poll` with generous timeouts (no arbitrary sleeps beyond the brief offline window) to keep the SSE timing robust. The test is annotated `scenario: reconnect-replay` for triage.

## Verification

Ran locally against the real server (reproducing CI env: `APPKIT_E2E_TEST=true` + mock workspace vars), Playwright auto-starting the server:

- Full `reconnect.spec.ts`: **4 passed** (new recovery test ~13s).
- Recovery test `--repeat-each=3`: **3/3 passed**, stable ~12.8s — no flakiness observed.
- **False-green check:** temporarily disabled the missed-event replay loop in `StreamManager._attachToExistingStream` and confirmed the new test **fails** (stalls at 4 messages, never reaches 5), proving it genuinely catches a replay regression. Reverted afterwards.

Biome clean; no new lint errors. The `playground-integration-test` CI job will also execute this.

This pull request and its description were written by Isaac.