### PR TITLE
feat: skip dev warehouse auto-resolution in agentic mode

### DIFF
--- a/apps/dev-playground/package.json
+++ b/apps/dev-playground/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "start": "node build/index.mjs",
     "start:local": "NODE_ENV=production node --env-file=./server/.env build/index.mjs",
-    "dev": "NODE_ENV=development APPKIT_AUTO_RESOLVE_WAREHOUSE=1 tsx watch server/index.ts",
-    "dev:inspect": "NODE_ENV=development APPKIT_AUTO_RESOLVE_WAREHOUSE=1 tsx --inspect --tsconfig ./tsconfig.json ./server",
+    "dev": "NODE_ENV=development tsx watch server/index.ts",
+    "dev:inspect": "NODE_ENV=development tsx --inspect --tsconfig ./tsconfig.json ./server",
     "build": "npm run build:app",
     "build:app": "tsdown --out-dir build server/index.ts && cd client && npm run build",
     "build:server": "tsdown --out-dir build server/index.ts",

--- a/apps/dev-playground/package.json
+++ b/apps/dev-playground/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "start": "node build/index.mjs",
     "start:local": "NODE_ENV=production node --env-file=./server/.env build/index.mjs",
-    "dev": "NODE_ENV=development tsx watch server/index.ts",
-    "dev:inspect": "NODE_ENV=development tsx --inspect --tsconfig ./tsconfig.json ./server",
+    "dev": "NODE_ENV=development APPKIT_AUTO_RESOLVE_WAREHOUSE=1 tsx watch server/index.ts",
+    "dev:inspect": "NODE_ENV=development APPKIT_AUTO_RESOLVE_WAREHOUSE=1 tsx --inspect --tsconfig ./tsconfig.json ./server",
     "build": "npm run build:app",
     "build:app": "tsdown --out-dir build server/index.ts && cd client && npm run build",
     "build:server": "tsdown --out-dir build server/index.ts",

--- a/packages/appkit/src/context/service-context.ts
+++ b/packages/appkit/src/context/service-context.ts
@@ -236,11 +236,11 @@ export class ServiceContext {
       return process.env.DATABRICKS_WAREHOUSE_ID;
     }
 
-    const autoResolve =
-      process.env.APPKIT_AUTO_RESOLVE_WAREHOUSE === "true" ||
-      process.env.APPKIT_AUTO_RESOLVE_WAREHOUSE === "1";
+    const agenticMode =
+      process.env.DATABRICKS_APPS_AGENTIC_MODE === "true" ||
+      process.env.DATABRICKS_APPS_AGENTIC_MODE === "1";
 
