### PR TITLE
feat(template): auto-start apps on deploy via lifecycle.started

### DIFF
--- a/template/README.md
+++ b/template/README.md
@@ -151,27 +151,15 @@ targets:
 
 Make sure to replace all placeholder values in `databricks.yml` with your actual resource IDs.
 
-### 2. Validate Bundle
+### 2. Deploy
+
+Deploy and start the app with a single command:
 
 ```bash
-databricks bundle validate
+databricks apps deploy
 ```
 
-### 3. Deploy
-
-Deploy to the default target:
-
-```bash
-databricks bundle deploy
-```
-
-### 4. Run
-
-Start the deployed app:
-
-```bash
-databricks bundle run <APP_NAME> -t dev
-```
+`databricks apps deploy` validates the project, deploys it, starts the app, and prints its URL.
 
 ### Deploy to Production
 
@@ -179,8 +167,10 @@ databricks bundle run <APP_NAME> -t dev
 2. Deploy to production:
 
 ```bash
-databricks bundle deploy -t prod
+databricks apps deploy -t prod
 ```
+
+> **Restarting a stopped app:** apps stop after a period of inactivity. To start one again without redeploying, run `databricks apps start <APP_NAME>`.
 
 ## Project Structure
 

--- a/template/databricks.yml.tmpl
+++ b/template/databricks.yml.tmpl
@@ -13,6 +13,10 @@ resources:
       description: "{{.appDescription}}"
       source_code_path: ./
 
+      # Start the app automatically on deploy.
+      lifecycle:
+        started: true
+
 {{- if or .plugins.genie .plugins.files .plugins.serving}}
       user_api_scopes:
 {{- if .plugins.genie}}


### PR DESCRIPTION
## What

- Add `lifecycle.started: true` to the scaffolded `template/databricks.yml.tmpl` (under `resources.apps.app`), so a deploy starts the app and returns its URL — no separate start step.
- Rework `template/README.md` deployment section to use the single **`databricks apps deploy`** command instead of the `bundle validate` → `bundle deploy` → `bundle run` sequence. Adds a short note on restarting a stopped app with `databricks apps start`.

## Why

A bare `databricks bundle deploy` creates the app with `no_compute=true` and leaves it **stopped**, so the scaffolded two-step README (`bundle deploy` then `bundle run`) was the source of agent runs emitting a manual trailing start step (e.g. "To start the deployed app: run `databricks apps start …`"). `lifecycle.started: true` (databricks/cli#4672) flips `no_compute` off; it's supported in direct deployment mode, which is the CLI default. The companion agent-skills PR aligns the docs to recommend `databricks apps deploy`.

## Notes

- `lifecycle.started` requires direct deployment mode (CLI default); only explicit terraform mode (`DATABRICKS_BUNDLE_ENGINE=terraform`) rejects it. Requires Databricks CLI ≥ v0.297.0.
- No committed rendered-template snapshots needed regenerating.

cc the appkit maintainers for review.

This pull request and its description were written by Isaac.