### PR TITLE
chore(docs): point docs links to developers.databricks.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ AppKit's power comes from its plugin system. Each plugin adds a focused capabili
 
 ## Getting started
 
-Follow the [Getting Started](https://www.databricks.com/devhub/docs/appkit/v0/) guide to get started with AppKit.
+Follow the [Getting Started](https://developers.databricks.com/docs/appkit/v0/) guide to get started with AppKit.
 
-🤖 For AI/code assistants, see the [AI-assisted development](https://www.databricks.com/devhub/docs/appkit/v0/development/ai-assisted-development) guide.
+🤖 For AI/code assistants, see the [AI-assisted development](https://developers.databricks.com/docs/appkit/v0/development/ai-assisted-development) guide.
 
 ## Documentation
 
-📖 For full AppKit documentation, visit the [AppKit Documentation](https://www.databricks.com/devhub/docs/appkit/v0/) website.
+📖 For full AppKit documentation, visit the [AppKit Documentation](https://developers.databricks.com/docs/appkit/v0/) website.
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,10 +30,10 @@ This command generates static content into the `build` directory and can be serv
 
 ## Deployment
 
-Documentation is published on [DevHub](https://www.databricks.com/devhub/docs/appkit/v0/). GitHub Pages (`databricks.github.io/appkit/`) automatically redirects all existing URLs to DevHub via `.github/workflows/docs-deploy.yml`.
+Documentation is published on [developers.databricks.com](https://developers.databricks.com/docs/appkit/v0/). GitHub Pages (`databricks.github.io/appkit/`) automatically redirects all existing URLs to developers.databricks.com via `.github/workflows/docs-deploy.yml`.
 
 The `pnpm build` command:
 1. Runs `docusaurus build` — generates HTML, `llms.txt`, and `.md` files
-2. Runs `apply-redirects` — replaces HTML pages with redirect pages pointing to DevHub
+2. Runs `apply-redirects` — replaces HTML pages with redirect pages pointing to developers.databricks.com
 
 Static files remain served from GitHub Pages: JSON schemas (`/schemas/`), `llms.txt`, and `.md` files (used by `npx @databricks/appkit docs` for npm-bundled documentation).

--- a/docs/scripts/apply-redirects.ts
+++ b/docs/scripts/apply-redirects.ts
@@ -1,5 +1,5 @@
 /**
- * Replaces all generated HTML pages with redirect pages pointing to DevHub.
+ * Replaces all generated HTML pages with redirect pages pointing to developers.databricks.com.
  * Run AFTER `docusaurus build` so that llms.txt and .md files are generated
  * from the original HTML content first.
  *
@@ -12,7 +12,7 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const BUILD_DIR = join(__dirname, "../build");
-const DEVHUB_BASE = "https://www.databricks.com/devhub/docs/appkit/v0";
+const DOCS_BASE = "https://developers.databricks.com/docs/appkit/v0";
 
 function generateRedirectHtml(targetUrl: string): string {
   return `<!DOCTYPE html>
@@ -48,7 +48,7 @@ if (!existsSync(BUILD_DIR)) {
   process.exit(1);
 }
 
-console.log("Applying DevHub redirects to HTML pages...");
+console.log("Applying developers.databricks.com redirects to HTML pages...");
 
 const htmlFiles = findHtmlFiles(BUILD_DIR);
 let count = 0;
@@ -59,11 +59,12 @@ for (const htmlPath of htmlFiles) {
     .slice(BUILD_DIR.length)
     .replace(/\/index\.html$/, "");
 
-  // Map /docs/{path} → devhub /{path} (devhub flattens the /docs/ prefix)
+  // Map /docs/{path} → /{path} (the target base already includes /docs/appkit/v0,
+  // so strip the local docusaurus /docs/ route prefix before appending)
   const pathWithoutDocs = relativePath.replace(/^\/docs\/?/, "/");
-  const devhubUrl = `${DEVHUB_BASE}${pathWithoutDocs || "/"}`;
+  const targetUrl = `${DOCS_BASE}${pathWithoutDocs || "/"}`;
 
-  writeFileSync(htmlPath, generateRedirectHtml(devhubUrl));
+  writeFileSync(htmlPath, generateRedirectHtml(targetUrl));
   count++;
 }
 
@@ -77,13 +78,13 @@ const notFoundHtml = `<!DOCTYPE html>
     (function() {
       var path = window.location.pathname.replace(/^\\/appkit\\/?/, '/');
       path = path.replace(/^\\/docs\\/?/, '/');
-      var target = "${DEVHUB_BASE}" + path + window.location.search + window.location.hash;
+      var target = "${DOCS_BASE}" + path + window.location.search + window.location.hash;
       window.location.replace(target);
     })();
   </script>
 </head>
 <body>
-  <p>Redirecting to <a href="${DEVHUB_BASE}/">AppKit Documentation</a>&hellip;</p>
+  <p>Redirecting to <a href="${DOCS_BASE}/">AppKit Documentation</a>&hellip;</p>
 </body>
 </html>`;
 writeFileSync(join(BUILD_DIR, "404.html"), notFoundHtml);

--- a/packages/appkit/src/registry/index.ts
+++ b/packages/appkit/src/registry/index.ts
@@ -29,7 +29,7 @@ export * from "./types";
  * }
  * ```
  *
- * @see {@link https://www.databricks.com/devhub/docs/appkit/v0/ | AppKit Documentation}
+ * @see {@link https://developers.databricks.com/docs/appkit/v0/ | AppKit Documentation}
  */
 // TODO: We may want to open a PR to https://github.com/SchemaStore/schemastore
 // export const MANIFEST_SCHEMA_ID =

--- a/template/README.md
+++ b/template/README.md
@@ -1,6 +1,6 @@
 # {{.projectName}}
 
-A Databricks App powered by [AppKit](https://www.databricks.com/devhub/docs/appkit/v0/), featuring React, TypeScript, and Tailwind CSS.
+A Databricks App powered by [AppKit](https://developers.databricks.com/docs/appkit/v0/), featuring React, TypeScript, and Tailwind CSS.
 
 **Enabled plugins:**
 {{- if .plugins.analytics}}
@@ -41,7 +41,7 @@ DATABRICKS_APP_PORT=8000
 
 #### Lakebase Configuration
 
-The Lakebase plugin requires additional environment variables for PostgreSQL connectivity. To learn how to configure the Lakebase plugin, see the [Lakebase plugin documentation](https://www.databricks.com/devhub/docs/appkit/v0/plugins/lakebase).
+The Lakebase plugin requires additional environment variables for PostgreSQL connectivity. To learn how to configure the Lakebase plugin, see the [Lakebase plugin documentation](https://developers.databricks.com/docs/appkit/v0/plugins/lakebase).
 {{- end}}
 
 ### CLI Authentication

--- a/template/client/src/App.tsx
+++ b/template/client/src/App.tsx
@@ -211,7 +211,7 @@ function HomePage() {
             </li>
             <li>
               <a
-                href="https://www.databricks.com/devhub/docs/appkit/v0/"
+                href="https://developers.databricks.com/docs/appkit/v0/"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-primary underline underline-offset-4 hover:text-primary/80"

--- a/template/server/routes/lakebase/todo-routes.ts
+++ b/template/server/routes/lakebase/todo-routes.ts
@@ -1,6 +1,6 @@
 {{if .plugins.lakebase -}}
 // For per-user connections (OBO) with Row-Level Security, see:
-// https://www.databricks.com/devhub/docs/appkit/v0/plugins/lakebase#on-behalf-of-obo--per-user-connections
+// https://developers.databricks.com/docs/appkit/v0/plugins/lakebase#on-behalf-of-obo--per-user-connections
 
 import { z } from 'zod';
 import { Application } from 'express';
@@ -45,7 +45,7 @@ export async function setupSampleLakebaseRoutes(appkit: AppKitWithLakebase) {
   } catch (err) {
     console.warn('[lakebase] Database setup failed:', (err as Error).message);
     console.warn('[lakebase] Routes will be registered but may return errors');
-    console.warn('[lakebase] See https://www.databricks.com/devhub/docs/appkit/v0/plugins/lakebase#database-permissions for troubleshooting');
+    console.warn('[lakebase] See https://developers.databricks.com/docs/appkit/v0/plugins/lakebase#database-permissions for troubleshooting');
   }
 
   appkit.server.extend((app) => {


### PR DESCRIPTION
## What

Repoint all AppKit documentation links from DevHub to the new canonical home:

```
https://www.databricks.com/devhub/docs/appkit/v0/...  →  https://developers.databricks.com/docs/appkit/v0/...
```

(drop `/devhub`, `www` → `developers`; paths/anchors after `v0` unchanged).

## Changes

- **Link swaps**: `README.md`, `template/README.md`, `template/server/routes/lakebase/todo-routes.ts`, `template/client/src/App.tsx`, `packages/appkit/src/registry/index.ts`.
- **Links + adjacent branding**: `docs/scripts/apply-redirects.ts` (redirect base URL + `DEVHUB_BASE` → `DOCS_BASE` + comments/log) and `docs/README.md` (link text + prose) — so the docs no longer read "published on DevHub" while linking elsewhere.

## Out of scope

- The `.github/workflows/ci.yml` `devhub-validation` job is left unchanged — it clones the `github.com/databricks/devhub` build repo, not a published link.

## Verification

- `grep` confirms no `databricks.com/devhub` URLs remain (only the CI repo clone).
- `apply-redirects.ts` loads and runs without reference errors after the `DEVHUB_BASE` → `DOCS_BASE` rename.

This pull request and its description were written by Isaac.