-    if (process.env.NODE_ENV === "development" && autoResolve) {
+    if (process.env.NODE_ENV === "development" && !agenticMode) {
       const response = (await client.apiClient.request({
         path: "/api/2.0/sql/warehouses",
         method: "GET",

--- a/packages/appkit/src/context/service-context.ts
+++ b/packages/appkit/src/context/service-context.ts
@@ -236,7 +236,11 @@ export class ServiceContext {
       return process.env.DATABRICKS_WAREHOUSE_ID;
     }
 
-    if (process.env.NODE_ENV === "development") {
+    const autoResolve =
+      process.env.APPKIT_AUTO_RESOLVE_WAREHOUSE === "true" ||
+      process.env.APPKIT_AUTO_RESOLVE_WAREHOUSE === "1";
+
+    if (process.env.NODE_ENV === "development" && autoResolve) {
       const response = (await client.apiClient.request({
         path: "/api/2.0/sql/warehouses",
         method: "GET",

--- a/packages/appkit/src/context/tests/service-context.test.ts
+++ b/packages/appkit/src/context/tests/service-context.test.ts
@@ -338,24 +338,23 @@ describe("ServiceContext", () => {
       expect(await state.warehouseId).toBe("env-wh-abc");
     });
 
-    test("should throw in dev mode when auto-resolve is not opted in", async () => {
+    test("should skip auto-resolve in dev mode when agentic mode is enabled", async () => {
       delete process.env.DATABRICKS_WAREHOUSE_ID;
-      delete process.env.APPKIT_AUTO_RESOLVE_WAREHOUSE;
       process.env.NODE_ENV = "development";
+      process.env.DATABRICKS_APPS_AGENTIC_MODE = "true";
 
       await expect(
         ServiceContext.initialize({ warehouseId: true }),
       ).rejects.toThrow(ConfigurationError);
-      // Must not attempt to list warehouses without explicit opt-in.
+      // Must not attempt to list warehouses in agentic mode.
       expect(mockApiRequest).not.toHaveBeenCalledWith(
         expect.objectContaining({ path: "/api/2.0/sql/warehouses" }),
       );
     });
 
-    test("should auto-discover warehouse in dev mode when opted in", async () => {
+    test("should auto-discover warehouse in development mode", async () => {
       delete process.env.DATABRICKS_WAREHOUSE_ID;
       process.env.NODE_ENV = "development";
-      process.env.APPKIT_AUTO_RESOLVE_WAREHOUSE = "1";
 
       mockApiRequest.mockImplementation(({ path }: { path: string }) => {
         if (path === "/api/2.0/sql/warehouses") {
@@ -380,7 +379,6 @@ describe("ServiceContext", () => {
     test("should sort warehouses by state priority in dev mode", async () => {
       delete process.env.DATABRICKS_WAREHOUSE_ID;
       process.env.NODE_ENV = "development";
-      process.env.APPKIT_AUTO_RESOLVE_WAREHOUSE = "1";
 
       mockApiRequest.mockImplementation(({ path }: { path: string }) => {
         if (path === "/api/2.0/sql/warehouses") {
@@ -404,7 +402,6 @@ describe("ServiceContext", () => {
     test("should throw in dev mode when no warehouses are available", async () => {
       delete process.env.DATABRICKS_WAREHOUSE_ID;
       process.env.NODE_ENV = "development";
-      process.env.APPKIT_AUTO_RESOLVE_WAREHOUSE = "1";
 
       mockApiRequest.mockImplementation(({ path }: { path: string }) => {
         if (path === "/api/2.0/sql/warehouses") {
@@ -421,7 +418,6 @@ describe("ServiceContext", () => {
     test("should throw in dev mode when all warehouses are deleted", async () => {
       delete process.env.DATABRICKS_WAREHOUSE_ID;
       process.env.NODE_ENV = "development";
-      process.env.APPKIT_AUTO_RESOLVE_WAREHOUSE = "1";
 
       mockApiRequest.mockImplementation(({ path }: { path: string }) => {
         if (path === "/api/2.0/sql/warehouses") {
@@ -443,7 +439,6 @@ describe("ServiceContext", () => {
     test("should throw in dev mode when best warehouse has no id", async () => {
       delete process.env.DATABRICKS_WAREHOUSE_ID;
       process.env.NODE_ENV = "development";
-      process.env.APPKIT_AUTO_RESOLVE_WAREHOUSE = "1";
 
       mockApiRequest.mockImplementation(({ path }: { path: string }) => {
         if (path === "/api/2.0/sql/warehouses") {

--- a/packages/appkit/src/context/tests/service-context.test.ts
+++ b/packages/appkit/src/context/tests/service-context.test.ts
@@ -338,9 +338,24 @@ describe("ServiceContext", () => {
       expect(await state.warehouseId).toBe("env-wh-abc");
     });
 
-    test("should auto-discover warehouse in development mode", async () => {
+    test("should throw in dev mode when auto-resolve is not opted in", async () => {
+      delete process.env.DATABRICKS_WAREHOUSE_ID;
+      delete process.env.APPKIT_AUTO_RESOLVE_WAREHOUSE;
+      process.env.NODE_ENV = "development";
+
+      await expect(
+        ServiceContext.initialize({ warehouseId: true }),
+      ).rejects.toThrow(ConfigurationError);
+      // Must not attempt to list warehouses without explicit opt-in.
+      expect(mockApiRequest).not.toHaveBeenCalledWith(
+        expect.objectContaining({ path: "/api/2.0/sql/warehouses" }),
+      );
+    });
+
+    test("should auto-discover warehouse in dev mode when opted in", async () => {
       delete process.env.DATABRICKS_WAREHOUSE_ID;
       process.env.NODE_ENV = "development";
+      process.env.APPKIT_AUTO_RESOLVE_WAREHOUSE = "1";
 
       mockApiRequest.mockImplementation(({ path }: { path: string }) => {
         if (path === "/api/2.0/sql/warehouses") {
@@ -365,6 +380,7 @@ describe("ServiceContext", () => {
     test("should sort warehouses by state priority in dev mode", async () => {
       delete process.env.DATABRICKS_WAREHOUSE_ID;
       process.env.NODE_ENV = "development";
+      process.env.APPKIT_AUTO_RESOLVE_WAREHOUSE = "1";
 
       mockApiRequest.mockImplementation(({ path }: { path: string }) => {
         if (path === "/api/2.0/sql/warehouses") {
@@ -388,6 +404,7 @@ describe("ServiceContext", () => {
     test("should throw in dev mode when no warehouses are available", async () => {
       delete process.env.DATABRICKS_WAREHOUSE_ID;
       process.env.NODE_ENV = "development";
+      process.env.APPKIT_AUTO_RESOLVE_WAREHOUSE = "1";
 
       mockApiRequest.mockImplementation(({ path }: { path: string }) => {
         if (path === "/api/2.0/sql/warehouses") {
@@ -404,6 +421,7 @@ describe("ServiceContext", () => {
     test("should throw in dev mode when all warehouses are deleted", async () => {
       delete process.env.DATABRICKS_WAREHOUSE_ID;
       process.env.NODE_ENV = "development";
+      process.env.APPKIT_AUTO_RESOLVE_WAREHOUSE = "1";
 
       mockApiRequest.mockImplementation(({ path }: { path: string }) => {
         if (path === "/api/2.0/sql/warehouses") {
@@ -425,6 +443,7 @@ describe("ServiceContext", () => {
     test("should throw in dev mode when best warehouse has no id", async () => {
       delete process.env.DATABRICKS_WAREHOUSE_ID;
       process.env.NODE_ENV = "development";
+      process.env.APPKIT_AUTO_RESOLVE_WAREHOUSE = "1";
 
       mockApiRequest.mockImplementation(({ path }: { path: string }) => {
         if (path === "/api/2.0/sql/warehouses") {


### PR DESCRIPTION
## What

In development, AppKit auto-resolves a SQL warehouse when `DATABRICKS_WAREHOUSE_ID` is unset (lists warehouses and picks the best one by state). This is convenient for local dev, but surprising for agentic contexts such as the Genie app builder, which share the same template `npm run dev` script and should not silently grab a workspace warehouse.

This PR keeps that default behavior and adds an opt-out: when `DATABRICKS_APPS_AGENTIC_MODE` is set to `"true"` or `"1"`, auto-resolution is skipped and a missing warehouse falls through to the usual `ConfigurationError` prompting for `DATABRICKS_WAREHOUSE_ID`.

## Behavior

- `NODE_ENV=development`, no `DATABRICKS_WAREHOUSE_ID`, agentic mode **off** → auto-resolve (unchanged).
- `NODE_ENV=development`, no `DATABRICKS_WAREHOUSE_ID`, agentic mode **on** → skip auto-resolve, throw `ConfigurationError` (no warehouse list call).
- `DATABRICKS_WAREHOUSE_ID` set → used directly, regardless of mode.
- Production → never auto-resolves (existing `NODE_ENV` guard retained).

No behavior change for existing apps that don't set `DATABRICKS_APPS_AGENTIC_MODE`.

## Changes

- `packages/appkit/src/context/service-context.ts` — gate the dev auto-resolve branch on `!agenticMode`.
- `packages/appkit/src/context/tests/service-context.test.ts` — add a test asserting agentic mode skips resolution and never lists warehouses.

## Verification

- `appkit` context test suite: 38/38 pass.
- `@databricks/appkit` typecheck: clean.
