### PR TITLE
fix(deps): pin template systeminformation to 5.31.7 for JFrog cooldown

### DIFF
--- a/template/package-lock.json
+++ b/template/package-lock.json
@@ -12431,9 +12431,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.31.11",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.11.tgz",
-      "integrity": "sha512-I6O7iaUj23AXRgCPDDnvi3xHvdOLp4+1YMbF+X194lJwY1NeWojgHJPhslVKcmTtrLTguRk3QJK+xEdTiI3P0w==",
+      "version": "5.31.7",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.7.tgz",
+      "integrity": "sha512-/8NC53e5nP9nmhn42/ncdOkyJnOoue/Vy+tJOyUGd1Yv66G069wK4rrziwhrqDETgk78CudTQupw5z19S5uoZw==",
       "license": "MIT",
       "os": [
         "darwin",

--- a/template/package.json
+++ b/template/package.json
@@ -75,6 +75,7 @@
   },
   "overrides": {
     "vite": "npm:rolldown-vite@7.1.14",
-    "@opentelemetry/core": "2.8.0"
+    "@opentelemetry/core": "2.8.0",
+    "systeminformation": "5.31.7"
   }
 }


### PR DESCRIPTION
## Problem

The `Install template dependencies` step fails with `E403` in both CI jobs that build the template artifact:
- `PR Template Artifact` (`ci.yml`) on PRs
- `template-artifact` (`prepare-release.yml`) on `main`

```
npm error 403 Forbidden - GET https://databricks.jfrog.io/.../systeminformation/-/systeminformation-5.31.11.tgz
... blocked by jfrog packages curation service ... {7d-cooldown, Package version is 6 days old}
```

Both jobs run **`npm install`** (not `npm ci`) on a fresh copy of the template. That re-resolves the transitive requirement `systeminformation@^5.31.6` (pulled in by `@databricks/appkit` → `@opentelemetry/instrumentation-host-metrics@0.2.0`) to the newest published version, `5.31.11`. JFrog's curation service blocks packages younger than 7 days, so the download 403s.

This is not a one-off: because the step re-resolves to latest on every run, it breaks again on any fresh `systeminformation` release inside its 7-day cooldown window. The monorepo itself is unaffected — its pnpm lock pins `5.31.7` and CI installs with `--frozen-lockfile`.

## Fix

Pin the transitive dep via the template's existing `overrides` block (same mechanism already used for `vite`/`@opentelemetry/core`) to `5.31.7` — the version AppKit is built/tested against and which JFrog already serves.

- `template/package.json` — add `"systeminformation": "5.31.7"` to `overrides`. `prepare-template-artifact.ts` copies `package.json` (overrides included) into the install dir before `npm install`, so this is what unblocks CI.
- `template/package-lock.json` — update the committed entry `5.31.11 → 5.31.7` (integrity taken from the monorepo pnpm lock) so the source snapshot stays consistent.

## Verification
- `tools/check-template-deps.ts` → passes (pin check only inspects `dependencies`/`devDependencies`).
- `tools/check-template-lock-registry.ts` → passes (public npm registry only).

Note: this pins `systeminformation` for scaffolded apps until someone bumps it — acceptable for a telemetry transitive dep and consistent with the other pinned overrides.