### PR TITLE
fix(appkit-ui): dark mode fixes for charts

### DIFF
--- a/apps/dev-playground/client/src/components/lakebase/ActivityLogsPanel.tsx
+++ b/apps/dev-playground/client/src/components/lakebase/ActivityLogsPanel.tsx
@@ -202,7 +202,7 @@ export function ActivityLogsPanel() {
         <CardContent>
           {logsLoading && (
             <div className="flex items-center gap-2 text-warning py-8">
-              <div className="w-2 h-2 bg-amber-500 rounded-full animate-pulse" />
+              <div className="w-2 h-2 bg-warning rounded-full animate-pulse" />
               Loading activity logs...
             </div>
           )}

--- a/apps/dev-playground/client/src/components/lakebase/OboProductsPanel.tsx
+++ b/apps/dev-playground/client/src/components/lakebase/OboProductsPanel.tsx
@@ -100,11 +100,11 @@ export function OboProductsPanel() {
   return (
     <div className="space-y-4">
       {/* Header */}
-      <Card className="border-2 border-amber-200">
+      <Card className="border border-warning/30">
         <CardHeader className="pb-0 gap-0">
           <div className="flex items-center gap-3">
-            <div className="p-2 bg-amber-100 rounded-lg flex-shrink-0 self-start">
-              <ShieldCheck className="h-6 w-6 text-amber-600" />
+            <div className="p-2 bg-warning/10 rounded-lg flex-shrink-0 self-start">
+              <ShieldCheck className="h-6 w-6 text-warning" />
             </div>
             <div className="flex-1 min-w-0">
               <CardTitle>Raw Driver — On-Behalf-Of (OBO)</CardTitle>
@@ -222,7 +222,7 @@ export function OboProductsPanel() {
       {/* Side-by-side comparison */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
         {/* My products (OBO, RLS filtered) */}
-        <Card className="border-amber-200">
+        <Card className="border-warning/30">
           <CardHeader>
             <div className="flex items-center justify-between">
               <div>
@@ -242,7 +242,7 @@ export function OboProductsPanel() {
           <CardContent>
             {myLoading && (
               <div className="flex items-center gap-2 text-warning py-4">
-                <div className="w-2 h-2 bg-amber-500 rounded-full animate-pulse" />
+                <div className="w-2 h-2 bg-warning rounded-full animate-pulse" />
                 Loading...
               </div>
             )}
@@ -283,7 +283,7 @@ export function OboProductsPanel() {
           <CardContent>
             {allLoading && (
               <div className="flex items-center gap-2 text-warning py-4">
-                <div className="w-2 h-2 bg-amber-500 rounded-full animate-pulse" />
+                <div className="w-2 h-2 bg-warning rounded-full animate-pulse" />
                 Loading...
               </div>
             )}

--- a/apps/dev-playground/client/src/components/lakebase/OrdersPanel.tsx
+++ b/apps/dev-playground/client/src/components/lakebase/OrdersPanel.tsx
@@ -338,7 +338,7 @@ export function OrdersPanel() {
         <CardContent>
           {ordersLoading && (
             <div className="flex items-center gap-2 text-warning py-8">
-              <div className="w-2 h-2 bg-amber-500 rounded-full animate-pulse" />
+              <div className="w-2 h-2 bg-warning rounded-full animate-pulse" />
               Loading orders...
             </div>
           )}

--- a/apps/dev-playground/client/src/components/lakebase/TasksPanel.tsx
+++ b/apps/dev-playground/client/src/components/lakebase/TasksPanel.tsx
@@ -273,7 +273,7 @@ export function TasksPanel() {
         <CardContent>
           {tasksLoading && (
             <div className="flex items-center gap-2 text-warning py-8">
-              <div className="w-2 h-2 bg-amber-500 rounded-full animate-pulse" />
+              <div className="w-2 h-2 bg-warning rounded-full animate-pulse" />
               Loading tasks...
             </div>
           )}

--- a/docs/static/appkit-ui/styles.gen.css
+++ b/docs/static/appkit-ui/styles.gen.css
@@ -594,6 +594,9 @@
   .h-3 {
     height: calc(var(--spacing) * 3);
   }
+  .h-3\.5 {
+    height: calc(var(--spacing) * 3.5);
+  }
   .h-4 {
     height: calc(var(--spacing) * 4);
   }
@@ -725,6 +728,9 @@
   }
   .w-3 {
     width: calc(var(--spacing) * 3);
+  }
+  .w-3\.5 {
+    width: calc(var(--spacing) * 3.5);
   }
   .w-3\/4 {
     width: calc(3/4 * 100%);
@@ -1267,6 +1273,12 @@
       border-color: color-mix(in oklab, var(--border) 50%, transparent);
     }
   }
+  .border-border\/60 {
+    border-color: var(--border);
+    @supports (color: color-mix(in lab, red, red)) {
+      border-color: color-mix(in oklab, var(--border) 60%, transparent);
+    }
+  }
   .border-input {
     border-color: var(--input);
   }
@@ -1727,6 +1739,9 @@
   }
   .opacity-50 {
     opacity: 50%;
+  }
+  .opacity-60 {
+    opacity: 60%;
   }
   .opacity-70 {
     opacity: 70%;
@@ -5378,6 +5393,7 @@
 }
 :root {
   --radius: 0.625rem;
+  color-scheme: light;
   --background: oklch(1 0 0);
   --foreground: oklch(0.141 0.005 285.823);
   --card: oklch(1 0 0);
@@ -5425,6 +5441,19 @@
   --chart-div-6: hsla(10, 60%, 65%, 1);
   --chart-div-7: hsla(10, 72%, 50%, 1);
   --chart-div-8: hsla(10, 80%, 40%, 1);
+  --chart-axis-label: hsla(
+    240,
+    4%,
+    46%,
+    1
+  );
+  --chart-axis-title: hsla(
+    240,
+    6%,
+    10%,
+    1
+  );
+  --chart-grid: hsla(240, 5%, 90%, 1);
   --chart-1: var(--chart-cat-1);
   --chart-2: var(--chart-cat-2);
   --chart-3: var(--chart-cat-3);
@@ -5443,6 +5472,7 @@
   --sidebar-ring: oklch(0.705 0.015 286.067);
 }
 .dark {
+  color-scheme: dark;
   --background: oklch(0.141 0.005 285.823);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.21 0.006 285.885);
@@ -5466,11 +5496,41 @@
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.552 0.016 285.938);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
+  --chart-cat-1: hsla(217, 91%, 65%, 1);
+  --chart-cat-2: hsla(160, 65%, 55%, 1);
+  --chart-cat-3: hsla(291, 60%, 65%, 1);
+  --chart-cat-4: hsla(38, 95%, 60%, 1);
+  --chart-cat-5: hsla(349, 80%, 62%, 1);
+  --chart-cat-6: hsla(189, 85%, 52%, 1);
+  --chart-cat-7: hsla(271, 65%, 70%, 1);
+  --chart-cat-8: hsla(142, 60%, 55%, 1);
+  --chart-seq-1: hsla(217, 50%, 25%, 1);
+  --chart-seq-2: hsla(217, 55%, 35%, 1);
+  --chart-seq-3: hsla(217, 60%, 45%, 1);
+  --chart-seq-4: hsla(217, 65%, 55%, 1);
+  --chart-seq-5: hsla(217, 70%, 62%, 1);
+  --chart-seq-6: hsla(217, 75%, 70%, 1);
+  --chart-seq-7: hsla(217, 80%, 78%, 1);
+  --chart-seq-8: hsla(217, 85%, 88%, 1);
+  --chart-div-1: hsla(217, 85%, 70%, 1);
+  --chart-div-2: hsla(217, 70%, 60%, 1);
+  --chart-div-3: hsla(217, 50%, 50%, 1);
+  --chart-div-4: hsla(217, 25%, 40%, 1);
+  --chart-div-5: hsla(10, 25%, 40%, 1);
+  --chart-div-6: hsla(10, 55%, 50%, 1);
+  --chart-div-7: hsla(10, 70%, 58%, 1);
+  --chart-div-8: hsla(10, 80%, 65%, 1);
+  --chart-1: var(--chart-cat-1);
+  --chart-2: var(--chart-cat-2);
+  --chart-3: var(--chart-cat-3);
+  --chart-4: var(--chart-cat-4);
+  --chart-5: var(--chart-cat-5);
+  --chart-6: var(--chart-cat-6);
+  --chart-7: var(--chart-cat-7);
+  --chart-8: var(--chart-cat-8);
+  --chart-axis-label: hsla(240, 5%, 65%, 1);
+  --chart-axis-title: hsla(0, 0%, 98%, 1);
+  --chart-grid: hsla(0, 0%, 100%, 0.1);
   --sidebar: oklch(0.21 0.006 285.885);
   --sidebar-foreground: oklch(0.985 0 0);
   --sidebar-primary: oklch(0.488 0.243 264.376);
@@ -5482,6 +5542,7 @@
 }
 @media (prefers-color-scheme: dark) {
   :root:not(.light) {
+    color-scheme: dark;
     --background: oklch(0.141 0.005 285.823);
     --foreground: oklch(0.985 0 0);
     --card: oklch(0.21 0.006 285.885);
@@ -5534,6 +5595,9 @@
     --chart-div-6: hsla(10, 55%, 50%, 1);
     --chart-div-7: hsla(10, 70%, 58%, 1);
     --chart-div-8: hsla(10, 80%, 65%, 1);
+    --chart-axis-label: hsla(240, 5%, 65%, 1);
+    --chart-axis-title: hsla(0, 0%, 98%, 1);
+    --chart-grid: hsla(0, 0%, 100%, 0.1);
     --chart-1: var(--chart-cat-1);
     --chart-2: var(--chart-cat-2);
     --chart-3: var(--chart-cat-3);

--- a/docs/static/appkit-ui/styles.gen.css
+++ b/docs/static/appkit-ui/styles.gen.css
@@ -5441,18 +5441,8 @@
   --chart-div-6: hsla(10, 60%, 65%, 1);
   --chart-div-7: hsla(10, 72%, 50%, 1);
   --chart-div-8: hsla(10, 80%, 40%, 1);
-  --chart-axis-label: hsla(
-    240,
-    4%,
-    46%,
-    1
-  );
-  --chart-axis-title: hsla(
-    240,
-    6%,
-    10%,
-    1
-  );
+  --chart-axis-label: hsla(240, 4%, 46%, 1);
+  --chart-axis-title: hsla(240, 6%, 10%, 1);
   --chart-grid: hsla(240, 5%, 90%, 1);
   --chart-1: var(--chart-cat-1);
   --chart-2: var(--chart-cat-2);

--- a/docs/static/appkit-ui/styles.gen.css
+++ b/docs/static/appkit-ui/styles.gen.css
@@ -5444,6 +5444,7 @@
   --chart-axis-label: hsla(240, 4%, 46%, 1);
   --chart-axis-title: hsla(240, 6%, 10%, 1);
   --chart-grid: hsla(240, 5%, 90%, 1);
+  --chart-tooltip-bg: hsla(0, 0%, 100%, 1);
   --chart-1: var(--chart-cat-1);
   --chart-2: var(--chart-cat-2);
   --chart-3: var(--chart-cat-3);
@@ -5521,6 +5522,7 @@
   --chart-axis-label: hsla(240, 5%, 65%, 1);
   --chart-axis-title: hsla(0, 0%, 98%, 1);
   --chart-grid: hsla(0, 0%, 100%, 0.1);
+  --chart-tooltip-bg: hsla(240, 6%, 13%, 1);
   --sidebar: oklch(0.21 0.006 285.885);
   --sidebar-foreground: oklch(0.985 0 0);
   --sidebar-primary: oklch(0.488 0.243 264.376);
@@ -5588,6 +5590,7 @@
     --chart-axis-label: hsla(240, 5%, 65%, 1);
     --chart-axis-title: hsla(0, 0%, 98%, 1);
     --chart-grid: hsla(0, 0%, 100%, 0.1);
+    --chart-tooltip-bg: hsla(240, 6%, 13%, 1);
     --chart-1: var(--chart-cat-1);
     --chart-2: var(--chart-cat-2);
     --chart-3: var(--chart-cat-3);

--- a/packages/appkit-ui/src/react/charts/__tests__/options.test.ts
+++ b/packages/appkit-ui/src/react/charts/__tests__/options.test.ts
@@ -58,6 +58,13 @@ function asRadarOption(result: Record<string, unknown>): RadarOption {
   return result as unknown as RadarOption;
 }
 
+// Distinct chrome tokens so theming assertions are unambiguous
+const TEST_UI = {
+  axisLabel: "#a11111",
+  axisTitle: "#b22222",
+  grid: "#c33333",
+};
+
 // Base context used across tests
 const createBaseContext = (
   overrides: Partial<OptionBuilderContext> = {},
@@ -68,6 +75,7 @@ const createBaseContext = (
   colors: ["#ff0000", "#00ff00", "#0000ff"],
   title: "Test Chart",
   showLegend: true,
+  ui: TEST_UI,
   ...overrides,
 });
 
@@ -588,6 +596,7 @@ describe("buildHeatmapOption", () => {
     colors: ["#ebedf0", "#9be9a8", "#40c463", "#30a14e", "#216e39"],
     title: "Activity Heatmap",
     showLegend: false,
+    ui: TEST_UI,
     // Heatmap-specific
     yAxisData: ["Mon", "Tue", "Wed"],
     heatmapData: [
@@ -672,5 +681,111 @@ describe("buildHeatmapOption", () => {
     expect(output).toBe(
       "&lt;img src=x onerror=alert(1)&gt;, &lt;script&gt;alert(2)&lt;/script&gt;: 10",
     );
+  });
+});
+
+describe("axis & chrome theming", () => {
+  type AxisShape = {
+    axisLabel: { color?: string; rotate?: number; width?: number };
+    axisLine: { lineStyle: { color: string } };
+    axisTick: { lineStyle: { color: string } };
+    splitLine: { lineStyle: { color: string } };
+    nameTextStyle?: { color: string };
+  };
+  type TextStyled = { textStyle: { color: string } };
+
+  test("applies ui tokens to cartesian axes, title, and legend", () => {
+    const ctx = createBaseContext({
+      yFields: ["a", "b"],
+      yDataMap: { a: [1, 2], b: [3, 4] },
+    });
+    const opt = buildCartesianOption({
+      ...ctx,
+      chartType: "bar",
+      isTimeSeries: false,
+      stacked: false,
+      smooth: false,
+      showSymbol: false,
+      symbolSize: 8,
+    });
+
+    const xAxis = opt.xAxis as AxisShape;
+    const yAxis = opt.yAxis as AxisShape;
+    expect(xAxis.axisLabel.color).toBe(TEST_UI.axisLabel);
+    expect(xAxis.axisLine.lineStyle.color).toBe(TEST_UI.grid);
+    expect(yAxis.axisLabel.color).toBe(TEST_UI.axisLabel);
+    expect(yAxis.splitLine.lineStyle.color).toBe(TEST_UI.grid);
+    expect((opt.title as TextStyled).textStyle.color).toBe(TEST_UI.axisTitle);
+    expect((opt.legend as TextStyled).textStyle.color).toBe(TEST_UI.axisTitle);
+  });
+
+  test("preserves x-axis formatter/rotate while setting label color", () => {
+    const ctx = createBaseContext({
+      xData: Array.from({ length: 15 }, (_, i) => `Item${i}`),
+      yDataMap: { value: Array(15).fill(10) },
+    });
+    const opt = buildCartesianOption({
+      ...ctx,
+      chartType: "bar",
+      isTimeSeries: false,
+      stacked: false,
+      smooth: false,
+      showSymbol: false,
+      symbolSize: 8,
+    });
+
+    const xAxis = opt.xAxis as AxisShape;
+    expect(xAxis.axisLabel.color).toBe(TEST_UI.axisLabel);
+    expect(xAxis.axisLabel.rotate).toBe(45);
+  });
+
+  test("applies ui tokens to horizontal bar axes (preserving label width)", () => {
+    const ctx = createBaseContext();
+    const opt = buildHorizontalBarOption(ctx, false);
+
+    const xAxis = opt.xAxis as AxisShape;
+    const yAxis = opt.yAxis as AxisShape;
+    expect(yAxis.axisLabel.color).toBe(TEST_UI.axisLabel);
+    expect(yAxis.axisLabel.width).toBe(100);
+    expect(xAxis.axisLine.lineStyle.color).toBe(TEST_UI.grid);
+  });
+
+  test("applies ui tokens to heatmap axes and visualMap", () => {
+    const ctx: HeatmapContext = {
+      ...createBaseContext({ showLegend: false }),
+      yAxisData: ["Mon", "Tue"],
+      heatmapData: [
+        [0, 0, 10],
+        [1, 0, 20],
+      ],
+      min: 10,
+      max: 20,
+      showLabels: false,
+    };
+    const opt = buildHeatmapOption(ctx);
+
+    expect((opt.xAxis as AxisShape).axisLabel.color).toBe(TEST_UI.axisLabel);
+    expect((opt.yAxis as AxisShape).axisLabel.color).toBe(TEST_UI.axisLabel);
+    expect((opt.visualMap as TextStyled).textStyle.color).toBe(
+      TEST_UI.axisTitle,
+    );
+  });
+
+  test("applies ui tokens to pie legend", () => {
+    const ctx = createBaseContext({ showLegend: true });
+    const opt = buildPieOption(ctx, "pie", 0, true, "outside");
+    expect((opt.legend as TextStyled).textStyle.color).toBe(TEST_UI.axisTitle);
+  });
+
+  test("applies ui tokens to radar chrome", () => {
+    const ctx = createBaseContext();
+    const opt = buildRadarOption(ctx, true);
+    const radar = opt.radar as {
+      axisName: { color: string };
+      axisLine: { lineStyle: { color: string } };
+      splitLine: { lineStyle: { color: string } };
+    };
+    expect(radar.axisName.color).toBe(TEST_UI.axisTitle);
+    expect(radar.splitLine.lineStyle.color).toBe(TEST_UI.grid);
   });
 });

--- a/packages/appkit-ui/src/react/charts/__tests__/options.test.ts
+++ b/packages/appkit-ui/src/react/charts/__tests__/options.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+import { FALLBACK_UI_TOKENS } from "../constants";
 import {
   buildCartesianOption,
   buildHeatmapOption,
@@ -787,5 +788,66 @@ describe("axis & chrome theming", () => {
     };
     expect(radar.axisName.color).toBe(TEST_UI.axisTitle);
     expect(radar.splitLine.lineStyle.color).toBe(TEST_UI.grid);
+  });
+
+  test("applies ui tokens to radar legend (multi-series)", () => {
+    const ctx = createBaseContext({
+      yFields: ["a", "b"],
+      yDataMap: { a: [1, 2, 3], b: [4, 5, 6] },
+      showLegend: true,
+    });
+    const opt = buildRadarOption(ctx, true);
+    expect((opt.legend as TextStyled).textStyle.color).toBe(TEST_UI.axisTitle);
+  });
+
+  test("applies axis-label color on scatter x-axis", () => {
+    const ctx = createBaseContext();
+    const opt = buildCartesianOption({
+      ...ctx,
+      chartType: "scatter",
+      isTimeSeries: false,
+      stacked: false,
+      smooth: false,
+      showSymbol: false,
+      symbolSize: 8,
+    });
+    expect((opt.xAxis as AxisShape).axisLabel.color).toBe(TEST_UI.axisLabel);
+  });
+
+  test("applies axis-label color on time-series x-axis", () => {
+    const ctx = createBaseContext();
+    const opt = buildCartesianOption({
+      ...ctx,
+      chartType: "line",
+      isTimeSeries: true,
+      stacked: false,
+      smooth: false,
+      showSymbol: false,
+      symbolSize: 8,
+    });
+    expect((opt.xAxis as AxisShape).axisLabel.color).toBe(TEST_UI.axisLabel);
+  });
+
+  test("falls back to default chrome tokens when ui is omitted", () => {
+    const ctx = createBaseContext({ ui: undefined });
+    const opt = buildCartesianOption({
+      ...ctx,
+      chartType: "bar",
+      isTimeSeries: false,
+      stacked: false,
+      smooth: false,
+      showSymbol: false,
+      symbolSize: 8,
+    });
+
+    expect((opt.xAxis as AxisShape).axisLabel.color).toBe(
+      FALLBACK_UI_TOKENS.axisLabel,
+    );
+    expect((opt.yAxis as AxisShape).splitLine.lineStyle.color).toBe(
+      FALLBACK_UI_TOKENS.grid,
+    );
+    expect((opt.title as TextStyled).textStyle.color).toBe(
+      FALLBACK_UI_TOKENS.axisTitle,
+    );
   });
 });

--- a/packages/appkit-ui/src/react/charts/__tests__/options.test.ts
+++ b/packages/appkit-ui/src/react/charts/__tests__/options.test.ts
@@ -15,6 +15,9 @@ interface EChartsOption {
   legend?: unknown;
   tooltip?: {
     formatter?: (params: { data: [number, number, number] }) => string;
+    backgroundColor?: string;
+    borderColor?: string;
+    textStyle?: { color: string };
   };
   xAxis: { type: string; data?: unknown[] };
   yAxis: { type: string; data?: unknown[] };
@@ -59,11 +62,12 @@ function asRadarOption(result: Record<string, unknown>): RadarOption {
   return result as unknown as RadarOption;
 }
 
-// Distinct chrome tokens so theming assertions are unambiguous
+// Distinct UI tokens so theming assertions are unambiguous
 const TEST_UI = {
   axisLabel: "#a11111",
   axisTitle: "#b22222",
   grid: "#c33333",
+  tooltipBg: "#d44444",
 };
 
 // Base context used across tests
@@ -685,7 +689,7 @@ describe("buildHeatmapOption", () => {
   });
 });
 
-describe("axis & chrome theming", () => {
+describe("axis & UI theming", () => {
   type AxisShape = {
     axisLabel: { color?: string; rotate?: number; width?: number };
     axisLine: { lineStyle: { color: string } };
@@ -778,7 +782,7 @@ describe("axis & chrome theming", () => {
     expect((opt.legend as TextStyled).textStyle.color).toBe(TEST_UI.axisTitle);
   });
 
-  test("applies ui tokens to radar chrome", () => {
+  test("applies ui tokens to radar", () => {
     const ctx = createBaseContext();
     const opt = buildRadarOption(ctx, true);
     const radar = opt.radar as {
@@ -828,7 +832,7 @@ describe("axis & chrome theming", () => {
     expect((opt.xAxis as AxisShape).axisLabel.color).toBe(TEST_UI.axisLabel);
   });
 
-  test("falls back to default chrome tokens when ui is omitted", () => {
+  test("falls back to default UI tokens when ui is omitted", () => {
     const ctx = createBaseContext({ ui: undefined });
     const opt = buildCartesianOption({
       ...ctx,
@@ -849,5 +853,78 @@ describe("axis & chrome theming", () => {
     expect((opt.title as TextStyled).textStyle.color).toBe(
       FALLBACK_UI_TOKENS.axisTitle,
     );
+    expect((opt.tooltip as { backgroundColor: string }).backgroundColor).toBe(
+      FALLBACK_UI_TOKENS.tooltipBg,
+    );
+  });
+});
+
+describe("tooltip theming", () => {
+  test("themes cartesian tooltip (background, border, text)", () => {
+    const ctx = createBaseContext();
+    const opt = asOption(
+      buildCartesianOption({
+        ...ctx,
+        chartType: "bar",
+        isTimeSeries: false,
+        stacked: false,
+        smooth: false,
+        showSymbol: false,
+        symbolSize: 8,
+      }),
+    );
+
+    expect(opt.tooltip?.backgroundColor).toBe(TEST_UI.tooltipBg);
+    expect(opt.tooltip?.borderColor).toBe(TEST_UI.grid);
+    expect(opt.tooltip?.textStyle?.color).toBe(TEST_UI.axisTitle);
+  });
+
+  test("themes horizontal bar tooltip while keeping axisPointer", () => {
+    const ctx = createBaseContext();
+    const opt = asOption(buildHorizontalBarOption(ctx, false));
+
+    expect(opt.tooltip?.backgroundColor).toBe(TEST_UI.tooltipBg);
+    expect(
+      (opt.tooltip as { axisPointer?: { type: string } }).axisPointer?.type,
+    ).toBe("shadow");
+  });
+
+  test("themes pie tooltip while keeping the formatter", () => {
+    const ctx = createBaseContext();
+    const opt = asOption(buildPieOption(ctx, "pie", 0, true, "outside"));
+
+    expect(opt.tooltip?.backgroundColor).toBe(TEST_UI.tooltipBg);
+    expect(opt.tooltip?.borderColor).toBe(TEST_UI.grid);
+    expect((opt.tooltip as { formatter?: string }).formatter).toBe(
+      "{b}: {c} ({d}%)",
+    );
+  });
+
+  test("themes radar tooltip", () => {
+    const ctx = createBaseContext();
+    const opt = asOption(buildRadarOption(ctx, true));
+
+    expect(opt.tooltip?.backgroundColor).toBe(TEST_UI.tooltipBg);
+    expect(opt.tooltip?.textStyle?.color).toBe(TEST_UI.axisTitle);
+  });
+
+  test("themes heatmap tooltip while keeping the escaping formatter", () => {
+    const ctx: HeatmapContext = {
+      ...createBaseContext({ showLegend: false }),
+      yAxisData: ["Mon", "Tue"],
+      heatmapData: [
+        [0, 0, 10],
+        [1, 0, 20],
+      ],
+      min: 10,
+      max: 20,
+      showLabels: false,
+    };
+    const opt = asOption(buildHeatmapOption(ctx));
+
+    expect(opt.tooltip?.backgroundColor).toBe(TEST_UI.tooltipBg);
+    expect(opt.tooltip?.borderColor).toBe(TEST_UI.grid);
+    // Formatter still runs (and still escapes) on top of the themed tooltip.
+    expect(opt.tooltip?.formatter?.({ data: [0, 0, 10] })).toBe("A, Mon: 10");
   });
 });

--- a/packages/appkit-ui/src/react/charts/__tests__/theme.test.ts
+++ b/packages/appkit-ui/src/react/charts/__tests__/theme.test.ts
@@ -608,17 +608,18 @@ describe("useChartUITokens", () => {
     window.MutationObserver = originalMutationObserver;
   });
 
-  test("returns chrome fallback tokens when CSS vars unavailable", () => {
+  test("returns fallback UI tokens when CSS vars unavailable", () => {
     const { result } = renderHook(() => useChartUITokens());
 
     expect(result.current).toEqual(FALLBACK_UI_TOKENS);
   });
 
-  test("reads chrome tokens from CSS variables by name", () => {
+  test("reads UI tokens from CSS variables by name", () => {
     const values: Record<string, string> = {
       [CHART_UI_VARS.axisLabel]: "rgb(10, 10, 10)",
       [CHART_UI_VARS.axisTitle]: "rgb(20, 20, 20)",
       [CHART_UI_VARS.grid]: "rgb(30, 30, 30)",
+      [CHART_UI_VARS.tooltipBg]: "rgb(40, 40, 40)",
     };
     vi.spyOn(window, "getComputedStyle").mockImplementation(
       () =>
@@ -633,10 +634,11 @@ describe("useChartUITokens", () => {
       axisLabel: "rgb(10, 10, 10)",
       axisTitle: "rgb(20, 20, 20)",
       grid: "rgb(30, 30, 30)",
+      tooltipBg: "rgb(40, 40, 40)",
     });
   });
 
-  test("falls back per field when only some chrome vars resolve", () => {
+  test("falls back per field when only some UI vars resolve", () => {
     // axisTitle intentionally missing — must fall back without shifting the
     // others (the failure mode of the old positional-array resolution).
     const values: Record<string, string> = {
@@ -656,10 +658,11 @@ describe("useChartUITokens", () => {
       axisLabel: "rgb(10, 10, 10)",
       axisTitle: FALLBACK_UI_TOKENS.axisTitle,
       grid: "rgb(30, 30, 30)",
+      tooltipBg: FALLBACK_UI_TOKENS.tooltipBg,
     });
   });
 
-  test("reads each chrome CSS variable by name", () => {
+  test("reads each UI CSS variable by name", () => {
     const getPropertyValueSpy = vi.fn().mockReturnValue("");
     vi.spyOn(window, "getComputedStyle").mockImplementation(
       () =>
@@ -675,61 +678,10 @@ describe("useChartUITokens", () => {
     }
   });
 
+  // Listener wiring (subscribe/cleanup/ref-counting) is shared via
+  // useThemeChangeEffect and covered by useThemeColors + the "shared
+  // theme-change subscription" block; here we only assert token values re-resolve.
   describe("theme change reactivity", () => {
-    test("subscribes to matchMedia color scheme changes", () => {
-      const addEventListenerSpy = vi.fn();
-      const removeEventListenerSpy = vi.fn();
-
-      window.matchMedia = vi.fn().mockImplementation((query) => ({
-        matches: false,
-        media: query,
-        onchange: null,
-        addListener: vi.fn(),
-        removeListener: vi.fn(),
-        addEventListener: addEventListenerSpy,
-        removeEventListener: removeEventListenerSpy,
-        dispatchEvent: vi.fn(),
-      }));
-
-      const { unmount } = renderHook(() => useChartUITokens());
-
-      expect(window.matchMedia).toHaveBeenCalledWith(
-        "(prefers-color-scheme: dark)",
-      );
-      expect(addEventListenerSpy).toHaveBeenCalledWith(
-        "change",
-        expect.any(Function),
-      );
-
-      unmount();
-
-      expect(removeEventListenerSpy).toHaveBeenCalledWith(
-        "change",
-        expect.any(Function),
-      );
-    });
-
-    test("subscribes to MutationObserver for theme attribute changes", () => {
-      const observeSpy = vi.fn();
-      const disconnectSpy = vi.fn();
-
-      window.MutationObserver = vi.fn().mockImplementation(() => ({
-        observe: observeSpy,
-        disconnect: disconnectSpy,
-      }));
-
-      const { unmount } = renderHook(() => useChartUITokens());
-
-      expect(observeSpy).toHaveBeenCalledWith(document.documentElement, {
-        attributes: true,
-        attributeFilter: ["class", "data-theme", "data-mode"],
-      });
-
-      unmount();
-
-      expect(disconnectSpy).toHaveBeenCalled();
-    });
-
     test("updates tokens when system color scheme changes", () => {
       let matchMediaCallback: () => void = () => {};
 
@@ -805,35 +757,6 @@ describe("useChartUITokens", () => {
       });
 
       expect(result.current.axisLabel).toBe("rgb(20, 20, 20)");
-    });
-  });
-
-  describe("effect cleanup", () => {
-    test("removes all listeners on unmount", () => {
-      const removeEventListenerSpy = vi.fn();
-      const disconnectSpy = vi.fn();
-
-      window.matchMedia = vi.fn().mockImplementation((query) => ({
-        matches: false,
-        media: query,
-        onchange: null,
-        addListener: vi.fn(),
-        removeListener: vi.fn(),
-        addEventListener: vi.fn(),
-        removeEventListener: removeEventListenerSpy,
-        dispatchEvent: vi.fn(),
-      }));
-      window.MutationObserver = vi.fn().mockImplementation(() => ({
-        observe: vi.fn(),
-        disconnect: disconnectSpy,
-      }));
-
-      const { unmount } = renderHook(() => useChartUITokens());
-
-      unmount();
-
-      expect(removeEventListenerSpy).toHaveBeenCalled();
-      expect(disconnectSpy).toHaveBeenCalled();
     });
   });
 });

--- a/packages/appkit-ui/src/react/charts/__tests__/theme.test.ts
+++ b/packages/appkit-ui/src/react/charts/__tests__/theme.test.ts
@@ -4,13 +4,16 @@ import {
   CHART_COLOR_VARS_CATEGORICAL,
   CHART_COLOR_VARS_DIVERGING,
   CHART_COLOR_VARS_SEQUENTIAL,
+  CHART_UI_VARS,
   FALLBACK_COLORS_CATEGORICAL,
   FALLBACK_COLORS_DIVERGING,
   FALLBACK_COLORS_SEQUENTIAL,
+  FALLBACK_UI_TOKENS,
 } from "../constants";
 import {
   resetThemeColorCache,
   useAllThemeColors,
+  useChartUITokens,
   useThemeColors,
 } from "../theme";
 import type { ChartColorPalette } from "../types";
@@ -567,5 +570,110 @@ describe("useAllThemeColors", () => {
         expect(typeof color).toBe("string");
       });
     }
+  });
+});
+
+describe("useChartUITokens", () => {
+  const originalGetComputedStyle = window.getComputedStyle;
+  const originalMatchMedia = window.matchMedia;
+  const originalMutationObserver = window.MutationObserver;
+
+  beforeEach(() => {
+    resetThemeColorCache();
+    window.matchMedia = createMockMatchMedia() as typeof window.matchMedia;
+    window.MutationObserver = vi.fn().mockImplementation(() => ({
+      observe: vi.fn(),
+      disconnect: vi.fn(),
+    }));
+    // Default: empty CSS variables → fallbacks
+    vi.spyOn(window, "getComputedStyle").mockImplementation(
+      () =>
+        ({
+          getPropertyValue: () => "",
+        }) as unknown as CSSStyleDeclaration,
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.getComputedStyle = originalGetComputedStyle;
+    window.matchMedia = originalMatchMedia;
+    window.MutationObserver = originalMutationObserver;
+  });
+
+  test("returns fallback tokens when CSS vars unavailable", () => {
+    const { result } = renderHook(() => useChartUITokens());
+
+    expect(result.current).toEqual(FALLBACK_UI_TOKENS);
+  });
+
+  test("reads chrome colors from CSS variables", () => {
+    const values: Record<string, string> = {
+      [CHART_UI_VARS.axisLabel]: "rgb(10, 10, 10)",
+      [CHART_UI_VARS.axisTitle]: "rgb(20, 20, 20)",
+      [CHART_UI_VARS.grid]: "rgb(30, 30, 30)",
+    };
+    vi.spyOn(window, "getComputedStyle").mockImplementation(
+      () =>
+        ({
+          getPropertyValue: (prop: string) => values[prop] || "",
+        }) as unknown as CSSStyleDeclaration,
+    );
+
+    const { result } = renderHook(() => useChartUITokens());
+
+    expect(result.current).toEqual({
+      axisLabel: "rgb(10, 10, 10)",
+      axisTitle: "rgb(20, 20, 20)",
+      grid: "rgb(30, 30, 30)",
+    });
+  });
+
+  test("falls back per-token when a single var is missing", () => {
+    const values: Record<string, string> = {
+      [CHART_UI_VARS.axisLabel]: "rgb(10, 10, 10)",
+    };
+    vi.spyOn(window, "getComputedStyle").mockImplementation(
+      () =>
+        ({
+          getPropertyValue: (prop: string) => values[prop] || "",
+        }) as unknown as CSSStyleDeclaration,
+    );
+
+    const { result } = renderHook(() => useChartUITokens());
+
+    expect(result.current.axisLabel).toBe("rgb(10, 10, 10)");
+    expect(result.current.axisTitle).toBe(FALLBACK_UI_TOKENS.axisTitle);
+    expect(result.current.grid).toBe(FALLBACK_UI_TOKENS.grid);
+  });
+
+  test("updates tokens when theme attributes change", () => {
+    let mutationCallback: () => void = () => {};
+    window.MutationObserver = vi.fn().mockImplementation((cb) => {
+      mutationCallback = cb;
+      return { observe: vi.fn(), disconnect: vi.fn() };
+    });
+
+    let call = 0;
+    vi.spyOn(window, "getComputedStyle").mockImplementation(
+      () =>
+        ({
+          getPropertyValue: (prop: string) => {
+            if (prop === CHART_UI_VARS.axisLabel) {
+              return call++ === 0 ? "rgb(1, 1, 1)" : "rgb(9, 9, 9)";
+            }
+            return "";
+          },
+        }) as unknown as CSSStyleDeclaration,
+    );
+
+    const { result } = renderHook(() => useChartUITokens());
+    expect(result.current.axisLabel).toBe("rgb(1, 1, 1)");
+
+    act(() => {
+      mutationCallback();
+    });
+
+    expect(result.current.axisLabel).toBe("rgb(9, 9, 9)");
   });
 });

--- a/packages/appkit-ui/src/react/charts/__tests__/theme.test.ts
+++ b/packages/appkit-ui/src/react/charts/__tests__/theme.test.ts
@@ -2,17 +2,18 @@ import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   CHART_COLOR_VARS_CATEGORICAL,
-  CHART_COLOR_VARS_CHROME,
   CHART_COLOR_VARS_DIVERGING,
   CHART_COLOR_VARS_SEQUENTIAL,
+  CHART_UI_VARS,
   FALLBACK_COLORS_CATEGORICAL,
-  FALLBACK_COLORS_CHROME,
   FALLBACK_COLORS_DIVERGING,
   FALLBACK_COLORS_SEQUENTIAL,
+  FALLBACK_UI_TOKENS,
 } from "../constants";
 import {
-  resetThemeColorCache,
+  resetThemeCache,
   useAllThemeColors,
+  useChartUITokens,
   useThemeColors,
 } from "../theme";
 import type { ChartColorPalette } from "../types";
@@ -38,7 +39,7 @@ describe("useThemeColors", () => {
 
   beforeEach(() => {
     // Reset the module-level cache before each test
-    resetThemeColorCache();
+    resetThemeCache();
 
     // Mock matchMedia
     window.matchMedia = createMockMatchMedia() as typeof window.matchMedia;
@@ -450,7 +451,7 @@ describe("useThemeColors", () => {
       expect(disconnectSpy).toHaveBeenCalled();
     });
 
-    test("cleans up old listeners when palette changes", () => {
+    test("does not churn listeners when palette changes", () => {
       const removeEventListenerSpy = vi.fn();
       const disconnectSpy = vi.fn();
       const addEventListenerSpy = vi.fn();
@@ -472,24 +473,31 @@ describe("useThemeColors", () => {
         disconnect: disconnectSpy,
       }));
 
-      const { rerender } = renderHook(
+      const { rerender, unmount } = renderHook(
         ({ palette }: { palette: ChartColorPalette }) =>
           useThemeColors(palette),
         { initialProps: { palette: "categorical" as ChartColorPalette } },
       );
 
-      // Initial setup
+      // Initial setup: one shared listener + observer.
       expect(addEventListenerSpy).toHaveBeenCalledTimes(1);
       expect(observeSpy).toHaveBeenCalledTimes(1);
 
-      // Change palette
+      // Changing the palette swaps the hook's callback but must NOT re-install
+      // the shared listeners — this is the per-render subscription churn the
+      // shared subscriber removes.
       rerender({ palette: "sequential" as ChartColorPalette });
 
-      // Old listeners should be cleaned up, new ones set up
+      expect(removeEventListenerSpy).not.toHaveBeenCalled();
+      expect(disconnectSpy).not.toHaveBeenCalled();
+      expect(addEventListenerSpy).toHaveBeenCalledTimes(1);
+      expect(observeSpy).toHaveBeenCalledTimes(1);
+
+      // Listeners are torn down only when the hook unmounts.
+      unmount();
+
       expect(removeEventListenerSpy).toHaveBeenCalledTimes(1);
       expect(disconnectSpy).toHaveBeenCalledTimes(1);
-      expect(addEventListenerSpy).toHaveBeenCalledTimes(2);
-      expect(observeSpy).toHaveBeenCalledTimes(2);
     });
   });
 });
@@ -501,7 +509,7 @@ describe("useAllThemeColors", () => {
 
   beforeEach(() => {
     // Reset the module-level cache before each test
-    resetThemeColorCache();
+    resetThemeCache();
 
     // Mock matchMedia
     window.matchMedia = createMockMatchMedia() as typeof window.matchMedia;
@@ -572,13 +580,18 @@ describe("useAllThemeColors", () => {
   });
 });
 
-describe('useThemeColors("chrome")', () => {
+describe("useChartUITokens", () => {
   const originalGetComputedStyle = window.getComputedStyle;
   const originalMatchMedia = window.matchMedia;
+  const originalMutationObserver = window.MutationObserver;
 
   beforeEach(() => {
-    resetThemeColorCache();
+    resetThemeCache();
     window.matchMedia = createMockMatchMedia() as typeof window.matchMedia;
+    window.MutationObserver = vi.fn().mockImplementation(() => ({
+      observe: vi.fn(),
+      disconnect: vi.fn(),
+    }));
     // Default: empty CSS variables → fallbacks
     vi.spyOn(window, "getComputedStyle").mockImplementation(
       () =>
@@ -592,19 +605,20 @@ describe('useThemeColors("chrome")', () => {
     vi.restoreAllMocks();
     window.getComputedStyle = originalGetComputedStyle;
     window.matchMedia = originalMatchMedia;
+    window.MutationObserver = originalMutationObserver;
   });
 
-  test("returns chrome fallback colors when CSS vars unavailable", () => {
-    const { result } = renderHook(() => useThemeColors("chrome"));
+  test("returns chrome fallback tokens when CSS vars unavailable", () => {
+    const { result } = renderHook(() => useChartUITokens());
 
-    expect(result.current).toEqual(FALLBACK_COLORS_CHROME);
+    expect(result.current).toEqual(FALLBACK_UI_TOKENS);
   });
 
-  test("reads chrome colors from CSS variables in order", () => {
+  test("reads chrome tokens from CSS variables by name", () => {
     const values: Record<string, string> = {
-      [CHART_COLOR_VARS_CHROME[0]]: "rgb(10, 10, 10)",
-      [CHART_COLOR_VARS_CHROME[1]]: "rgb(20, 20, 20)",
-      [CHART_COLOR_VARS_CHROME[2]]: "rgb(30, 30, 30)",
+      [CHART_UI_VARS.axisLabel]: "rgb(10, 10, 10)",
+      [CHART_UI_VARS.axisTitle]: "rgb(20, 20, 20)",
+      [CHART_UI_VARS.grid]: "rgb(30, 30, 30)",
     };
     vi.spyOn(window, "getComputedStyle").mockImplementation(
       () =>
@@ -613,16 +627,39 @@ describe('useThemeColors("chrome")', () => {
         }) as unknown as CSSStyleDeclaration,
     );
 
-    const { result } = renderHook(() => useThemeColors("chrome"));
+    const { result } = renderHook(() => useChartUITokens());
 
-    expect(result.current).toEqual([
-      "rgb(10, 10, 10)",
-      "rgb(20, 20, 20)",
-      "rgb(30, 30, 30)",
-    ]);
+    expect(result.current).toEqual({
+      axisLabel: "rgb(10, 10, 10)",
+      axisTitle: "rgb(20, 20, 20)",
+      grid: "rgb(30, 30, 30)",
+    });
   });
 
-  test("reads the chrome CSS variables in order", () => {
+  test("falls back per field when only some chrome vars resolve", () => {
+    // axisTitle intentionally missing — must fall back without shifting the
+    // others (the failure mode of the old positional-array resolution).
+    const values: Record<string, string> = {
+      [CHART_UI_VARS.axisLabel]: "rgb(10, 10, 10)",
+      [CHART_UI_VARS.grid]: "rgb(30, 30, 30)",
+    };
+    vi.spyOn(window, "getComputedStyle").mockImplementation(
+      () =>
+        ({
+          getPropertyValue: (prop: string) => values[prop] || "",
+        }) as unknown as CSSStyleDeclaration,
+    );
+
+    const { result } = renderHook(() => useChartUITokens());
+
+    expect(result.current).toEqual({
+      axisLabel: "rgb(10, 10, 10)",
+      axisTitle: FALLBACK_UI_TOKENS.axisTitle,
+      grid: "rgb(30, 30, 30)",
+    });
+  });
+
+  test("reads each chrome CSS variable by name", () => {
     const getPropertyValueSpy = vi.fn().mockReturnValue("");
     vi.spyOn(window, "getComputedStyle").mockImplementation(
       () =>
@@ -631,10 +668,238 @@ describe('useThemeColors("chrome")', () => {
         }) as unknown as CSSStyleDeclaration,
     );
 
-    renderHook(() => useThemeColors("chrome"));
+    renderHook(() => useChartUITokens());
 
-    for (const varName of CHART_COLOR_VARS_CHROME) {
+    for (const varName of Object.values(CHART_UI_VARS)) {
       expect(getPropertyValueSpy).toHaveBeenCalledWith(varName);
     }
+  });
+
+  describe("theme change reactivity", () => {
+    test("subscribes to matchMedia color scheme changes", () => {
+      const addEventListenerSpy = vi.fn();
+      const removeEventListenerSpy = vi.fn();
+
+      window.matchMedia = vi.fn().mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: addEventListenerSpy,
+        removeEventListener: removeEventListenerSpy,
+        dispatchEvent: vi.fn(),
+      }));
+
+      const { unmount } = renderHook(() => useChartUITokens());
+
+      expect(window.matchMedia).toHaveBeenCalledWith(
+        "(prefers-color-scheme: dark)",
+      );
+      expect(addEventListenerSpy).toHaveBeenCalledWith(
+        "change",
+        expect.any(Function),
+      );
+
+      unmount();
+
+      expect(removeEventListenerSpy).toHaveBeenCalledWith(
+        "change",
+        expect.any(Function),
+      );
+    });
+
+    test("subscribes to MutationObserver for theme attribute changes", () => {
+      const observeSpy = vi.fn();
+      const disconnectSpy = vi.fn();
+
+      window.MutationObserver = vi.fn().mockImplementation(() => ({
+        observe: observeSpy,
+        disconnect: disconnectSpy,
+      }));
+
+      const { unmount } = renderHook(() => useChartUITokens());
+
+      expect(observeSpy).toHaveBeenCalledWith(document.documentElement, {
+        attributes: true,
+        attributeFilter: ["class", "data-theme", "data-mode"],
+      });
+
+      unmount();
+
+      expect(disconnectSpy).toHaveBeenCalled();
+    });
+
+    test("updates tokens when system color scheme changes", () => {
+      let matchMediaCallback: () => void = () => {};
+
+      window.matchMedia = vi.fn().mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: (_event: string, callback: () => void) => {
+          matchMediaCallback = callback;
+        },
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }));
+      window.MutationObserver = vi.fn().mockImplementation(() => ({
+        observe: vi.fn(),
+        disconnect: vi.fn(),
+      }));
+
+      let callCount = 0;
+      vi.spyOn(window, "getComputedStyle").mockImplementation(() => {
+        return {
+          getPropertyValue: (prop: string) => {
+            if (prop === CHART_UI_VARS.axisLabel) {
+              return callCount++ === 0 ? "rgb(1, 1, 1)" : "rgb(2, 2, 2)";
+            }
+            return "";
+          },
+        } as unknown as CSSStyleDeclaration;
+      });
+
+      const { result } = renderHook(() => useChartUITokens());
+
+      expect(result.current.axisLabel).toBe("rgb(1, 1, 1)");
+
+      act(() => {
+        matchMediaCallback();
+      });
+
+      expect(result.current.axisLabel).toBe("rgb(2, 2, 2)");
+    });
+
+    test("updates tokens when theme attributes change via MutationObserver", () => {
+      let mutationCallback: () => void = () => {};
+
+      window.MutationObserver = vi.fn().mockImplementation((callback) => {
+        mutationCallback = callback;
+        return {
+          observe: vi.fn(),
+          disconnect: vi.fn(),
+        };
+      });
+
+      let callCount = 0;
+      vi.spyOn(window, "getComputedStyle").mockImplementation(() => {
+        return {
+          getPropertyValue: (prop: string) => {
+            if (prop === CHART_UI_VARS.axisLabel) {
+              return callCount++ === 0 ? "rgb(10, 10, 10)" : "rgb(20, 20, 20)";
+            }
+            return "";
+          },
+        } as unknown as CSSStyleDeclaration;
+      });
+
+      const { result } = renderHook(() => useChartUITokens());
+
+      expect(result.current.axisLabel).toBe("rgb(10, 10, 10)");
+
+      act(() => {
+        mutationCallback();
+      });
+
+      expect(result.current.axisLabel).toBe("rgb(20, 20, 20)");
+    });
+  });
+
+  describe("effect cleanup", () => {
+    test("removes all listeners on unmount", () => {
+      const removeEventListenerSpy = vi.fn();
+      const disconnectSpy = vi.fn();
+
+      window.matchMedia = vi.fn().mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: removeEventListenerSpy,
+        dispatchEvent: vi.fn(),
+      }));
+      window.MutationObserver = vi.fn().mockImplementation(() => ({
+        observe: vi.fn(),
+        disconnect: disconnectSpy,
+      }));
+
+      const { unmount } = renderHook(() => useChartUITokens());
+
+      unmount();
+
+      expect(removeEventListenerSpy).toHaveBeenCalled();
+      expect(disconnectSpy).toHaveBeenCalled();
+    });
+  });
+});
+
+describe("shared theme-change subscription", () => {
+  const originalGetComputedStyle = window.getComputedStyle;
+  const originalMatchMedia = window.matchMedia;
+  const originalMutationObserver = window.MutationObserver;
+
+  beforeEach(() => {
+    resetThemeCache();
+    vi.spyOn(window, "getComputedStyle").mockImplementation(
+      () =>
+        ({
+          getPropertyValue: () => "",
+        }) as unknown as CSSStyleDeclaration,
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.getComputedStyle = originalGetComputedStyle;
+    window.matchMedia = originalMatchMedia;
+    window.MutationObserver = originalMutationObserver;
+  });
+
+  test("installs one shared listener for many hooks and releases it only after the last unmounts", () => {
+    const addEventListenerSpy = vi.fn();
+    const removeEventListenerSpy = vi.fn();
+    window.matchMedia = vi.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: addEventListenerSpy,
+      removeEventListener: removeEventListenerSpy,
+      dispatchEvent: vi.fn(),
+    }));
+
+    const observeSpy = vi.fn();
+    const disconnectSpy = vi.fn();
+    window.MutationObserver = vi.fn().mockImplementation(() => ({
+      observe: observeSpy,
+      disconnect: disconnectSpy,
+    }));
+
+    // Three independent hook instances — what a dashboard with several charts
+    // looks like. The old per-hook design installed three listeners + observers.
+    const a = renderHook(() => useThemeColors("categorical"));
+    const b = renderHook(() => useChartUITokens());
+    const c = renderHook(() => useThemeColors("sequential"));
+
+    expect(window.matchMedia).toHaveBeenCalledTimes(1);
+    expect(addEventListenerSpy).toHaveBeenCalledTimes(1);
+    expect(observeSpy).toHaveBeenCalledTimes(1);
+
+    // Tearing down all but the last keeps the shared listener alive.
+    a.unmount();
+    b.unmount();
+    expect(removeEventListenerSpy).not.toHaveBeenCalled();
+    expect(disconnectSpy).not.toHaveBeenCalled();
+
+    // The final unmount releases the shared listener exactly once.
+    c.unmount();
+    expect(removeEventListenerSpy).toHaveBeenCalledTimes(1);
+    expect(disconnectSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/appkit-ui/src/react/charts/__tests__/theme.test.ts
+++ b/packages/appkit-ui/src/react/charts/__tests__/theme.test.ts
@@ -2,18 +2,17 @@ import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   CHART_COLOR_VARS_CATEGORICAL,
+  CHART_COLOR_VARS_CHROME,
   CHART_COLOR_VARS_DIVERGING,
   CHART_COLOR_VARS_SEQUENTIAL,
-  CHART_UI_VARS,
   FALLBACK_COLORS_CATEGORICAL,
+  FALLBACK_COLORS_CHROME,
   FALLBACK_COLORS_DIVERGING,
   FALLBACK_COLORS_SEQUENTIAL,
-  FALLBACK_UI_TOKENS,
 } from "../constants";
 import {
   resetThemeColorCache,
   useAllThemeColors,
-  useChartUITokens,
   useThemeColors,
 } from "../theme";
 import type { ChartColorPalette } from "../types";
@@ -573,18 +572,13 @@ describe("useAllThemeColors", () => {
   });
 });
 
-describe("useChartUITokens", () => {
+describe('useThemeColors("chrome")', () => {
   const originalGetComputedStyle = window.getComputedStyle;
   const originalMatchMedia = window.matchMedia;
-  const originalMutationObserver = window.MutationObserver;
 
   beforeEach(() => {
     resetThemeColorCache();
     window.matchMedia = createMockMatchMedia() as typeof window.matchMedia;
-    window.MutationObserver = vi.fn().mockImplementation(() => ({
-      observe: vi.fn(),
-      disconnect: vi.fn(),
-    }));
     // Default: empty CSS variables → fallbacks
     vi.spyOn(window, "getComputedStyle").mockImplementation(
       () =>
@@ -598,20 +592,19 @@ describe("useChartUITokens", () => {
     vi.restoreAllMocks();
     window.getComputedStyle = originalGetComputedStyle;
     window.matchMedia = originalMatchMedia;
-    window.MutationObserver = originalMutationObserver;
   });
 
-  test("returns fallback tokens when CSS vars unavailable", () => {
-    const { result } = renderHook(() => useChartUITokens());
+  test("returns chrome fallback colors when CSS vars unavailable", () => {
+    const { result } = renderHook(() => useThemeColors("chrome"));
 
-    expect(result.current).toEqual(FALLBACK_UI_TOKENS);
+    expect(result.current).toEqual(FALLBACK_COLORS_CHROME);
   });
 
-  test("reads chrome colors from CSS variables", () => {
+  test("reads chrome colors from CSS variables in order", () => {
     const values: Record<string, string> = {
-      [CHART_UI_VARS.axisLabel]: "rgb(10, 10, 10)",
-      [CHART_UI_VARS.axisTitle]: "rgb(20, 20, 20)",
-      [CHART_UI_VARS.grid]: "rgb(30, 30, 30)",
+      [CHART_COLOR_VARS_CHROME[0]]: "rgb(10, 10, 10)",
+      [CHART_COLOR_VARS_CHROME[1]]: "rgb(20, 20, 20)",
+      [CHART_COLOR_VARS_CHROME[2]]: "rgb(30, 30, 30)",
     };
     vi.spyOn(window, "getComputedStyle").mockImplementation(
       () =>
@@ -620,60 +613,28 @@ describe("useChartUITokens", () => {
         }) as unknown as CSSStyleDeclaration,
     );
 
-    const { result } = renderHook(() => useChartUITokens());
+    const { result } = renderHook(() => useThemeColors("chrome"));
 
-    expect(result.current).toEqual({
-      axisLabel: "rgb(10, 10, 10)",
-      axisTitle: "rgb(20, 20, 20)",
-      grid: "rgb(30, 30, 30)",
-    });
+    expect(result.current).toEqual([
+      "rgb(10, 10, 10)",
+      "rgb(20, 20, 20)",
+      "rgb(30, 30, 30)",
+    ]);
   });
 
-  test("falls back per-token when a single var is missing", () => {
-    const values: Record<string, string> = {
-      [CHART_UI_VARS.axisLabel]: "rgb(10, 10, 10)",
-    };
+  test("reads the chrome CSS variables in order", () => {
+    const getPropertyValueSpy = vi.fn().mockReturnValue("");
     vi.spyOn(window, "getComputedStyle").mockImplementation(
       () =>
         ({
-          getPropertyValue: (prop: string) => values[prop] || "",
+          getPropertyValue: getPropertyValueSpy,
         }) as unknown as CSSStyleDeclaration,
     );
 
-    const { result } = renderHook(() => useChartUITokens());
+    renderHook(() => useThemeColors("chrome"));
 
-    expect(result.current.axisLabel).toBe("rgb(10, 10, 10)");
-    expect(result.current.axisTitle).toBe(FALLBACK_UI_TOKENS.axisTitle);
-    expect(result.current.grid).toBe(FALLBACK_UI_TOKENS.grid);
-  });
-
-  test("updates tokens when theme attributes change", () => {
-    let mutationCallback: () => void = () => {};
-    window.MutationObserver = vi.fn().mockImplementation((cb) => {
-      mutationCallback = cb;
-      return { observe: vi.fn(), disconnect: vi.fn() };
-    });
-
-    let call = 0;
-    vi.spyOn(window, "getComputedStyle").mockImplementation(
-      () =>
-        ({
-          getPropertyValue: (prop: string) => {
-            if (prop === CHART_UI_VARS.axisLabel) {
-              return call++ === 0 ? "rgb(1, 1, 1)" : "rgb(9, 9, 9)";
-            }
-            return "";
-          },
-        }) as unknown as CSSStyleDeclaration,
-    );
-
-    const { result } = renderHook(() => useChartUITokens());
-    expect(result.current.axisLabel).toBe("rgb(1, 1, 1)");
-
-    act(() => {
-      mutationCallback();
-    });
-
-    expect(result.current.axisLabel).toBe("rgb(9, 9, 9)");
+    for (const varName of CHART_COLOR_VARS_CHROME) {
+      expect(getPropertyValueSpy).toHaveBeenCalledWith(varName);
+    }
   });
 });

--- a/packages/appkit-ui/src/react/charts/base.tsx
+++ b/packages/appkit-ui/src/react/charts/base.tsx
@@ -10,7 +10,7 @@ import {
   buildRadarOption,
   type OptionBuilderContext,
 } from "./options";
-import { useThemeColors } from "./theme";
+import { useChartUITokens, useThemeColors } from "./theme";
 import type {
   ChartColorPalette,
   ChartData,
@@ -132,6 +132,9 @@ export function BaseChart({
   const themeColors = useThemeColors(resolvedPalette);
   const colors = customColors ?? themeColors;
 
+  // Chart-chrome colors (axis text, titles, grid lines) for the active theme
+  const ui = useChartUITokens();
+
   // Store ECharts instance directly to avoid stale ref issues on unmount
   const echartsInstanceRef = useRef<ECharts | null>(null);
 
@@ -191,6 +194,7 @@ export function BaseChart({
       title,
       showLegend,
       xField,
+      ui,
     };
     const isPie = chartType === "pie" || chartType === "donut";
     const isRadar = chartType === "radar";
@@ -255,6 +259,7 @@ export function BaseChart({
   }, [
     normalized,
     colors,
+    ui,
     title,
     showLegend,
     chartType,

--- a/packages/appkit-ui/src/react/charts/base.tsx
+++ b/packages/appkit-ui/src/react/charts/base.tsx
@@ -10,7 +10,7 @@ import {
   buildRadarOption,
   type OptionBuilderContext,
 } from "./options";
-import { useChartUITokens, useThemeColors } from "./theme";
+import { useThemeColors } from "./theme";
 import type {
   ChartColorPalette,
   ChartData,
@@ -132,8 +132,9 @@ export function BaseChart({
   const themeColors = useThemeColors(resolvedPalette);
   const colors = customColors ?? themeColors;
 
-  // Chart-chrome colors (axis text, titles, grid lines) for the active theme
-  const ui = useChartUITokens();
+  // Chart-chrome colors (axis text, titles, grid lines) for the active theme.
+  // Order matches CHART_COLOR_VARS_CHROME: [axisLabel, axisTitle, grid].
+  const chrome = useThemeColors("chrome");
 
   // Store ECharts instance directly to avoid stale ref issues on unmount
   const echartsInstanceRef = useRef<ECharts | null>(null);
@@ -186,6 +187,11 @@ export function BaseChart({
     // For other charts, yDataMap is required
     const yDataMap = "yDataMap" in normalized ? normalized.yDataMap : {};
 
+    const ui = {
+      axisLabel: chrome[0],
+      axisTitle: chrome[1],
+      grid: chrome[2],
+    };
     const baseCtx: OptionBuilderContext = {
       xData,
       yDataMap,
@@ -259,7 +265,7 @@ export function BaseChart({
   }, [
     normalized,
     colors,
-    ui,
+    chrome,
     title,
     showLegend,
     chartType,

--- a/packages/appkit-ui/src/react/charts/base.tsx
+++ b/packages/appkit-ui/src/react/charts/base.tsx
@@ -132,8 +132,6 @@ export function BaseChart({
   const themeColors = useThemeColors(resolvedPalette);
   const colors = customColors ?? themeColors;
 
-  // Chart-chrome colors (axis text, titles, grid lines) for the active theme.
-  // Order matches CHART_COLOR_VARS_CHROME: [axisLabel, axisTitle, grid].
   const chrome = useThemeColors("chrome");
 
   // Store ECharts instance directly to avoid stale ref issues on unmount

--- a/packages/appkit-ui/src/react/charts/base.tsx
+++ b/packages/appkit-ui/src/react/charts/base.tsx
@@ -10,7 +10,7 @@ import {
   buildRadarOption,
   type OptionBuilderContext,
 } from "./options";
-import { useThemeColors } from "./theme";
+import { useChartUITokens, useThemeColors } from "./theme";
 import type {
   ChartColorPalette,
   ChartData,
@@ -132,7 +132,7 @@ export function BaseChart({
   const themeColors = useThemeColors(resolvedPalette);
   const colors = customColors ?? themeColors;
 
-  const chrome = useThemeColors("chrome");
+  const ui = useChartUITokens();
 
   // Store ECharts instance directly to avoid stale ref issues on unmount
   const echartsInstanceRef = useRef<ECharts | null>(null);
@@ -185,11 +185,6 @@ export function BaseChart({
     // For other charts, yDataMap is required
     const yDataMap = "yDataMap" in normalized ? normalized.yDataMap : {};
 
-    const ui = {
-      axisLabel: chrome[0],
-      axisTitle: chrome[1],
-      grid: chrome[2],
-    };
     const baseCtx: OptionBuilderContext = {
       xData,
       yDataMap,
@@ -263,7 +258,7 @@ export function BaseChart({
   }, [
     normalized,
     colors,
-    chrome,
+    ui,
     title,
     showLegend,
     chartType,

--- a/packages/appkit-ui/src/react/charts/constants.ts
+++ b/packages/appkit-ui/src/react/charts/constants.ts
@@ -104,19 +104,21 @@ export const FALLBACK_COLORS_DIVERGING = [
 ];
 
 // ============================================================================
-// Chart Chrome (axis text, titles, grid lines)
+// Chart UI tokens (axis text, titles, grid lines)
 // ============================================================================
 
-/** CSS variable names for chart chrome colors (read at runtime like the palettes) */
+/** CSS variable names for the chart UI tokens (read at runtime like the palettes) */
 export const CHART_UI_VARS: Record<keyof ChartUITokens, string> = {
   axisLabel: "--chart-axis-label",
   axisTitle: "--chart-axis-title",
   grid: "--chart-grid",
+  tooltipBg: "--chart-tooltip-bg",
 };
 
-/** Fallback chart chrome colors (light values; used when CSS variables unavailable) */
+/** Fallback chart UI tokens (light values). */
 export const FALLBACK_UI_TOKENS: ChartUITokens = {
   axisLabel: "hsla(240, 4%, 46%, 1)", // ≈ --muted-foreground
   axisTitle: "hsla(240, 6%, 10%, 1)", // ≈ --foreground
   grid: "hsla(240, 5%, 90%, 1)", // ≈ --border
+  tooltipBg: "hsla(0, 0%, 100%, 1)", // ≈ --popover
 };

--- a/packages/appkit-ui/src/react/charts/constants.ts
+++ b/packages/appkit-ui/src/react/charts/constants.ts
@@ -2,6 +2,8 @@
 // Shared Constants for Chart Components
 // ============================================================================
 
+import type { ChartUITokens } from "./types";
+
 // Re-export field patterns from shared constants
 export {
   DATE_FIELD_PATTERNS,
@@ -100,3 +102,21 @@ export const FALLBACK_COLORS_DIVERGING = [
   "hsla(10, 72%, 50%, 1)",
   "hsla(10, 80%, 40%, 1)", // Strong positive
 ];
+
+// ============================================================================
+// Chart Chrome (axis text, titles, grid lines)
+// ============================================================================
+
+/** CSS variable names for chart chrome colors (read at runtime like the palettes) */
+export const CHART_UI_VARS: Record<keyof ChartUITokens, string> = {
+  axisLabel: "--chart-axis-label",
+  axisTitle: "--chart-axis-title",
+  grid: "--chart-grid",
+};
+
+/** Fallback chart chrome colors (light values; used when CSS variables unavailable) */
+export const FALLBACK_UI_TOKENS: ChartUITokens = {
+  axisLabel: "hsla(240, 4%, 46%, 1)",
+  axisTitle: "hsla(240, 6%, 10%, 1)",
+  grid: "hsla(240, 5%, 90%, 1)",
+};

--- a/packages/appkit-ui/src/react/charts/constants.ts
+++ b/packages/appkit-ui/src/react/charts/constants.ts
@@ -2,6 +2,8 @@
 // Shared Constants for Chart Components
 // ============================================================================
 
+import type { ChartUITokens } from "./types";
+
 // Re-export field patterns from shared constants
 export {
   DATE_FIELD_PATTERNS,
@@ -105,20 +107,16 @@ export const FALLBACK_COLORS_DIVERGING = [
 // Chart Chrome (axis text, titles, grid lines)
 // ============================================================================
 
-/**
- * CSS variable names for chart "chrome" — read like the palettes via
- * `useThemeColors("chrome")`.
- * Order: [axis tick labels, axis/legend/title text, axis/grid lines].
- */
-export const CHART_COLOR_VARS_CHROME = [
-  "--chart-axis-label",
-  "--chart-axis-title",
-  "--chart-grid",
-] as const;
+/** CSS variable names for chart chrome colors (read at runtime like the palettes) */
+export const CHART_UI_VARS: Record<keyof ChartUITokens, string> = {
+  axisLabel: "--chart-axis-label",
+  axisTitle: "--chart-axis-title",
+  grid: "--chart-grid",
+};
 
-/** Fallback chart chrome colors (light values), same order as CHART_COLOR_VARS_CHROME */
-export const FALLBACK_COLORS_CHROME = [
-  "hsla(240, 4%, 46%, 1)", // axis tick labels ≈ --muted-foreground
-  "hsla(240, 6%, 10%, 1)", // axis/legend/title text ≈ --foreground
-  "hsla(240, 5%, 90%, 1)", // axis/grid lines ≈ --border
-];
+/** Fallback chart chrome colors (light values; used when CSS variables unavailable) */
+export const FALLBACK_UI_TOKENS: ChartUITokens = {
+  axisLabel: "hsla(240, 4%, 46%, 1)", // ≈ --muted-foreground
+  axisTitle: "hsla(240, 6%, 10%, 1)", // ≈ --foreground
+  grid: "hsla(240, 5%, 90%, 1)", // ≈ --border
+};

--- a/packages/appkit-ui/src/react/charts/constants.ts
+++ b/packages/appkit-ui/src/react/charts/constants.ts
@@ -2,8 +2,6 @@
 // Shared Constants for Chart Components
 // ============================================================================
 
-import type { ChartUITokens } from "./types";
-
 // Re-export field patterns from shared constants
 export {
   DATE_FIELD_PATTERNS,
@@ -107,16 +105,20 @@ export const FALLBACK_COLORS_DIVERGING = [
 // Chart Chrome (axis text, titles, grid lines)
 // ============================================================================
 
-/** CSS variable names for chart chrome colors (read at runtime like the palettes) */
-export const CHART_UI_VARS: Record<keyof ChartUITokens, string> = {
-  axisLabel: "--chart-axis-label",
-  axisTitle: "--chart-axis-title",
-  grid: "--chart-grid",
-};
+/**
+ * CSS variable names for chart "chrome" — read like the palettes via
+ * `useThemeColors("chrome")`.
+ * Order: [axis tick labels, axis/legend/title text, axis/grid lines].
+ */
+export const CHART_COLOR_VARS_CHROME = [
+  "--chart-axis-label",
+  "--chart-axis-title",
+  "--chart-grid",
+] as const;
 
-/** Fallback chart chrome colors (light values; used when CSS variables unavailable) */
-export const FALLBACK_UI_TOKENS: ChartUITokens = {
-  axisLabel: "hsla(240, 4%, 46%, 1)",
-  axisTitle: "hsla(240, 6%, 10%, 1)",
-  grid: "hsla(240, 5%, 90%, 1)",
-};
+/** Fallback chart chrome colors (light values), same order as CHART_COLOR_VARS_CHROME */
+export const FALLBACK_COLORS_CHROME = [
+  "hsla(240, 4%, 46%, 1)", // axis tick labels ≈ --muted-foreground
+  "hsla(240, 6%, 10%, 1)", // axis/legend/title text ≈ --foreground
+  "hsla(240, 5%, 90%, 1)", // axis/grid lines ≈ --border
+];

--- a/packages/appkit-ui/src/react/charts/index.ts
+++ b/packages/appkit-ui/src/react/charts/index.ts
@@ -45,17 +45,16 @@ export {
   // Color palette CSS variables
   CHART_COLOR_VARS,
   CHART_COLOR_VARS_CATEGORICAL,
+  CHART_COLOR_VARS_CHROME,
   CHART_COLOR_VARS_DIVERGING,
   CHART_COLOR_VARS_SEQUENTIAL,
-  // Chart chrome (axis text, titles, grid lines)
-  CHART_UI_VARS,
   // Field detection patterns
   DATE_FIELD_PATTERNS,
   // Fallback colors
   FALLBACK_COLORS_CATEGORICAL,
+  FALLBACK_COLORS_CHROME,
   FALLBACK_COLORS_DIVERGING,
   FALLBACK_COLORS_SEQUENTIAL,
-  FALLBACK_UI_TOKENS,
   METADATA_DATE_PATTERNS,
   NAME_FIELD_PATTERNS,
 } from "./constants";
@@ -66,7 +65,6 @@ export {
 
 export {
   useAllThemeColors,
-  useChartUITokens,
   useThemeColors,
 } from "./theme";
 

--- a/packages/appkit-ui/src/react/charts/index.ts
+++ b/packages/appkit-ui/src/react/charts/index.ts
@@ -45,14 +45,12 @@ export {
   // Color palette CSS variables
   CHART_COLOR_VARS,
   CHART_COLOR_VARS_CATEGORICAL,
-  CHART_COLOR_VARS_CHROME,
   CHART_COLOR_VARS_DIVERGING,
   CHART_COLOR_VARS_SEQUENTIAL,
   // Field detection patterns
   DATE_FIELD_PATTERNS,
   // Fallback colors
   FALLBACK_COLORS_CATEGORICAL,
-  FALLBACK_COLORS_CHROME,
   FALLBACK_COLORS_DIVERGING,
   FALLBACK_COLORS_SEQUENTIAL,
   METADATA_DATE_PATTERNS,
@@ -65,6 +63,7 @@ export {
 
 export {
   useAllThemeColors,
+  useChartUITokens,
   useThemeColors,
 } from "./theme";
 

--- a/packages/appkit-ui/src/react/charts/index.ts
+++ b/packages/appkit-ui/src/react/charts/index.ts
@@ -47,12 +47,15 @@ export {
   CHART_COLOR_VARS_CATEGORICAL,
   CHART_COLOR_VARS_DIVERGING,
   CHART_COLOR_VARS_SEQUENTIAL,
+  // Chart chrome (axis text, titles, grid lines)
+  CHART_UI_VARS,
   // Field detection patterns
   DATE_FIELD_PATTERNS,
   // Fallback colors
   FALLBACK_COLORS_CATEGORICAL,
   FALLBACK_COLORS_DIVERGING,
   FALLBACK_COLORS_SEQUENTIAL,
+  FALLBACK_UI_TOKENS,
   METADATA_DATE_PATTERNS,
   NAME_FIELD_PATTERNS,
 } from "./constants";
@@ -63,6 +66,7 @@ export {
 
 export {
   useAllThemeColors,
+  useChartUITokens,
   useThemeColors,
 } from "./theme";
 
@@ -110,6 +114,7 @@ export type {
   ChartColorPalette,
   ChartData,
   ChartType,
+  ChartUITokens,
   // Data formats
   DataFormat,
   DataProps,

--- a/packages/appkit-ui/src/react/charts/options.ts
+++ b/packages/appkit-ui/src/react/charts/options.ts
@@ -59,8 +59,6 @@ function axisCommon(ui: ChartUITokens) {
   };
 }
 
-// Spread of axisCommon whose axisLabel keeps the themed color even when a chart
-// adds its own axisLabel options (rotate, width, formatter, ...).
 function mergeAxisLabel(
   ui: ChartUITokens,
   axisLabel: Record<string, unknown>,
@@ -73,6 +71,14 @@ function mergeAxisLabel(
 
 function legendTextStyle(ui: ChartUITokens) {
   return { textStyle: { color: ui.axisTitle } };
+}
+
+function tooltipTokens(ui: ChartUITokens) {
+  return {
+    backgroundColor: ui.tooltipBg,
+    borderColor: ui.grid,
+    textStyle: { color: ui.axisTitle },
+  };
 }
 
 // ============================================================================
@@ -90,7 +96,7 @@ export function buildRadarOption(
 
   return {
     ...buildBaseOption(ctx),
-    tooltip: { trigger: "item" },
+    tooltip: { ...tooltipTokens(ui), trigger: "item" },
     legend:
       ctx.showLegend && ctx.yFields.length > 1
         ? { top: "bottom", ...legendTextStyle(ui) }
@@ -140,7 +146,11 @@ export function buildPieOption(
 
   return {
     ...buildBaseOption(ctx),
-    tooltip: { trigger: "item", formatter: "{b}: {c} ({d}%)" },
+    tooltip: {
+      ...tooltipTokens(ui),
+      trigger: "item",
+      formatter: "{b}: {c} ({d}%)",
+    },
     legend: ctx.showLegend
       ? {
           orient: "vertical",
@@ -187,7 +197,11 @@ export function buildHorizontalBarOption(
 
   return {
     ...buildBaseOption(ctx),
-    tooltip: { trigger: "axis", axisPointer: { type: "shadow" } },
+    tooltip: {
+      ...tooltipTokens(ui),
+      trigger: "axis",
+      axisPointer: { type: "shadow" },
+    },
     legend:
       ctx.showLegend && hasMultipleSeries
         ? { top: "bottom", ...legendTextStyle(ui) }
@@ -243,6 +257,7 @@ export function buildHeatmapOption(
   return {
     ...buildBaseOption(ctx),
     tooltip: {
+      ...tooltipTokens(ui),
       trigger: "item",
       formatter: (params: { data: [number, number, number] }) => {
         const [xIdx, yIdx, value] = params.data;
@@ -324,7 +339,7 @@ export function buildCartesianOption(
 
   return {
     ...buildBaseOption(ctx),
-    tooltip: { trigger: isScatter ? "item" : "axis" },
+    tooltip: { ...tooltipTokens(ui), trigger: isScatter ? "item" : "axis" },
     legend:
       ctx.showLegend && hasMultipleSeries
         ? { top: "bottom", ...legendTextStyle(ui) }

--- a/packages/appkit-ui/src/react/charts/options.ts
+++ b/packages/appkit-ui/src/react/charts/options.ts
@@ -1,4 +1,4 @@
-import type { ChartType } from "./types";
+import type { ChartType, ChartUITokens } from "./types";
 import {
   createTimeSeriesData,
   escapeHtml,
@@ -18,6 +18,8 @@ export interface OptionBuilderContext {
   title?: string;
   showLegend: boolean;
   xField?: string;
+  /** Resolved chart-chrome colors (axis text, titles, grid lines). */
+  ui: ChartUITokens;
 }
 
 export interface CartesianContext extends OptionBuilderContext {
@@ -35,9 +37,35 @@ export interface CartesianContext extends OptionBuilderContext {
 
 function buildBaseOption(ctx: OptionBuilderContext): Record<string, unknown> {
   return {
-    title: ctx.title ? { text: ctx.title, left: "center" } : undefined,
+    title: ctx.title
+      ? {
+          text: ctx.title,
+          left: "center",
+          textStyle: { color: ctx.ui.axisTitle },
+        }
+      : undefined,
     color: ctx.colors,
   };
+}
+
+/**
+ * Shared axis chrome (tick labels, axis/tick/split lines, axis name) resolved
+ * from the active theme. Spread into an axis object, then override `axisLabel`
+ * if you need to keep a formatter/rotate (merge the color back in).
+ */
+function axisCommon(ui: ChartUITokens) {
+  return {
+    axisLabel: { color: ui.axisLabel },
+    axisLine: { lineStyle: { color: ui.grid } },
+    axisTick: { lineStyle: { color: ui.grid } },
+    splitLine: { lineStyle: { color: ui.grid } },
+    nameTextStyle: { color: ui.axisTitle },
+  };
+}
+
+/** Shared legend text color resolved from the active theme. */
+function legendTextStyle(ui: ChartUITokens) {
+  return { textStyle: { color: ui.axisTitle } };
 }
 
 // ============================================================================
@@ -56,13 +84,18 @@ export function buildRadarOption(
     ...buildBaseOption(ctx),
     tooltip: { trigger: "item" },
     legend:
-      ctx.showLegend && ctx.yFields.length > 1 ? { top: "bottom" } : undefined,
+      ctx.showLegend && ctx.yFields.length > 1
+        ? { top: "bottom", ...legendTextStyle(ctx.ui) }
+        : undefined,
     radar: {
       indicator: ctx.xData.map((name) => ({
         name: String(name),
         max: maxValue * 1.2,
       })),
       shape: "polygon",
+      axisName: { color: ctx.ui.axisTitle },
+      axisLine: { lineStyle: { color: ctx.ui.grid } },
+      splitLine: { lineStyle: { color: ctx.ui.grid } },
     },
     series: [
       {
@@ -100,7 +133,12 @@ export function buildPieOption(
     ...buildBaseOption(ctx),
     tooltip: { trigger: "item", formatter: "{b}: {c} ({d}%)" },
     legend: ctx.showLegend
-      ? { orient: "vertical", left: "left", top: "middle" }
+      ? {
+          orient: "vertical",
+          left: "left",
+          top: "middle",
+          ...legendTextStyle(ctx.ui),
+        }
       : undefined,
     series: [
       {
@@ -140,18 +178,23 @@ export function buildHorizontalBarOption(
   return {
     ...buildBaseOption(ctx),
     tooltip: { trigger: "axis", axisPointer: { type: "shadow" } },
-    legend: ctx.showLegend && hasMultipleSeries ? { top: "bottom" } : undefined,
+    legend:
+      ctx.showLegend && hasMultipleSeries
+        ? { top: "bottom", ...legendTextStyle(ctx.ui) }
+        : undefined,
     grid: {
       left: "20%",
       right: "10%",
       top: ctx.title ? "15%" : "5%",
       bottom: ctx.showLegend && hasMultipleSeries ? "15%" : "5%",
     },
-    xAxis: { type: "value" },
+    xAxis: { type: "value", ...axisCommon(ctx.ui) },
     yAxis: {
       type: "category",
       data: ctx.xData,
+      ...axisCommon(ctx.ui),
       axisLabel: {
+        color: ctx.ui.axisLabel,
         width: 100,
         overflow: "truncate",
         formatter: (value: string) => truncateLabel(String(value)),
@@ -211,7 +254,9 @@ export function buildHeatmapOption(
       type: "category",
       data: ctx.xData,
       splitArea: { show: true },
+      ...axisCommon(ctx.ui),
       axisLabel: {
+        color: ctx.ui.axisLabel,
         rotate: ctx.xData.length > 10 ? 45 : 0,
         formatter: (v: string) => truncateLabel(String(v), 10),
       },
@@ -220,7 +265,9 @@ export function buildHeatmapOption(
       type: "category",
       data: ctx.yAxisData,
       splitArea: { show: true },
+      ...axisCommon(ctx.ui),
       axisLabel: {
+        color: ctx.ui.axisLabel,
         formatter: (v: string) => truncateLabel(String(v), 12),
       },
     },
@@ -231,6 +278,7 @@ export function buildHeatmapOption(
       orient: "vertical",
       right: "2%",
       top: "center",
+      textStyle: { color: ctx.ui.axisTitle },
       inRange: {
         color: ctx.colors.length >= 2 ? ctx.colors : ["#f0f0f0", ctx.colors[0]],
       },
@@ -271,7 +319,10 @@ export function buildCartesianOption(
   return {
     ...buildBaseOption(ctx),
     tooltip: { trigger: isScatter ? "item" : "axis" },
-    legend: ctx.showLegend && hasMultipleSeries ? { top: "bottom" } : undefined,
+    legend:
+      ctx.showLegend && hasMultipleSeries
+        ? { top: "bottom", ...legendTextStyle(ctx.ui) }
+        : undefined,
     grid: {
       left: "10%",
       right: "10%",
@@ -283,10 +334,12 @@ export function buildCartesianOption(
       type: isScatter ? "value" : isTimeSeries ? "time" : "category",
       data: isScatter || isTimeSeries ? undefined : ctx.xData,
       name: ctx.xField ? formatLabel(ctx.xField) : undefined,
+      ...axisCommon(ctx.ui),
       axisLabel:
         isScatter || isTimeSeries
-          ? { show: true }
+          ? { show: true, color: ctx.ui.axisLabel }
           : {
+              color: ctx.ui.axisLabel,
               rotate: ctx.xData.length > 10 ? 45 : 0,
               formatter: (v: string) => truncateLabel(String(v), 10),
             },
@@ -294,6 +347,7 @@ export function buildCartesianOption(
     yAxis: {
       type: "value",
       name: ctx.yFields.length === 1 ? formatLabel(ctx.yFields[0]) : undefined,
+      ...axisCommon(ctx.ui),
     },
     series: ctx.yFields.map((key, idx) => ({
       name: formatLabel(key),

--- a/packages/appkit-ui/src/react/charts/options.ts
+++ b/packages/appkit-ui/src/react/charts/options.ts
@@ -1,3 +1,4 @@
+import { FALLBACK_UI_TOKENS } from "./constants";
 import type { ChartType, ChartUITokens } from "./types";
 import {
   createTimeSeriesData,
@@ -18,7 +19,7 @@ export interface OptionBuilderContext {
   title?: string;
   showLegend: boolean;
   xField?: string;
-  ui: ChartUITokens;
+  ui?: ChartUITokens;
 }
 
 export interface CartesianContext extends OptionBuilderContext {
@@ -35,12 +36,13 @@ export interface CartesianContext extends OptionBuilderContext {
 // ============================================================================
 
 function buildBaseOption(ctx: OptionBuilderContext): Record<string, unknown> {
+  const ui = ctx.ui ?? FALLBACK_UI_TOKENS;
   return {
     title: ctx.title
       ? {
           text: ctx.title,
           left: "center",
-          textStyle: { color: ctx.ui.axisTitle },
+          textStyle: { color: ui.axisTitle },
         }
       : undefined,
     color: ctx.colors,
@@ -57,6 +59,18 @@ function axisCommon(ui: ChartUITokens) {
   };
 }
 
+// Spread of axisCommon whose axisLabel keeps the themed color even when a chart
+// adds its own axisLabel options (rotate, width, formatter, ...).
+function mergeAxisLabel(
+  ui: ChartUITokens,
+  axisLabel: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    ...axisCommon(ui),
+    axisLabel: { color: ui.axisLabel, ...axisLabel },
+  };
+}
+
 function legendTextStyle(ui: ChartUITokens) {
   return { textStyle: { color: ui.axisTitle } };
 }
@@ -69,6 +83,7 @@ export function buildRadarOption(
   ctx: OptionBuilderContext,
   showArea = true,
 ): Record<string, unknown> {
+  const ui = ctx.ui ?? FALLBACK_UI_TOKENS;
   const maxValue = Math.max(
     ...ctx.yFields.flatMap((f) => ctx.yDataMap[f].map((v) => Number(v) || 0)),
   );
@@ -78,7 +93,7 @@ export function buildRadarOption(
     tooltip: { trigger: "item" },
     legend:
       ctx.showLegend && ctx.yFields.length > 1
-        ? { top: "bottom", ...legendTextStyle(ctx.ui) }
+        ? { top: "bottom", ...legendTextStyle(ui) }
         : undefined,
     radar: {
       indicator: ctx.xData.map((name) => ({
@@ -86,9 +101,9 @@ export function buildRadarOption(
         max: maxValue * 1.2,
       })),
       shape: "polygon",
-      axisName: { color: ctx.ui.axisTitle },
-      axisLine: { lineStyle: { color: ctx.ui.grid } },
-      splitLine: { lineStyle: { color: ctx.ui.grid } },
+      axisName: { color: ui.axisTitle },
+      axisLine: { lineStyle: { color: ui.grid } },
+      splitLine: { lineStyle: { color: ui.grid } },
     },
     series: [
       {
@@ -115,6 +130,7 @@ export function buildPieOption(
   showLabels: boolean,
   labelPosition: string,
 ): Record<string, unknown> {
+  const ui = ctx.ui ?? FALLBACK_UI_TOKENS;
   const pieData = ctx.xData.map((name, i) => ({
     name: String(name),
     value: ctx.yDataMap[ctx.yFields[0]]?.[i] ?? 0,
@@ -130,7 +146,7 @@ export function buildPieOption(
           orient: "vertical",
           left: "left",
           top: "middle",
-          ...legendTextStyle(ctx.ui),
+          ...legendTextStyle(ui),
         }
       : undefined,
     series: [
@@ -166,6 +182,7 @@ export function buildHorizontalBarOption(
   ctx: OptionBuilderContext,
   stacked: boolean,
 ): Record<string, unknown> {
+  const ui = ctx.ui ?? FALLBACK_UI_TOKENS;
   const hasMultipleSeries = ctx.yFields.length > 1;
 
   return {
@@ -173,7 +190,7 @@ export function buildHorizontalBarOption(
     tooltip: { trigger: "axis", axisPointer: { type: "shadow" } },
     legend:
       ctx.showLegend && hasMultipleSeries
-        ? { top: "bottom", ...legendTextStyle(ctx.ui) }
+        ? { top: "bottom", ...legendTextStyle(ui) }
         : undefined,
     grid: {
       left: "20%",
@@ -181,17 +198,15 @@ export function buildHorizontalBarOption(
       top: ctx.title ? "15%" : "5%",
       bottom: ctx.showLegend && hasMultipleSeries ? "15%" : "5%",
     },
-    xAxis: { type: "value", ...axisCommon(ctx.ui) },
+    xAxis: { type: "value", ...axisCommon(ui) },
     yAxis: {
       type: "category",
       data: ctx.xData,
-      ...axisCommon(ctx.ui),
-      axisLabel: {
-        color: ctx.ui.axisLabel,
+      ...mergeAxisLabel(ui, {
         width: 100,
         overflow: "truncate",
         formatter: (value: string) => truncateLabel(String(value)),
-      },
+      }),
     },
     series: ctx.yFields.map((key, idx) => ({
       name: formatLabel(key),
@@ -224,6 +239,7 @@ export interface HeatmapContext extends OptionBuilderContext {
 export function buildHeatmapOption(
   ctx: HeatmapContext,
 ): Record<string, unknown> {
+  const ui = ctx.ui ?? FALLBACK_UI_TOKENS;
   return {
     ...buildBaseOption(ctx),
     tooltip: {
@@ -247,22 +263,18 @@ export function buildHeatmapOption(
       type: "category",
       data: ctx.xData,
       splitArea: { show: true },
-      ...axisCommon(ctx.ui),
-      axisLabel: {
-        color: ctx.ui.axisLabel,
+      ...mergeAxisLabel(ui, {
         rotate: ctx.xData.length > 10 ? 45 : 0,
         formatter: (v: string) => truncateLabel(String(v), 10),
-      },
+      }),
     },
     yAxis: {
       type: "category",
       data: ctx.yAxisData,
       splitArea: { show: true },
-      ...axisCommon(ctx.ui),
-      axisLabel: {
-        color: ctx.ui.axisLabel,
+      ...mergeAxisLabel(ui, {
         formatter: (v: string) => truncateLabel(String(v), 12),
-      },
+      }),
     },
     visualMap: {
       min: ctx.min,
@@ -271,7 +283,7 @@ export function buildHeatmapOption(
       orient: "vertical",
       right: "2%",
       top: "center",
-      textStyle: { color: ctx.ui.axisTitle },
+      textStyle: { color: ui.axisTitle },
       inRange: {
         color: ctx.colors.length >= 2 ? ctx.colors : ["#f0f0f0", ctx.colors[0]],
       },
@@ -303,6 +315,7 @@ export function buildHeatmapOption(
 export function buildCartesianOption(
   ctx: CartesianContext,
 ): Record<string, unknown> {
+  const ui = ctx.ui ?? FALLBACK_UI_TOKENS;
   const { chartType, isTimeSeries, stacked, smooth, showSymbol, symbolSize } =
     ctx;
   const hasMultipleSeries = ctx.yFields.length > 1;
@@ -314,7 +327,7 @@ export function buildCartesianOption(
     tooltip: { trigger: isScatter ? "item" : "axis" },
     legend:
       ctx.showLegend && hasMultipleSeries
-        ? { top: "bottom", ...legendTextStyle(ctx.ui) }
+        ? { top: "bottom", ...legendTextStyle(ui) }
         : undefined,
     grid: {
       left: "10%",
@@ -327,20 +340,20 @@ export function buildCartesianOption(
       type: isScatter ? "value" : isTimeSeries ? "time" : "category",
       data: isScatter || isTimeSeries ? undefined : ctx.xData,
       name: ctx.xField ? formatLabel(ctx.xField) : undefined,
-      ...axisCommon(ctx.ui),
-      axisLabel:
+      ...mergeAxisLabel(
+        ui,
         isScatter || isTimeSeries
-          ? { show: true, color: ctx.ui.axisLabel }
+          ? { show: true }
           : {
-              color: ctx.ui.axisLabel,
               rotate: ctx.xData.length > 10 ? 45 : 0,
               formatter: (v: string) => truncateLabel(String(v), 10),
             },
+      ),
     },
     yAxis: {
       type: "value",
       name: ctx.yFields.length === 1 ? formatLabel(ctx.yFields[0]) : undefined,
-      ...axisCommon(ctx.ui),
+      ...axisCommon(ui),
     },
     series: ctx.yFields.map((key, idx) => ({
       name: formatLabel(key),

--- a/packages/appkit-ui/src/react/charts/options.ts
+++ b/packages/appkit-ui/src/react/charts/options.ts
@@ -18,7 +18,6 @@ export interface OptionBuilderContext {
   title?: string;
   showLegend: boolean;
   xField?: string;
-  /** Resolved chart-chrome colors (axis text, titles, grid lines). */
   ui: ChartUITokens;
 }
 
@@ -48,11 +47,6 @@ function buildBaseOption(ctx: OptionBuilderContext): Record<string, unknown> {
   };
 }
 
-/**
- * Shared axis chrome (tick labels, axis/tick/split lines, axis name) resolved
- * from the active theme. Spread into an axis object, then override `axisLabel`
- * if you need to keep a formatter/rotate (merge the color back in).
- */
 function axisCommon(ui: ChartUITokens) {
   return {
     axisLabel: { color: ui.axisLabel },
@@ -63,7 +57,6 @@ function axisCommon(ui: ChartUITokens) {
   };
 }
 
-/** Shared legend text color resolved from the active theme. */
 function legendTextStyle(ui: ChartUITokens) {
   return { textStyle: { color: ui.axisTitle } };
 }

--- a/packages/appkit-ui/src/react/charts/theme.ts
+++ b/packages/appkit-ui/src/react/charts/theme.ts
@@ -1,22 +1,28 @@
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   CHART_COLOR_VARS_CATEGORICAL,
+  CHART_COLOR_VARS_CHROME,
   CHART_COLOR_VARS_DIVERGING,
   CHART_COLOR_VARS_SEQUENTIAL,
-  CHART_UI_VARS,
   FALLBACK_COLORS_CATEGORICAL,
+  FALLBACK_COLORS_CHROME,
   FALLBACK_COLORS_DIVERGING,
   FALLBACK_COLORS_SEQUENTIAL,
-  FALLBACK_UI_TOKENS,
 } from "./constants";
-import type { ChartColorPalette, ChartUITokens } from "./types";
+import type { ChartColorPalette } from "./types";
 
 // ============================================================================
 // Theme Colors (resolved from CSS variables)
 // ============================================================================
 
+/**
+ * Named sets of theme colors resolved from CSS variables: the three data-series
+ * palettes plus "chrome" (axis tick labels, axis/legend/title text, grid lines).
+ */
+type ThemeColorScheme = ChartColorPalette | "chrome";
+
 const PALETTE_CONFIG: Record<
-  ChartColorPalette,
+  ThemeColorScheme,
   { vars: readonly string[]; fallback: string[] }
 > = {
   categorical: {
@@ -31,6 +37,10 @@ const PALETTE_CONFIG: Record<
     vars: CHART_COLOR_VARS_DIVERGING,
     fallback: FALLBACK_COLORS_DIVERGING,
   },
+  chrome: {
+    vars: CHART_COLOR_VARS_CHROME,
+    fallback: FALLBACK_COLORS_CHROME,
+  },
 };
 
 // ============================================================================
@@ -43,24 +53,20 @@ const PALETTE_CONFIG: Record<
  */
 const colorCache = new Map<string, string[]>();
 
-/** Cache for computed chart-chrome tokens (axis text, grid lines). */
-let uiTokenCache: ChartUITokens | null = null;
-
 /**
- * Clears the theme color caches (palette colors + chrome tokens).
+ * Clears the theme color cache.
  * Called when theme change events fire, or for testing when mocks change.
  * @internal
  */
 export function resetThemeColorCache(): void {
   colorCache.clear();
-  uiTokenCache = null;
 }
 
 /**
  * Gets theme colors with module-level caching.
- * Avoids repeated CSS variable lookups for the same palette within a theme.
+ * Avoids repeated CSS variable lookups for the same scheme within a theme.
  */
-function getThemeColors(palette: ChartColorPalette = "categorical"): string[] {
+function getThemeColors(palette: ThemeColorScheme = "categorical"): string[] {
   const config = PALETTE_CONFIG[palette];
 
   if (typeof window === "undefined") return config.fallback;
@@ -89,72 +95,14 @@ function getThemeColors(palette: ChartColorPalette = "categorical"): string[] {
 }
 
 /**
- * Gets chart-chrome tokens (axis text, titles, grid lines) with caching.
- * These are read the same way as the palette colors and are authored in `hsla`
- * so ECharts/zrender can parse them (the `oklch` semantic tokens cannot be
- * passed to ECharts directly).
- */
-function getThemeUITokens(): ChartUITokens {
-  if (typeof window === "undefined") return FALLBACK_UI_TOKENS;
-
-  if (uiTokenCache) return uiTokenCache;
-
-  const styles = getComputedStyle(document.documentElement);
-  const read = (varName: string, fallback: string): string => {
-    const value = styles.getPropertyValue(varName).trim();
-    return value || fallback;
-  };
-
-  uiTokenCache = {
-    axisLabel: read(CHART_UI_VARS.axisLabel, FALLBACK_UI_TOKENS.axisLabel),
-    axisTitle: read(CHART_UI_VARS.axisTitle, FALLBACK_UI_TOKENS.axisTitle),
-    grid: read(CHART_UI_VARS.grid, FALLBACK_UI_TOKENS.grid),
-  };
-
-  return uiTokenCache;
-}
-
-// ============================================================================
-// Theme Change Subscription (shared)
-// ============================================================================
-
-/**
- * Runs `onChange` whenever the active theme changes — either the system color
- * scheme (matchMedia) or a theme attribute on the root element (class /
- * data-theme / data-mode). Shared by the color and chrome-token hooks.
- */
-function useThemeChangeEffect(onChange: () => void): void {
-  useEffect(() => {
-    // Listen for system color scheme changes
-    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-    mediaQuery.addEventListener("change", onChange);
-
-    // Listen for theme attribute changes (e.g., class="dark", data-theme="dark")
-    const observer = new MutationObserver(onChange);
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ["class", "data-theme", "data-mode"],
-    });
-
-    return () => {
-      mediaQuery.removeEventListener("change", onChange);
-      observer.disconnect();
-    };
-  }, [onChange]);
-}
-
-// ============================================================================
-// Hooks
-// ============================================================================
-
-/**
  * Hook to get theme colors with automatic updates on theme change.
  * Re-resolves CSS variables when color scheme or theme attributes change.
  *
- * @param palette - Color palette type: "categorical" (default), "sequential", or "diverging"
+ * @param palette - Which set to resolve: "categorical" (default), "sequential",
+ *   "diverging", or "chrome" (axis/grid/legend colors for chart chrome).
  */
 export function useThemeColors(
-  palette: ChartColorPalette = "categorical",
+  palette: ThemeColorScheme = "categorical",
 ): string[] {
   const [colors, setColors] = useState<string[]>(() =>
     typeof window === "undefined"
@@ -162,35 +110,31 @@ export function useThemeColors(
       : getThemeColors(palette),
   );
 
-  // Clear cache and re-fetch colors when theme changes
-  const updateColors = useCallback(() => {
-    resetThemeColorCache();
-    setColors(getThemeColors(palette));
+  useEffect(() => {
+    // Clear cache and re-fetch colors when theme changes
+    const updateColors = () => {
+      resetThemeColorCache();
+      setColors(getThemeColors(palette));
+    };
+
+    // Listen for system color scheme changes
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    mediaQuery.addEventListener("change", updateColors);
+
+    // Listen for theme attribute changes (e.g., class="dark", data-theme="dark")
+    const observer = new MutationObserver(updateColors);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class", "data-theme", "data-mode"],
+    });
+
+    return () => {
+      mediaQuery.removeEventListener("change", updateColors);
+      observer.disconnect();
+    };
   }, [palette]);
 
-  useThemeChangeEffect(updateColors);
-
   return colors;
-}
-
-/**
- * Hook to get the chart-chrome tokens (axis text, titles, grid lines) with
- * automatic updates on theme change. Pass the result into the ECharts option
- * builders so axis labels, lines, legends, and titles follow the active theme.
- */
-export function useChartUITokens(): ChartUITokens {
-  const [tokens, setTokens] = useState<ChartUITokens>(() =>
-    typeof window === "undefined" ? FALLBACK_UI_TOKENS : getThemeUITokens(),
-  );
-
-  const updateTokens = useCallback(() => {
-    resetThemeColorCache();
-    setTokens(getThemeUITokens());
-  }, []);
-
-  useThemeChangeEffect(updateTokens);
-
-  return tokens;
 }
 
 /**

--- a/packages/appkit-ui/src/react/charts/theme.ts
+++ b/packages/appkit-ui/src/react/charts/theme.ts
@@ -43,10 +43,10 @@ const PALETTE_CONFIG: Record<
  */
 const colorCache = new Map<string, string[]>();
 
-/** Cache for computed chart-chrome tokens (axis text, grid lines). */
+/** Cache for the computed chart UI tokens (axis text, grid lines). */
 let uiTokenCache: ChartUITokens | null = null;
 
-/** Clears both theme caches (palette colors + chrome tokens). */
+/** Clears both theme caches (palette colors + UI tokens). */
 function clearThemeCaches(): void {
   colorCache.clear();
   uiTokenCache = null;
@@ -85,10 +85,9 @@ function getThemeColors(palette: ChartColorPalette = "categorical"): string[] {
 }
 
 /**
- * Gets chart-chrome tokens (axis text, titles, grid lines) with caching.
- * Each token falls back independently, so a single missing CSS variable never
- * shifts the others. Authored in `hsla` so ECharts/zrender can parse them (the
- * `oklch` semantic tokens cannot be passed to ECharts directly).
+ * Gets the chart UI tokens (axis text, titles, grid lines) with caching.
+ * Authored in `hsla` because ECharts/zrender cannot parse the `oklch` semantic
+ * tokens.
  */
 function getThemeUITokens(): ChartUITokens {
   if (typeof window === "undefined") return FALLBACK_UI_TOKENS;
@@ -105,6 +104,7 @@ function getThemeUITokens(): ChartUITokens {
     axisLabel: read(CHART_UI_VARS.axisLabel, FALLBACK_UI_TOKENS.axisLabel),
     axisTitle: read(CHART_UI_VARS.axisTitle, FALLBACK_UI_TOKENS.axisTitle),
     grid: read(CHART_UI_VARS.grid, FALLBACK_UI_TOKENS.grid),
+    tooltipBg: read(CHART_UI_VARS.tooltipBg, FALLBACK_UI_TOKENS.tooltipBg),
   };
 
   return uiTokenCache;
@@ -114,17 +114,14 @@ function getThemeUITokens(): ChartUITokens {
 // Theme Change Subscription (shared)
 // ============================================================================
 
-// One matchMedia listener + one MutationObserver for the whole module, shared by
-// every chart hook. A theme change resets the caches once, then notifies all
-// subscribers — instead of each hook installing its own listener and racing to
-// clear the caches the others just repopulated.
+// One shared, ref-counted matchMedia + MutationObserver for the whole module: a
+// theme change clears the caches once, then notifies every subscribed hook.
 const subscribers = new Set<() => void>();
 let teardownListeners: (() => void) | null = null;
 
 function handleThemeChange(): void {
   clearThemeCaches();
-  // Snapshot so a subscriber mounting/unmounting during notification cannot
-  // mutate the set mid-iteration.
+  // Snapshot: a subscriber may add/remove itself during iteration.
   for (const notify of [...subscribers]) notify();
 }
 
@@ -149,7 +146,7 @@ function ensureListening(): void {
 /**
  * Resets all module-level theme state: clears both caches and drops the shared
  * subscription (removing the matchMedia/MutationObserver listeners). Used by
- * tests to isolate runs; the runtime only ever clears caches, via the dispatcher.
+ * tests to isolate runs; the runtime only ever clears caches.
  * @internal
  */
 export function resetThemeCache(): void {
@@ -203,7 +200,7 @@ export function useThemeColors(
       : getThemeColors(palette),
   );
 
-  // Re-resolve colors when the theme changes (the cache is reset centrally).
+  // Re-resolve colors when the theme changes.
   const updateColors = useCallback(() => {
     setColors(getThemeColors(palette));
   }, [palette]);
@@ -214,16 +211,16 @@ export function useThemeColors(
 }
 
 /**
- * Hook to get the chart-chrome tokens (axis text, titles, grid lines) with
- * automatic updates on theme change. Pass the result into the ECharts option
- * builders so axis labels, lines, legends, and titles follow the active theme.
+ * Hook to get the chart UI tokens (axis text, titles, grid lines) with automatic
+ * updates on theme change. Pass the result into the ECharts option builders so
+ * axis labels, lines, legends, and titles follow the active theme.
  */
 export function useChartUITokens(): ChartUITokens {
   const [tokens, setTokens] = useState<ChartUITokens>(() =>
     typeof window === "undefined" ? FALLBACK_UI_TOKENS : getThemeUITokens(),
   );
 
-  // Re-resolve tokens when the theme changes (the cache is reset centrally).
+  // Re-resolve tokens when the theme changes.
   const updateTokens = useCallback(() => {
     setTokens(getThemeUITokens());
   }, []);

--- a/packages/appkit-ui/src/react/charts/theme.ts
+++ b/packages/appkit-ui/src/react/charts/theme.ts
@@ -1,28 +1,22 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   CHART_COLOR_VARS_CATEGORICAL,
-  CHART_COLOR_VARS_CHROME,
   CHART_COLOR_VARS_DIVERGING,
   CHART_COLOR_VARS_SEQUENTIAL,
+  CHART_UI_VARS,
   FALLBACK_COLORS_CATEGORICAL,
-  FALLBACK_COLORS_CHROME,
   FALLBACK_COLORS_DIVERGING,
   FALLBACK_COLORS_SEQUENTIAL,
+  FALLBACK_UI_TOKENS,
 } from "./constants";
-import type { ChartColorPalette } from "./types";
+import type { ChartColorPalette, ChartUITokens } from "./types";
 
 // ============================================================================
 // Theme Colors (resolved from CSS variables)
 // ============================================================================
 
-/**
- * Named sets of theme colors resolved from CSS variables: the three data-series
- * palettes plus "chrome" (axis tick labels, axis/legend/title text, grid lines).
- */
-type ThemeColorScheme = ChartColorPalette | "chrome";
-
 const PALETTE_CONFIG: Record<
-  ThemeColorScheme,
+  ChartColorPalette,
   { vars: readonly string[]; fallback: string[] }
 > = {
   categorical: {
@@ -37,10 +31,6 @@ const PALETTE_CONFIG: Record<
     vars: CHART_COLOR_VARS_DIVERGING,
     fallback: FALLBACK_COLORS_DIVERGING,
   },
-  chrome: {
-    vars: CHART_COLOR_VARS_CHROME,
-    fallback: FALLBACK_COLORS_CHROME,
-  },
 };
 
 // ============================================================================
@@ -53,20 +43,20 @@ const PALETTE_CONFIG: Record<
  */
 const colorCache = new Map<string, string[]>();
 
-/**
- * Clears the theme color cache.
- * Called when theme change events fire, or for testing when mocks change.
- * @internal
- */
-export function resetThemeColorCache(): void {
+/** Cache for computed chart-chrome tokens (axis text, grid lines). */
+let uiTokenCache: ChartUITokens | null = null;
+
+/** Clears both theme caches (palette colors + chrome tokens). */
+function clearThemeCaches(): void {
   colorCache.clear();
+  uiTokenCache = null;
 }
 
 /**
  * Gets theme colors with module-level caching.
- * Avoids repeated CSS variable lookups for the same scheme within a theme.
+ * Avoids repeated CSS variable lookups for the same palette within a theme.
  */
-function getThemeColors(palette: ThemeColorScheme = "categorical"): string[] {
+function getThemeColors(palette: ChartColorPalette = "categorical"): string[] {
   const config = PALETTE_CONFIG[palette];
 
   if (typeof window === "undefined") return config.fallback;
@@ -95,14 +85,117 @@ function getThemeColors(palette: ThemeColorScheme = "categorical"): string[] {
 }
 
 /**
+ * Gets chart-chrome tokens (axis text, titles, grid lines) with caching.
+ * Each token falls back independently, so a single missing CSS variable never
+ * shifts the others. Authored in `hsla` so ECharts/zrender can parse them (the
+ * `oklch` semantic tokens cannot be passed to ECharts directly).
+ */
+function getThemeUITokens(): ChartUITokens {
+  if (typeof window === "undefined") return FALLBACK_UI_TOKENS;
+
+  if (uiTokenCache) return uiTokenCache;
+
+  const styles = getComputedStyle(document.documentElement);
+  const read = (varName: string, fallback: string): string => {
+    const value = styles.getPropertyValue(varName).trim();
+    return value || fallback;
+  };
+
+  uiTokenCache = {
+    axisLabel: read(CHART_UI_VARS.axisLabel, FALLBACK_UI_TOKENS.axisLabel),
+    axisTitle: read(CHART_UI_VARS.axisTitle, FALLBACK_UI_TOKENS.axisTitle),
+    grid: read(CHART_UI_VARS.grid, FALLBACK_UI_TOKENS.grid),
+  };
+
+  return uiTokenCache;
+}
+
+// ============================================================================
+// Theme Change Subscription (shared)
+// ============================================================================
+
+// One matchMedia listener + one MutationObserver for the whole module, shared by
+// every chart hook. A theme change resets the caches once, then notifies all
+// subscribers — instead of each hook installing its own listener and racing to
+// clear the caches the others just repopulated.
+const subscribers = new Set<() => void>();
+let teardownListeners: (() => void) | null = null;
+
+function handleThemeChange(): void {
+  clearThemeCaches();
+  // Snapshot so a subscriber mounting/unmounting during notification cannot
+  // mutate the set mid-iteration.
+  for (const notify of [...subscribers]) notify();
+}
+
+function ensureListening(): void {
+  if (teardownListeners) return;
+
+  const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+  mediaQuery.addEventListener("change", handleThemeChange);
+
+  const observer = new MutationObserver(handleThemeChange);
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ["class", "data-theme", "data-mode"],
+  });
+
+  teardownListeners = () => {
+    mediaQuery.removeEventListener("change", handleThemeChange);
+    observer.disconnect();
+  };
+}
+
+/**
+ * Resets all module-level theme state: clears both caches and drops the shared
+ * subscription (removing the matchMedia/MutationObserver listeners). Used by
+ * tests to isolate runs; the runtime only ever clears caches, via the dispatcher.
+ * @internal
+ */
+export function resetThemeCache(): void {
+  clearThemeCaches();
+  subscribers.clear();
+  teardownListeners?.();
+  teardownListeners = null;
+}
+
+/**
+ * Subscribes `onChange` to theme changes (system color scheme via matchMedia, or
+ * a theme attribute on the root element). Listeners are shared and ref-counted,
+ * so each hook subscribes once per mount regardless of how `onChange`'s identity
+ * changes between renders.
+ */
+function useThemeChangeEffect(onChange: () => void): void {
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+
+  useEffect(() => {
+    const subscriber = () => onChangeRef.current();
+    subscribers.add(subscriber);
+    ensureListening();
+
+    return () => {
+      subscribers.delete(subscriber);
+      if (subscribers.size === 0 && teardownListeners) {
+        teardownListeners();
+        teardownListeners = null;
+      }
+    };
+  }, []);
+}
+
+// ============================================================================
+// Hooks
+// ============================================================================
+
+/**
  * Hook to get theme colors with automatic updates on theme change.
  * Re-resolves CSS variables when color scheme or theme attributes change.
  *
- * @param palette - Which set to resolve: "categorical" (default), "sequential",
- *   "diverging", or "chrome" (axis/grid/legend colors for chart chrome).
+ * @param palette - Color palette type: "categorical" (default), "sequential", or "diverging"
  */
 export function useThemeColors(
-  palette: ThemeColorScheme = "categorical",
+  palette: ChartColorPalette = "categorical",
 ): string[] {
   const [colors, setColors] = useState<string[]>(() =>
     typeof window === "undefined"
@@ -110,31 +203,34 @@ export function useThemeColors(
       : getThemeColors(palette),
   );
 
-  useEffect(() => {
-    // Clear cache and re-fetch colors when theme changes
-    const updateColors = () => {
-      resetThemeColorCache();
-      setColors(getThemeColors(palette));
-    };
-
-    // Listen for system color scheme changes
-    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-    mediaQuery.addEventListener("change", updateColors);
-
-    // Listen for theme attribute changes (e.g., class="dark", data-theme="dark")
-    const observer = new MutationObserver(updateColors);
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ["class", "data-theme", "data-mode"],
-    });
-
-    return () => {
-      mediaQuery.removeEventListener("change", updateColors);
-      observer.disconnect();
-    };
+  // Re-resolve colors when the theme changes (the cache is reset centrally).
+  const updateColors = useCallback(() => {
+    setColors(getThemeColors(palette));
   }, [palette]);
 
+  useThemeChangeEffect(updateColors);
+
   return colors;
+}
+
+/**
+ * Hook to get the chart-chrome tokens (axis text, titles, grid lines) with
+ * automatic updates on theme change. Pass the result into the ECharts option
+ * builders so axis labels, lines, legends, and titles follow the active theme.
+ */
+export function useChartUITokens(): ChartUITokens {
+  const [tokens, setTokens] = useState<ChartUITokens>(() =>
+    typeof window === "undefined" ? FALLBACK_UI_TOKENS : getThemeUITokens(),
+  );
+
+  // Re-resolve tokens when the theme changes (the cache is reset centrally).
+  const updateTokens = useCallback(() => {
+    setTokens(getThemeUITokens());
+  }, []);
+
+  useThemeChangeEffect(updateTokens);
+
+  return tokens;
 }
 
 /**

--- a/packages/appkit-ui/src/react/charts/theme.ts
+++ b/packages/appkit-ui/src/react/charts/theme.ts
@@ -1,13 +1,15 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   CHART_COLOR_VARS_CATEGORICAL,
   CHART_COLOR_VARS_DIVERGING,
   CHART_COLOR_VARS_SEQUENTIAL,
+  CHART_UI_VARS,
   FALLBACK_COLORS_CATEGORICAL,
   FALLBACK_COLORS_DIVERGING,
   FALLBACK_COLORS_SEQUENTIAL,
+  FALLBACK_UI_TOKENS,
 } from "./constants";
-import type { ChartColorPalette } from "./types";
+import type { ChartColorPalette, ChartUITokens } from "./types";
 
 // ============================================================================
 // Theme Colors (resolved from CSS variables)
@@ -41,13 +43,17 @@ const PALETTE_CONFIG: Record<
  */
 const colorCache = new Map<string, string[]>();
 
+/** Cache for computed chart-chrome tokens (axis text, grid lines). */
+let uiTokenCache: ChartUITokens | null = null;
+
 /**
- * Clears the theme color cache.
+ * Clears the theme color caches (palette colors + chrome tokens).
  * Called when theme change events fire, or for testing when mocks change.
  * @internal
  */
 export function resetThemeColorCache(): void {
   colorCache.clear();
+  uiTokenCache = null;
 }
 
 /**
@@ -83,6 +89,65 @@ function getThemeColors(palette: ChartColorPalette = "categorical"): string[] {
 }
 
 /**
+ * Gets chart-chrome tokens (axis text, titles, grid lines) with caching.
+ * These are read the same way as the palette colors and are authored in `hsla`
+ * so ECharts/zrender can parse them (the `oklch` semantic tokens cannot be
+ * passed to ECharts directly).
+ */
+function getThemeUITokens(): ChartUITokens {
+  if (typeof window === "undefined") return FALLBACK_UI_TOKENS;
+
+  if (uiTokenCache) return uiTokenCache;
+
+  const styles = getComputedStyle(document.documentElement);
+  const read = (varName: string, fallback: string): string => {
+    const value = styles.getPropertyValue(varName).trim();
+    return value || fallback;
+  };
+
+  uiTokenCache = {
+    axisLabel: read(CHART_UI_VARS.axisLabel, FALLBACK_UI_TOKENS.axisLabel),
+    axisTitle: read(CHART_UI_VARS.axisTitle, FALLBACK_UI_TOKENS.axisTitle),
+    grid: read(CHART_UI_VARS.grid, FALLBACK_UI_TOKENS.grid),
+  };
+
+  return uiTokenCache;
+}
+
+// ============================================================================
+// Theme Change Subscription (shared)
+// ============================================================================
+
+/**
+ * Runs `onChange` whenever the active theme changes — either the system color
+ * scheme (matchMedia) or a theme attribute on the root element (class /
+ * data-theme / data-mode). Shared by the color and chrome-token hooks.
+ */
+function useThemeChangeEffect(onChange: () => void): void {
+  useEffect(() => {
+    // Listen for system color scheme changes
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    mediaQuery.addEventListener("change", onChange);
+
+    // Listen for theme attribute changes (e.g., class="dark", data-theme="dark")
+    const observer = new MutationObserver(onChange);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class", "data-theme", "data-mode"],
+    });
+
+    return () => {
+      mediaQuery.removeEventListener("change", onChange);
+      observer.disconnect();
+    };
+  }, [onChange]);
+}
+
+// ============================================================================
+// Hooks
+// ============================================================================
+
+/**
  * Hook to get theme colors with automatic updates on theme change.
  * Re-resolves CSS variables when color scheme or theme attributes change.
  *
@@ -97,31 +162,35 @@ export function useThemeColors(
       : getThemeColors(palette),
   );
 
-  useEffect(() => {
-    // Clear cache and re-fetch colors when theme changes
-    const updateColors = () => {
-      resetThemeColorCache();
-      setColors(getThemeColors(palette));
-    };
-
-    // Listen for system color scheme changes
-    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-    mediaQuery.addEventListener("change", updateColors);
-
-    // Listen for theme attribute changes (e.g., class="dark", data-theme="dark")
-    const observer = new MutationObserver(updateColors);
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ["class", "data-theme", "data-mode"],
-    });
-
-    return () => {
-      mediaQuery.removeEventListener("change", updateColors);
-      observer.disconnect();
-    };
+  // Clear cache and re-fetch colors when theme changes
+  const updateColors = useCallback(() => {
+    resetThemeColorCache();
+    setColors(getThemeColors(palette));
   }, [palette]);
 
+  useThemeChangeEffect(updateColors);
+
   return colors;
+}
+
+/**
+ * Hook to get the chart-chrome tokens (axis text, titles, grid lines) with
+ * automatic updates on theme change. Pass the result into the ECharts option
+ * builders so axis labels, lines, legends, and titles follow the active theme.
+ */
+export function useChartUITokens(): ChartUITokens {
+  const [tokens, setTokens] = useState<ChartUITokens>(() =>
+    typeof window === "undefined" ? FALLBACK_UI_TOKENS : getThemeUITokens(),
+  );
+
+  const updateTokens = useCallback(() => {
+    resetThemeColorCache();
+    setTokens(getThemeUITokens());
+  }, []);
+
+  useThemeChangeEffect(updateTokens);
+
+  return tokens;
 }
 
 /**

--- a/packages/appkit-ui/src/react/charts/types.ts
+++ b/packages/appkit-ui/src/react/charts/types.ts
@@ -31,6 +31,20 @@ export type ChartData = Table | Record<string, unknown>[];
 /** Color palette types for different visualization needs */
 export type ChartColorPalette = "categorical" | "sequential" | "diverging";
 
+/**
+ * Resolved colors for chart "chrome" — axis text, titles, and grid lines.
+ * These are read from CSS variables and passed into ECharts options (which,
+ * unlike the Recharts `ChartContainer`, cannot consume CSS classes directly).
+ */
+export interface ChartUITokens {
+  /** Axis tick labels (≈ `--muted-foreground`) */
+  axisLabel: string;
+  /** Axis names, legend, title, and visualMap text (≈ `--foreground`) */
+  axisTitle: string;
+  /** Axis, tick, and split (grid) lines (≈ `--border`) */
+  grid: string;
+}
+
 /** Common visual and behavior props for all charts */
 export interface ChartBaseProps {
   /** Chart title */

--- a/packages/appkit-ui/src/react/charts/types.ts
+++ b/packages/appkit-ui/src/react/charts/types.ts
@@ -31,11 +31,7 @@ export type ChartData = Table | Record<string, unknown>[];
 /** Color palette types for different visualization needs */
 export type ChartColorPalette = "categorical" | "sequential" | "diverging";
 
-/**
- * Resolved colors for chart "chrome" — axis text, titles, and grid lines.
- * These are read from CSS variables and passed into ECharts options (which,
- * unlike the Recharts `ChartContainer`, cannot consume CSS classes directly).
- */
+/** Resolved colors for chart "chrome" — axis text, titles, and grid lines. */
 export interface ChartUITokens {
   /** Axis tick labels (≈ `--muted-foreground`) */
   axisLabel: string;

--- a/packages/appkit-ui/src/react/charts/types.ts
+++ b/packages/appkit-ui/src/react/charts/types.ts
@@ -31,7 +31,7 @@ export type ChartData = Table | Record<string, unknown>[];
 /** Color palette types for different visualization needs */
 export type ChartColorPalette = "categorical" | "sequential" | "diverging";
 
-/** Resolved colors for chart "chrome" — axis text, titles, and grid lines. */
+/** Resolved colors for the chart UI — axis text, titles, grid lines, and tooltip. */
 export interface ChartUITokens {
   /** Axis tick labels (≈ `--muted-foreground`) */
   axisLabel: string;
@@ -39,6 +39,8 @@ export interface ChartUITokens {
   axisTitle: string;
   /** Axis, tick, and split (grid) lines (≈ `--border`) */
   grid: string;
+  /** Tooltip popover background (≈ `--popover`) */
+  tooltipBg: string;
 }
 
 /** Common visual and behavior props for all charts */

--- a/packages/appkit-ui/src/react/styles/globals.css
+++ b/packages/appkit-ui/src/react/styles/globals.css
@@ -70,8 +70,7 @@
 
   /* ========================================
      CHART CHROME - axis labels, titles, grid lines
-     Authored in hsla so ECharts/zrender can parse them
-     (oklch is not parseable). Visually ≈ the semantic tokens.
+     ≈ muted-foreground / foreground / border (hsla so ECharts can parse)
      ======================================== */
   --chart-axis-label: hsla(
     240,

--- a/packages/appkit-ui/src/react/styles/globals.css
+++ b/packages/appkit-ui/src/react/styles/globals.css
@@ -4,6 +4,7 @@
 
 :root {
   --radius: 0.625rem;
+  color-scheme: light;
   --background: oklch(1 0 0);
   --foreground: oklch(0.141 0.005 285.823);
   --card: oklch(1 0 0);
@@ -67,6 +68,25 @@
   --chart-div-7: hsla(10, 72%, 50%, 1);
   --chart-div-8: hsla(10, 80%, 40%, 1); /* Strong positive */
 
+  /* ========================================
+     CHART CHROME - axis labels, titles, grid lines
+     Authored in hsla so ECharts/zrender can parse them
+     (oklch is not parseable). Visually ≈ the semantic tokens.
+     ======================================== */
+  --chart-axis-label: hsla(
+    240,
+    4%,
+    46%,
+    1
+  ); /* tick labels ≈ --muted-foreground */
+  --chart-axis-title: hsla(
+    240,
+    6%,
+    10%,
+    1
+  ); /* names/legend/title ≈ --foreground */
+  --chart-grid: hsla(240, 5%, 90%, 1); /* axis/tick/split lines ≈ --border */
+
   /* Legacy aliases (for backwards compatibility) */
   --chart-1: var(--chart-cat-1);
   --chart-2: var(--chart-cat-2);
@@ -88,6 +108,7 @@
 
 /* Dark theme via class (takes precedence over media query) */
 .dark {
+  color-scheme: dark;
   --background: oklch(0.141 0.005 285.823);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.21 0.006 285.885);
@@ -111,11 +132,46 @@
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.552 0.016 285.938);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
+  /* CATEGORICAL */
+  --chart-cat-1: hsla(217, 91%, 65%, 1); /* Blue */
+  --chart-cat-2: hsla(160, 65%, 55%, 1); /* Teal */
+  --chart-cat-3: hsla(291, 60%, 65%, 1); /* Purple */
+  --chart-cat-4: hsla(38, 95%, 60%, 1); /* Amber */
+  --chart-cat-5: hsla(349, 80%, 62%, 1); /* Rose */
+  --chart-cat-6: hsla(189, 85%, 52%, 1); /* Cyan */
+  --chart-cat-7: hsla(271, 65%, 70%, 1); /* Lavender */
+  --chart-cat-8: hsla(142, 60%, 55%, 1); /* Emerald */
+  /* SEQUENTIAL (inverted for dark mode) */
+  --chart-seq-1: hsla(217, 50%, 25%, 1);
+  --chart-seq-2: hsla(217, 55%, 35%, 1);
+  --chart-seq-3: hsla(217, 60%, 45%, 1);
+  --chart-seq-4: hsla(217, 65%, 55%, 1);
+  --chart-seq-5: hsla(217, 70%, 62%, 1);
+  --chart-seq-6: hsla(217, 75%, 70%, 1);
+  --chart-seq-7: hsla(217, 80%, 78%, 1);
+  --chart-seq-8: hsla(217, 85%, 88%, 1);
+  /* DIVERGING */
+  --chart-div-1: hsla(217, 85%, 70%, 1);
+  --chart-div-2: hsla(217, 70%, 60%, 1);
+  --chart-div-3: hsla(217, 50%, 50%, 1);
+  --chart-div-4: hsla(217, 25%, 40%, 1);
+  --chart-div-5: hsla(10, 25%, 40%, 1);
+  --chart-div-6: hsla(10, 55%, 50%, 1);
+  --chart-div-7: hsla(10, 70%, 58%, 1);
+  --chart-div-8: hsla(10, 80%, 65%, 1);
+  /* Legacy aliases */
+  --chart-1: var(--chart-cat-1);
+  --chart-2: var(--chart-cat-2);
+  --chart-3: var(--chart-cat-3);
+  --chart-4: var(--chart-cat-4);
+  --chart-5: var(--chart-cat-5);
+  --chart-6: var(--chart-cat-6);
+  --chart-7: var(--chart-cat-7);
+  --chart-8: var(--chart-cat-8);
+  /* Chart chrome (≈ muted-foreground / foreground / border, hsla for ECharts) */
+  --chart-axis-label: hsla(240, 5%, 65%, 1);
+  --chart-axis-title: hsla(0, 0%, 98%, 1);
+  --chart-grid: hsla(0, 0%, 100%, 0.1);
   --sidebar: oklch(0.21 0.006 285.885);
   --sidebar-foreground: oklch(0.985 0 0);
   --sidebar-primary: oklch(0.488 0.243 264.376);
@@ -129,6 +185,7 @@
 /* Dark theme via media query (fallback when no class is set) */
 @media (prefers-color-scheme: dark) {
   :root:not(.light) {
+    color-scheme: dark;
     --background: oklch(0.141 0.005 285.823);
     --foreground: oklch(0.985 0 0);
     --card: oklch(0.21 0.006 285.885);
@@ -192,6 +249,11 @@
     --chart-div-6: hsla(10, 55%, 50%, 1);
     --chart-div-7: hsla(10, 70%, 58%, 1);
     --chart-div-8: hsla(10, 80%, 65%, 1); /* Strong positive (red) */
+
+    /* Chart chrome (≈ muted-foreground / foreground / border, hsla for ECharts) */
+    --chart-axis-label: hsla(240, 5%, 65%, 1);
+    --chart-axis-title: hsla(0, 0%, 98%, 1);
+    --chart-grid: hsla(0, 0%, 100%, 0.1);
 
     /* Legacy aliases */
     --chart-1: var(--chart-cat-1);
@@ -276,6 +338,11 @@
   --color-chart-div-6: var(--chart-div-6);
   --color-chart-div-7: var(--chart-div-7);
   --color-chart-div-8: var(--chart-div-8);
+
+  /* Chart chrome */
+  --color-chart-axis-label: var(--chart-axis-label);
+  --color-chart-axis-title: var(--chart-axis-title);
+  --color-chart-grid: var(--chart-grid);
   --color-sidebar: var(--sidebar);
   --color-sidebar-foreground: var(--sidebar-foreground);
   --color-sidebar-primary: var(--sidebar-primary);

--- a/packages/appkit-ui/src/react/styles/globals.css
+++ b/packages/appkit-ui/src/react/styles/globals.css
@@ -69,12 +69,13 @@
   --chart-div-8: hsla(10, 80%, 40%, 1); /* Strong positive */
 
   /* ========================================
-     CHART CHROME - axis labels, titles, grid lines
-     ≈ muted-foreground / foreground / border (hsla so ECharts can parse)
+     CHART UI TOKENS - axis labels, titles, grid lines, tooltip
+     ≈ muted-foreground / foreground / border / popover (hsla so ECharts can parse)
      ======================================== */
   --chart-axis-label: hsla(240, 4%, 46%, 1);
   --chart-axis-title: hsla(240, 6%, 10%, 1);
   --chart-grid: hsla(240, 5%, 90%, 1);
+  --chart-tooltip-bg: hsla(0, 0%, 100%, 1);
 
   /* Legacy aliases (for backwards compatibility) */
   --chart-1: var(--chart-cat-1);
@@ -157,10 +158,11 @@
   --chart-6: var(--chart-cat-6);
   --chart-7: var(--chart-cat-7);
   --chart-8: var(--chart-cat-8);
-  /* Chart chrome (≈ muted-foreground / foreground / border, hsla for ECharts) */
+  /* Chart UI tokens (≈ muted-foreground / foreground / border / popover, hsla for ECharts) */
   --chart-axis-label: hsla(240, 5%, 65%, 1);
   --chart-axis-title: hsla(0, 0%, 98%, 1);
   --chart-grid: hsla(0, 0%, 100%, 0.1);
+  --chart-tooltip-bg: hsla(240, 6%, 13%, 1);
   --sidebar: oklch(0.21 0.006 285.885);
   --sidebar-foreground: oklch(0.985 0 0);
   --sidebar-primary: oklch(0.488 0.243 264.376);
@@ -239,10 +241,11 @@
     --chart-div-7: hsla(10, 70%, 58%, 1);
     --chart-div-8: hsla(10, 80%, 65%, 1); /* Strong positive (red) */
 
-    /* Chart chrome (≈ muted-foreground / foreground / border, hsla for ECharts) */
+    /* Chart UI tokens (≈ muted-foreground / foreground / border / popover, hsla for ECharts) */
     --chart-axis-label: hsla(240, 5%, 65%, 1);
     --chart-axis-title: hsla(0, 0%, 98%, 1);
     --chart-grid: hsla(0, 0%, 100%, 0.1);
+    --chart-tooltip-bg: hsla(240, 6%, 13%, 1);
 
     /* Legacy aliases */
     --chart-1: var(--chart-cat-1);
@@ -328,10 +331,11 @@
   --color-chart-div-7: var(--chart-div-7);
   --color-chart-div-8: var(--chart-div-8);
 
-  /* Chart chrome */
+  /* Chart UI tokens */
   --color-chart-axis-label: var(--chart-axis-label);
   --color-chart-axis-title: var(--chart-axis-title);
   --color-chart-grid: var(--chart-grid);
+  --color-chart-tooltip-bg: var(--chart-tooltip-bg);
   --color-sidebar: var(--sidebar);
   --color-sidebar-foreground: var(--sidebar-foreground);
   --color-sidebar-primary: var(--sidebar-primary);

--- a/packages/appkit-ui/src/react/styles/globals.css
+++ b/packages/appkit-ui/src/react/styles/globals.css
@@ -72,19 +72,9 @@
      CHART CHROME - axis labels, titles, grid lines
      ≈ muted-foreground / foreground / border (hsla so ECharts can parse)
      ======================================== */
-  --chart-axis-label: hsla(
-    240,
-    4%,
-    46%,
-    1
-  ); /* tick labels ≈ --muted-foreground */
-  --chart-axis-title: hsla(
-    240,
-    6%,
-    10%,
-    1
-  ); /* names/legend/title ≈ --foreground */
-  --chart-grid: hsla(240, 5%, 90%, 1); /* axis/tick/split lines ≈ --border */
+  --chart-axis-label: hsla(240, 4%, 46%, 1);
+  --chart-axis-title: hsla(240, 6%, 10%, 1);
+  --chart-grid: hsla(240, 5%, 90%, 1);
 
   /* Legacy aliases (for backwards compatibility) */
   --chart-1: var(--chart-cat-1);


### PR DESCRIPTION
## Summary

Dark-mode contrast fixes for `@databricks/appkit-ui` charts (plus two small related fixes), surfaced across the dev-playground:

- **Chart chrome** — axis labels, axis names, and grid/axis lines used ECharts' default grays, illegible on dark cards. Series colors were themed; the chrome wasn't.
- **Tooltips** — rendered as ECharts' default white box on dark charts.
- **Palette** — the dark `--chart-cat/seq/div-*` palette was only defined under `@media (prefers-color-scheme: dark)`, not the `.dark` class, so choosing "Dark" while the OS was Light used the light palette.
- **Native inputs** — `color-scheme` per theme fixes the near-invisible date/time calendar picker icon.
- _dev-playground only_ — Lakebase panels swap `amber-*` → theme-aware `warning/*`.

## What changed

**`@databricks/appkit-ui`**
- `styles/globals.css`: per-theme `color-scheme`; new `hsla` chrome vars `--chart-axis-label` / `-axis-title` / `-grid` / `-tooltip-bg` (+ `@theme` entries); mirror the dark `--chart-cat/seq/div-*` palette into `.dark`.
- `charts/`: `useChartUITokens()` resolves the chrome vars via one shared theme-change subscription (same pattern as `useThemeColors`); option builders apply them to axes, grid, legend, title, visualMap, radar chrome, and tooltips (`backgroundColor` / `borderColor` / `textStyle`). Vars are authored in `hsla` because ECharts/zrender cannot parse the `oklch()` semantic tokens.

**dev-playground**
- Lakebase panels: `amber-*` → `warning/*` (matches the existing `destructive/*` usage in the same files).

## Before / After

**Before**

<img width="1440" height="1702" alt="before-01-analytics-fullpage" src="https://github.com/user-attachments/assets/2e1ca969-cda4-4e63-a779-762c0cabbf0a" />
<img width="1440" height="900" alt="before-02-tooltip" src="https://github.com/user-attachments/assets/0aacd8ac-bbaf-45b6-800a-fdaa38d1a35f" />

**After**

<img width="1430" height="1702" alt="after-01-analytics-fullpage" src="https://github.com/user-attachments/assets/07d74ee2-08c7-48f0-96f8-296ed7c01aaf" />
<img width="1440" height="900" alt="after-02-tooltip" src="https://github.com/user-attachments/assets/c1b1be67-1675-415a-861a-b28aaf607a64" />

## Testing

- Chart unit tests cover `useChartUITokens`, the shared theme-change subscription, option-builder chrome, and tooltip theming.
- `pnpm -r typecheck`, `pnpm build`, `pnpm check:fix`, `pnpm docs:build` — all green.
- Verified live in **dark and light** on the analytics dashboard: legible axes, dark themed tooltip, dark-tuned palette applied, no light-mode regression.

This pull request and its description were written by Isaac.
