### PR TITLE
feat(appkit): mlflow tracing for agents (stack 1/5)

### DIFF
--- a/packages/appkit/package.json
+++ b/packages/appkit/package.json
@@ -85,7 +85,7 @@
     "get-port": "7.2.0",
     "js-yaml": "4.2.0",
     "magic-string": "0.30.21",
-    "mlflow-tracing": "^0.1.3",
+    "mlflow-tracing": "0.1.3",
     "obug": "2.1.1",
     "pg": "8.18.0",
     "picocolors": "1.1.1",

--- a/packages/appkit/package.json
+++ b/packages/appkit/package.json
@@ -85,6 +85,7 @@
     "get-port": "7.2.0",
     "js-yaml": "4.2.0",
     "magic-string": "0.30.21",
+    "mlflow-tracing": "^0.1.3",
     "obug": "2.1.1",
     "pg": "8.18.0",
     "picocolors": "1.1.1",

--- a/packages/appkit/src/plugins/agents/agents.ts
+++ b/packages/appkit/src/plugins/agents/agents.ts
@@ -1302,10 +1302,8 @@ export class AgentsPlugin extends Plugin implements ToolProvider {
     const tools = Array.from(registered.toolIndex.values()).map((e) => e.def);
     const limits = this.resolvedLimits;
 
-    // Surfaced in the response envelope so an eval runner can attach
-    // assessments to this turn's trace. Set inside the span below (the only
-    // context where the active trace id is resolvable); undefined when tracing
-    // is disabled.
+    // Assigned inside the span below (the only place the active trace id
+    // resolves), read into the response envelope after.
     let mlflowTraceId: string | undefined;
 
     const runState: RunState = {
@@ -1341,8 +1339,8 @@ export class AgentsPlugin extends Plugin implements ToolProvider {
           })),
         },
         async (span) => {
-          // Link this turn's trace to an eval run when supplied, so the trace
-          // shows under the MLflow evaluation run. Mirrors `_streamAgent`.
+          // Link this turn's trace to an eval run when the eval runner
+          // supplied one, so the trace shows under the MLflow evaluation run.
           if (mlflowRunId) linkTraceToRun(mlflowRunId);
 
           const pluginNames = this.context
@@ -1392,8 +1390,6 @@ export class AgentsPlugin extends Plugin implements ToolProvider {
             });
           }
 
-          // Capture inside the span, where the active trace id resolves.
-          // No-op when tracing is disabled.
           mlflowTraceId = currentTraceId();
         },
       );
@@ -1442,9 +1438,8 @@ export class AgentsPlugin extends Plugin implements ToolProvider {
       created_at: Math.floor(Date.now() / 1000),
       status: "completed",
       thread_id: thread.id,
-      // Present only when tracing is enabled; lets an eval runner attach
-      // assessments to this turn's trace (the streaming path surfaces the same
-      // id via a `metadata` event).
+      // Lets an eval runner attach assessments to this turn's trace; absent
+      // when tracing is disabled.
       ...(mlflowTraceId ? { mlflow_trace_id: mlflowTraceId } : {}),
       output: [message],
     });

--- a/packages/appkit/src/plugins/agents/agents.ts
+++ b/packages/appkit/src/plugins/agents/agents.ts
@@ -1118,9 +1118,7 @@ export class AgentsPlugin extends Plugin implements ToolProvider {
           outboundEvents.push(evt);
         }
 
-        // Root MLflow span for the turn (AGENT). Tool calls dispatched while
-        // the adapter streams nest under it via the SDK's active context.
-        // No-op passthrough unless an MLflow experiment is bound.
+        // Root MLflow span for the turn; tool-call spans nest under it.
         await traceAgent(
           registered.name ?? "agent",
           {
@@ -1471,8 +1469,8 @@ export class AgentsPlugin extends Plugin implements ToolProvider {
       }
     }
 
-    // MLflow TOOL span — nests under the turn's AGENT span. Wraps the
-    // execution only (not the approval wait above, which is human latency).
+    // Traced from here so the span covers execution only, not the approval
+    // wait above (which is human latency).
     const toolResult = await traceTool(name, args, async () => {
       let result: unknown;
       if (entry.source === "toolkit") {
@@ -1534,7 +1532,6 @@ export class AgentsPlugin extends Plugin implements ToolProvider {
         );
       }
 
-      // Auto-captured as the TOOL span's outputs by `traceTool`.
       return result;
     });
 

--- a/packages/appkit/src/plugins/agents/agents.ts
+++ b/packages/appkit/src/plugins/agents/agents.ts
@@ -885,7 +885,7 @@ export class AgentsPlugin extends Plugin implements ToolProvider {
       });
       return;
     }
-    const { message, threadId, agent: agentName } = parsed.data;
+    const { message, threadId, agent: agentName, mlflowRunId } = parsed.data;
 
     const registered = this.resolveAgent(agentName);
     if (!registered) {
@@ -939,7 +939,7 @@ export class AgentsPlugin extends Plugin implements ToolProvider {
       res.status(500).json({ error: "Thread operation failed" });
       return;
     }
-    return this._streamAgent(req, res, registered, thread, userId);
+    return this._streamAgent(req, res, registered, thread, userId, mlflowRunId);
   }
 
   /**
@@ -1066,6 +1066,7 @@ export class AgentsPlugin extends Plugin implements ToolProvider {
     registered: RegisteredAgent,
     thread: Thread,
     userId: string,
+    mlflowRunId?: string,
   ): Promise<void> {
     const abortController = new AbortController();
     const signal = abortController.signal;
@@ -1130,9 +1131,7 @@ export class AgentsPlugin extends Plugin implements ToolProvider {
           async (span) => {
             // Link this turn's trace to an eval run when the eval runner
             // supplied one, so the trace shows under the MLflow evaluation run.
-            const evalRunId = (req.body as { mlflowRunId?: string })
-              ?.mlflowRunId;
-            if (evalRunId) linkTraceToRun(evalRunId);
+            if (mlflowRunId) linkTraceToRun(mlflowRunId);
 
             const pluginNames = this.context
               ? this.context

--- a/packages/appkit/src/plugins/agents/agents.ts
+++ b/packages/appkit/src/plugins/agents/agents.ts
@@ -59,7 +59,8 @@ import {
   currentTraceId,
   initAgentTracing,
   linkTraceToRun,
-  withAgentSpan,
+  traceAgent,
+  traceTool,
 } from "./mlflow";
 import {
   approvalRequestSchema,
@@ -1120,16 +1121,13 @@ export class AgentsPlugin extends Plugin implements ToolProvider {
         // Root MLflow span for the turn (AGENT). Tool calls dispatched while
         // the adapter streams nest under it via the SDK's active context.
         // No-op passthrough unless an MLflow experiment is bound.
-        await withAgentSpan(
+        await traceAgent(
+          registered.name ?? "agent",
           {
-            name: registered.name ?? "agent",
-            type: "AGENT",
-            inputs: {
-              messages: thread.messages.map((m) => ({
-                role: m.role,
-                content: m.content,
-              })),
-            },
+            messages: thread.messages.map((m) => ({
+              role: m.role,
+              content: m.content,
+            })),
           },
           async (span) => {
             // Link this turn's trace to an eval run when the eval runner
@@ -1187,7 +1185,7 @@ export class AgentsPlugin extends Plugin implements ToolProvider {
             });
 
             if (fullContent) {
-              span?.setOutputs({ role: "assistant", content: fullContent });
+              span.setOutputs({ role: "assistant", content: fullContent });
               await this.threadStore.addMessage(thread.id, userId, {
                 id: randomUUID(),
                 role: "assistant",
@@ -1475,82 +1473,70 @@ export class AgentsPlugin extends Plugin implements ToolProvider {
 
     // MLflow TOOL span — nests under the turn's AGENT span. Wraps the
     // execution only (not the approval wait above, which is human latency).
-    const toolResult = await withAgentSpan(
-      { name, type: "TOOL", inputs: args },
-      async (span) => {
-        let result: unknown;
-        if (entry.source === "toolkit") {
-          if (!this.context) {
-            throw new Error(
-              "Plugin tool execution requires PluginContext; this should never happen through createApp",
-            );
-          }
-          result = await this.context.executeTool(
-            runState.req,
-            entry.pluginName,
-            entry.localName,
-            args,
-            runState.signal,
-            runState.limits.toolCallTimeoutMs,
-          );
-        } else if (entry.source === "function") {
-          // Function tools declare their parameters as a JSON-object schema,
-          // so adapters always serialize `args` as an object. A non-object
-          // value here means the upstream model emitted malformed tool-call
-          // JSON; surface a clear error rather than silently passing through
-          // a wrong-shape value the tool will then choke on.
-          if (
-            typeof args !== "object" ||
-            args === null ||
-            Array.isArray(args)
-          ) {
-            throw new Error(
-              `Function tool '${name}' received non-object arguments (got ${args === null ? "null" : Array.isArray(args) ? "array" : typeof args}); expected a JSON object.`,
-            );
-          }
-          result = await entry.functionTool.execute(
-            args as Record<string, unknown>,
-          );
-        } else if (entry.source === "mcp") {
-          if (!this.mcpClient) throw new Error("MCP client not connected");
-          const oboToken = runState.req.headers["x-forwarded-access-token"];
-          const mcpAuth =
-            typeof oboToken === "string"
-              ? { Authorization: `Bearer ${oboToken}` }
-              : undefined;
-          result = await this.mcpClient.callTool(
-            entry.mcpToolName,
-            args,
-            mcpAuth,
-          );
-        } else if (entry.source === "subagent") {
-          const childAgent = this.agents.get(entry.agentName);
-          if (!childAgent)
-            throw new Error(`Sub-agent not found: ${entry.agentName}`);
-          result = await this.runSubAgent(
-            runState,
-            childAgent,
-            args,
-            depth + 1,
-          );
-        } else if (entry.source === "hosted-supervisor") {
-          // Defense-in-depth: should never fire. Hosted-supervisor entries are
-          // routed via `AgentInput.extensions` and the SA endpoint executes
-          // them server-side; their `def` is filtered out of the adapter's
-          // `tools` array, so the model never sees a callable schema for them.
-          // If we reach here, the agent is paired with a non-SA adapter that
-          // somehow surfaced the placeholder def to the model — surface a
-          // clear error rather than crash later in `normalizeToolResult`.
+    const toolResult = await traceTool(name, args, async () => {
+      let result: unknown;
+      if (entry.source === "toolkit") {
+        if (!this.context) {
           throw new Error(
-            `Tool '${name}' is a hosted-supervisor tool and cannot be invoked from the Node process. ` +
-              "It is executed server-side by the Databricks AI Gateway and is only reachable when the agent's model is a Supervisor API adapter.",
+            "Plugin tool execution requires PluginContext; this should never happen through createApp",
           );
         }
+        result = await this.context.executeTool(
+          runState.req,
+          entry.pluginName,
+          entry.localName,
+          args,
+          runState.signal,
+          runState.limits.toolCallTimeoutMs,
+        );
+      } else if (entry.source === "function") {
+        // Function tools declare their parameters as a JSON-object schema,
+        // so adapters always serialize `args` as an object. A non-object
+        // value here means the upstream model emitted malformed tool-call
+        // JSON; surface a clear error rather than silently passing through
+        // a wrong-shape value the tool will then choke on.
+        if (typeof args !== "object" || args === null || Array.isArray(args)) {
+          throw new Error(
+            `Function tool '${name}' received non-object arguments (got ${args === null ? "null" : Array.isArray(args) ? "array" : typeof args}); expected a JSON object.`,
+          );
+        }
+        result = await entry.functionTool.execute(
+          args as Record<string, unknown>,
+        );
+      } else if (entry.source === "mcp") {
+        if (!this.mcpClient) throw new Error("MCP client not connected");
+        const oboToken = runState.req.headers["x-forwarded-access-token"];
+        const mcpAuth =
+          typeof oboToken === "string"
+            ? { Authorization: `Bearer ${oboToken}` }
+            : undefined;
+        result = await this.mcpClient.callTool(
+          entry.mcpToolName,
+          args,
+          mcpAuth,
+        );
+      } else if (entry.source === "subagent") {
+        const childAgent = this.agents.get(entry.agentName);
+        if (!childAgent)
+          throw new Error(`Sub-agent not found: ${entry.agentName}`);
+        result = await this.runSubAgent(runState, childAgent, args, depth + 1);
+      } else if (entry.source === "hosted-supervisor") {
+        // Defense-in-depth: should never fire. Hosted-supervisor entries are
+        // routed via `AgentInput.extensions` and the SA endpoint executes
+        // them server-side; their `def` is filtered out of the adapter's
+        // `tools` array, so the model never sees a callable schema for them.
+        // If we reach here, the agent is paired with a non-SA adapter that
+        // somehow surfaced the placeholder def to the model — surface a
+        // clear error rather than crash later in `normalizeToolResult`.
+        throw new Error(
+          `Tool '${name}' is a hosted-supervisor tool and cannot be invoked from the Node process. ` +
+            "It is executed server-side by the Databricks AI Gateway and is only reachable when the agent's model is a Supervisor API adapter.",
+        );
+      }
 
-        span?.setOutputs(result);
-        return result;
-      },
-    );
+      // Auto-captured as the TOOL span's outputs by `traceTool`.
+      return result;
+    });
 
     return normalizeToolResult(toolResult);
   }

--- a/packages/appkit/src/plugins/agents/agents.ts
+++ b/packages/appkit/src/plugins/agents/agents.ts
@@ -56,6 +56,12 @@ import { EventChannel } from "./event-channel";
 import { AgentEventTranslator } from "./event-translator";
 import manifest from "./manifest.json";
 import {
+  currentTraceId,
+  initAgentTracing,
+  linkTraceToRun,
+  withAgentSpan,
+} from "./mlflow";
+import {
   approvalRequestSchema,
   cancelRequestSchema,
   chatRequestSchema,
@@ -133,7 +139,11 @@ interface RunState {
 }
 
 export class AgentsPlugin extends Plugin implements ToolProvider {
-  static manifest = manifest as PluginManifest;
+  // Routed through `unknown`: the optional resources have differing `fields`
+  // keys (serving `name`, experiment `experimentId`), which TS widens to an
+  // incompatible union on the JSON import. The shape is validated at runtime
+  // against the plugin-manifest schema.
+  static manifest = manifest as unknown as PluginManifest;
   static phase: PluginPhase = "deferred";
 
   protected declare config: AgentsPluginConfig;
@@ -276,6 +286,7 @@ export class AgentsPlugin extends Plugin implements ToolProvider {
   }
 
   async setup() {
+    await initAgentTracing();
     const { agents, defaultAgentName } = await this.buildAgentRegistry();
     this.agents = agents;
     this.defaultAgentName = defaultAgentName;
@@ -1106,62 +1117,98 @@ export class AgentsPlugin extends Plugin implements ToolProvider {
           outboundEvents.push(evt);
         }
 
-        const pluginNames = this.context
-          ? this.context
-              .getPluginNames()
-              .filter((n) => n !== this.name && n !== "server")
-          : [];
-        const fullPrompt = composePromptForAgent(
-          registered,
-          this.config.baseSystemPrompt,
+        // Root MLflow span for the turn (AGENT). Tool calls dispatched while
+        // the adapter streams nest under it via the SDK's active context.
+        // No-op passthrough unless an MLflow experiment is bound.
+        await withAgentSpan(
           {
-            agentName: registered.name,
-            pluginNames,
-            toolNames: tools.map((t) => t.name),
+            name: registered.name ?? "agent",
+            type: "AGENT",
+            inputs: {
+              messages: thread.messages.map((m) => ({
+                role: m.role,
+                content: m.content,
+              })),
+            },
           },
-        );
+          async (span) => {
+            // Link this turn's trace to an eval run when the eval runner
+            // supplied one, so the trace shows under the MLflow evaluation run.
+            const evalRunId = (req.body as { mlflowRunId?: string })
+              ?.mlflowRunId;
+            if (evalRunId) linkTraceToRun(evalRunId);
 
-        const messagesWithSystem: Message[] = [
-          {
-            id: "system",
-            role: "system",
-            content: fullPrompt,
-            createdAt: new Date(),
-          },
-          ...thread.messages,
-        ];
+            const pluginNames = this.context
+              ? this.context
+                  .getPluginNames()
+                  .filter((n) => n !== this.name && n !== "server")
+              : [];
+            const fullPrompt = composePromptForAgent(
+              registered,
+              this.config.baseSystemPrompt,
+              {
+                agentName: registered.name,
+                pluginNames,
+                toolNames: tools.map((t) => t.name),
+              },
+            );
 
-        const stream = registered.adapter.run(
-          {
-            messages: messagesWithSystem,
-            tools,
-            threadId: thread.id,
-            signal,
-            extensions: buildAdapterExtensions(registered.toolIndex),
-          },
-          { executeTool, signal },
-        );
+            const messagesWithSystem: Message[] = [
+              {
+                id: "system",
+                role: "system",
+                content: fullPrompt,
+                createdAt: new Date(),
+              },
+              ...thread.messages,
+            ];
 
-        // The accumulation rule (deltas append, `message` replaces) is shared
-        // with `runAgent` and `runSubAgent`; see `consumeAdapterStream` for
-        // the rationale.
-        const fullContent = await consumeAdapterStream(stream, {
-          signal,
-          onEvent: (event) => {
-            for (const translated of translator.translate(event)) {
-              outboundEvents.push(translated);
+            const stream = registered.adapter.run(
+              {
+                messages: messagesWithSystem,
+                tools,
+                threadId: thread.id,
+                signal,
+                extensions: buildAdapterExtensions(registered.toolIndex),
+              },
+              { executeTool, signal },
+            );
+
+            // The accumulation rule (deltas append, `message` replaces) is
+            // shared with `runAgent` and `runSubAgent`; see
+            // `consumeAdapterStream` for the rationale.
+            const fullContent = await consumeAdapterStream(stream, {
+              signal,
+              onEvent: (event) => {
+                for (const translated of translator.translate(event)) {
+                  outboundEvents.push(translated);
+                }
+              },
+            });
+
+            if (fullContent) {
+              span?.setOutputs({ role: "assistant", content: fullContent });
+              await this.threadStore.addMessage(thread.id, userId, {
+                id: randomUUID(),
+                role: "assistant",
+                content: fullContent,
+                createdAt: new Date(),
+              });
+            }
+
+            // Surface the MLflow trace id so eval runs can attach assessments
+            // to this turn's trace. No-op when tracing is disabled.
+            const mlflowTraceId = currentTraceId();
+            if (mlflowTraceId) {
+              for (const evt of translator.translate({
+                type: "metadata",
+                data: { mlflowTraceId },
+              })) {
+                outboundEvents.push(evt);
+              }
             }
           },
-        });
-
-        if (fullContent) {
-          await this.threadStore.addMessage(thread.id, userId, {
-            id: randomUUID(),
-            role: "assistant",
-            content: fullContent,
-            createdAt: new Date(),
-          });
-        }
+        );
 
         for (const evt of translator.finalize()) outboundEvents.push(evt);
       } catch (error) {
@@ -1426,63 +1473,86 @@ export class AgentsPlugin extends Plugin implements ToolProvider {
       }
     }
 
-    let result: unknown;
-    if (entry.source === "toolkit") {
-      if (!this.context) {
-        throw new Error(
-          "Plugin tool execution requires PluginContext; this should never happen through createApp",
-        );
-      }
-      result = await this.context.executeTool(
-        runState.req,
-        entry.pluginName,
-        entry.localName,
-        args,
-        runState.signal,
-        runState.limits.toolCallTimeoutMs,
-      );
-    } else if (entry.source === "function") {
-      // Function tools declare their parameters as a JSON-object schema,
-      // so adapters always serialize `args` as an object. A non-object
-      // value here means the upstream model emitted malformed tool-call
-      // JSON; surface a clear error rather than silently passing through
-      // a wrong-shape value the tool will then choke on.
-      if (typeof args !== "object" || args === null || Array.isArray(args)) {
-        throw new Error(
-          `Function tool '${name}' received non-object arguments (got ${args === null ? "null" : Array.isArray(args) ? "array" : typeof args}); expected a JSON object.`,
-        );
-      }
-      result = await entry.functionTool.execute(
-        args as Record<string, unknown>,
-      );
-    } else if (entry.source === "mcp") {
-      if (!this.mcpClient) throw new Error("MCP client not connected");
-      const oboToken = runState.req.headers["x-forwarded-access-token"];
-      const mcpAuth =
-        typeof oboToken === "string"
-          ? { Authorization: `Bearer ${oboToken}` }
-          : undefined;
-      result = await this.mcpClient.callTool(entry.mcpToolName, args, mcpAuth);
-    } else if (entry.source === "subagent") {
-      const childAgent = this.agents.get(entry.agentName);
-      if (!childAgent)
-        throw new Error(`Sub-agent not found: ${entry.agentName}`);
-      result = await this.runSubAgent(runState, childAgent, args, depth + 1);
-    } else if (entry.source === "hosted-supervisor") {
-      // Defense-in-depth: should never fire. Hosted-supervisor entries are
-      // routed via `AgentInput.extensions` and the SA endpoint executes
-      // them server-side; their `def` is filtered out of the adapter's
-      // `tools` array, so the model never sees a callable schema for them.
-      // If we reach here, the agent is paired with a non-SA adapter that
-      // somehow surfaced the placeholder def to the model — surface a
-      // clear error rather than crash later in `normalizeToolResult`.
-      throw new Error(
-        `Tool '${name}' is a hosted-supervisor tool and cannot be invoked from the Node process. ` +
-          "It is executed server-side by the Databricks AI Gateway and is only reachable when the agent's model is a Supervisor API adapter.",
-      );
-    }
+    // MLflow TOOL span — nests under the turn's AGENT span. Wraps the
+    // execution only (not the approval wait above, which is human latency).
+    const toolResult = await withAgentSpan(
+      { name, type: "TOOL", inputs: args },
+      async (span) => {
+        let result: unknown;
+        if (entry.source === "toolkit") {
+          if (!this.context) {
+            throw new Error(
+              "Plugin tool execution requires PluginContext; this should never happen through createApp",
+            );
+          }
+          result = await this.context.executeTool(
+            runState.req,
+            entry.pluginName,
+            entry.localName,
+            args,
+            runState.signal,
+            runState.limits.toolCallTimeoutMs,
+          );
+        } else if (entry.source === "function") {
+          // Function tools declare their parameters as a JSON-object schema,
+          // so adapters always serialize `args` as an object. A non-object
+          // value here means the upstream model emitted malformed tool-call
+          // JSON; surface a clear error rather than silently passing through
+          // a wrong-shape value the tool will then choke on.
+          if (
+            typeof args !== "object" ||
+            args === null ||
+            Array.isArray(args)
+          ) {
+            throw new Error(
+              `Function tool '${name}' received non-object arguments (got ${args === null ? "null" : Array.isArray(args) ? "array" : typeof args}); expected a JSON object.`,
+            );
+          }
+          result = await entry.functionTool.execute(
+            args as Record<string, unknown>,
+          );
+        } else if (entry.source === "mcp") {
+          if (!this.mcpClient) throw new Error("MCP client not connected");
+          const oboToken = runState.req.headers["x-forwarded-access-token"];
+          const mcpAuth =
+            typeof oboToken === "string"
+              ? { Authorization: `Bearer ${oboToken}` }
+              : undefined;
+          result = await this.mcpClient.callTool(
+            entry.mcpToolName,
+            args,
+            mcpAuth,
+          );
+        } else if (entry.source === "subagent") {
+          const childAgent = this.agents.get(entry.agentName);
+          if (!childAgent)
+            throw new Error(`Sub-agent not found: ${entry.agentName}`);
+          result = await this.runSubAgent(
+            runState,
+            childAgent,
+            args,
+            depth + 1,
+          );
+        } else if (entry.source === "hosted-supervisor") {
+          // Defense-in-depth: should never fire. Hosted-supervisor entries are
+          // routed via `AgentInput.extensions` and the SA endpoint executes
+          // them server-side; their `def` is filtered out of the adapter's
+          // `tools` array, so the model never sees a callable schema for them.
+          // If we reach here, the agent is paired with a non-SA adapter that
+          // somehow surfaced the placeholder def to the model — surface a
+          // clear error rather than crash later in `normalizeToolResult`.
+          throw new Error(
+            `Tool '${name}' is a hosted-supervisor tool and cannot be invoked from the Node process. ` +
+              "It is executed server-side by the Databricks AI Gateway and is only reachable when the agent's model is a Supervisor API adapter.",
+          );
+        }
 
-    return normalizeToolResult(result);
+        span?.setOutputs(result);
+        return result;
+      },
+    );
+
+    return normalizeToolResult(toolResult);
   }
 
   /**

--- a/packages/appkit/src/plugins/agents/agents.ts
+++ b/packages/appkit/src/plugins/agents/agents.ts
@@ -985,7 +985,7 @@ export class AgentsPlugin extends Plugin implements ToolProvider {
       });
       return;
     }
-    const { input } = parsed.data;
+    const { input, mlflowRunId } = parsed.data;
     const registered = this.resolveAgent();
     if (!registered) {
       res.status(400).json({ error: "No agent registered" });
@@ -1057,7 +1057,14 @@ export class AgentsPlugin extends Plugin implements ToolProvider {
       return;
     }
 
-    return this._runAgentNonStreaming(req, res, registered, thread, userId);
+    return this._runAgentNonStreaming(
+      req,
+      res,
+      registered,
+      thread,
+      userId,
+      mlflowRunId,
+    );
   }
 
   private async _streamAgent(
@@ -1285,6 +1292,7 @@ export class AgentsPlugin extends Plugin implements ToolProvider {
     registered: RegisteredAgent,
     thread: Thread,
     userId: string,
+    mlflowRunId?: string,
   ): Promise<void> {
     const abortController = new AbortController();
     const signal = abortController.signal;
@@ -1293,6 +1301,12 @@ export class AgentsPlugin extends Plugin implements ToolProvider {
 
     const tools = Array.from(registered.toolIndex.values()).map((e) => e.def);
     const limits = this.resolvedLimits;
+
+    // Surfaced in the response envelope so an eval runner can attach
+    // assessments to this turn's trace. Set inside the span below (the only
+    // context where the active trace id is resolvable); undefined when tracing
+    // is disabled.
+    let mlflowTraceId: string | undefined;
 
     const runState: RunState = {
       req,
@@ -1327,6 +1341,10 @@ export class AgentsPlugin extends Plugin implements ToolProvider {
           })),
         },
         async (span) => {
+          // Link this turn's trace to an eval run when supplied, so the trace
+          // shows under the MLflow evaluation run. Mirrors `_streamAgent`.
+          if (mlflowRunId) linkTraceToRun(mlflowRunId);
+
           const pluginNames = this.context
             ? this.context
                 .getPluginNames()
@@ -1373,6 +1391,10 @@ export class AgentsPlugin extends Plugin implements ToolProvider {
               createdAt: new Date(),
             });
           }
+
+          // Capture inside the span, where the active trace id resolves.
+          // No-op when tracing is disabled.
+          mlflowTraceId = currentTraceId();
         },
       );
     } catch (error) {
@@ -1420,6 +1442,10 @@ export class AgentsPlugin extends Plugin implements ToolProvider {
       created_at: Math.floor(Date.now() / 1000),
       status: "completed",
       thread_id: thread.id,
+      // Present only when tracing is enabled; lets an eval runner attach
+      // assessments to this turn's trace (the streaming path surfaces the same
+      // id via a `metadata` event).
+      ...(mlflowTraceId ? { mlflow_trace_id: mlflowTraceId } : {}),
       output: [message],
     });
   }

--- a/packages/appkit/src/plugins/agents/agents.ts
+++ b/packages/appkit/src/plugins/agents/agents.ts
@@ -1315,51 +1315,66 @@ export class AgentsPlugin extends Plugin implements ToolProvider {
 
     let fullContent = "";
     try {
-      const pluginNames = this.context
-        ? this.context
-            .getPluginNames()
-            .filter((n) => n !== this.name && n !== "server")
-        : [];
-      const fullPrompt = composePromptForAgent(
-        registered,
-        this.config.baseSystemPrompt,
+      // Root MLflow span for the turn; tool-call spans nest under it. Mirrors
+      // the streaming path so the invoke surface produces the same trace shape
+      // instead of orphan root TOOL spans.
+      await traceAgent(
+        registered.name ?? "agent",
         {
-          agentName: registered.name,
-          pluginNames,
-          toolNames: tools.map((t) => t.name),
+          messages: thread.messages.map((m) => ({
+            role: m.role,
+            content: m.content,
+          })),
+        },
+        async (span) => {
+          const pluginNames = this.context
+            ? this.context
+                .getPluginNames()
+                .filter((n) => n !== this.name && n !== "server")
+            : [];
+          const fullPrompt = composePromptForAgent(
+            registered,
+            this.config.baseSystemPrompt,
+            {
+              agentName: registered.name,
+              pluginNames,
+              toolNames: tools.map((t) => t.name),
+            },
+          );
+
+          const messagesWithSystem: Message[] = [
+            {
+              id: "system",
+              role: "system",
+              content: fullPrompt,
+              createdAt: new Date(),
+            },
+            ...thread.messages,
+          ];
+
+          const stream = registered.adapter.run(
+            {
+              messages: messagesWithSystem,
+              tools,
+              threadId: thread.id,
+              signal,
+            },
+            { executeTool, signal },
+          );
+
+          fullContent = await consumeAdapterStream(stream, { signal });
+
+          if (fullContent) {
+            span.setOutputs({ role: "assistant", content: fullContent });
+            await this.threadStore.addMessage(thread.id, userId, {
+              id: randomUUID(),
+              role: "assistant",
+              content: fullContent,
+              createdAt: new Date(),
+            });
+          }
         },
       );
-
-      const messagesWithSystem: Message[] = [
-        {
-          id: "system",
-          role: "system",
-          content: fullPrompt,
-          createdAt: new Date(),
-        },
-        ...thread.messages,
-      ];
-
-      const stream = registered.adapter.run(
-        {
-          messages: messagesWithSystem,
-          tools,
-          threadId: thread.id,
-          signal,
-        },
-        { executeTool, signal },
-      );
-
-      fullContent = await consumeAdapterStream(stream, { signal });
-
-      if (fullContent) {
-        await this.threadStore.addMessage(thread.id, userId, {
-          id: randomUUID(),
-          role: "assistant",
-          content: fullContent,
-          createdAt: new Date(),
-        });
-      }
     } catch (error) {
       if (signal.aborted) {
         res.status(499).json({ error: "Request aborted" });

--- a/packages/appkit/src/plugins/agents/manifest.json
+++ b/packages/appkit/src/plugins/agents/manifest.json
@@ -19,6 +19,19 @@
             "description": "Default LLM serving endpoint name"
           }
         }
+      },
+      {
+        "type": "experiment",
+        "alias": "MLflow experiment for agent traces",
+        "resourceKey": "agents-mlflow-experiment",
+        "description": "When bound, agent turns and tool calls are traced to this MLflow experiment via OpenTelemetry. Tracing is a no-op when unset.",
+        "permission": "CAN_EDIT",
+        "fields": {
+          "experimentId": {
+            "env": "MLFLOW_EXPERIMENT_ID",
+            "description": "MLflow experiment id traces are logged to"
+          }
+        }
       }
     ]
   }

--- a/packages/appkit/src/plugins/agents/mlflow.ts
+++ b/packages/appkit/src/plugins/agents/mlflow.ts
@@ -1,4 +1,3 @@
-import type { LiveSpan } from "mlflow-tracing";
 import { createLogger } from "../../logging/logger";
 
 const logger = createLogger("agents");
@@ -62,28 +61,66 @@ export async function initAgentTracing(): Promise<void> {
   }
 }
 
-export type AgentSpanType = "AGENT" | "TOOL";
+/**
+ * Records a span's outputs. Callers get one from `traceAgent`/`traceTool`;
+ * it's a no-op when tracing is disabled, so call sites never branch on it.
+ */
+export interface SpanRecorder {
+  setOutputs(outputs: unknown): void;
+}
+
+const noopRecorder: SpanRecorder = { setOutputs() {} };
 
 /**
- * Run `fn` inside an MLflow span when tracing is enabled, otherwise just run it
- * (zero overhead). Spans auto-nest via the SDK's active context, so a TOOL span
- * opened inside an AGENT span's callback becomes its child. The callback gets
- * the span (or `undefined` when disabled) to record outputs.
+ * Run `fn` inside an MLflow span of `spanType` when tracing is enabled,
+ * otherwise just run it (zero overhead). Spans auto-nest via the SDK's active
+ * context, so a TOOL span opened inside an AGENT span's callback becomes its
+ * child. The callback's resolved value is recorded as the span's outputs unless
+ * it called `setOutputs` first; return `undefined` (or set outputs explicitly)
+ * when the return value isn't the output you want traced.
  */
-export async function withAgentSpan<T>(
-  options: { name: string; type: AgentSpanType; inputs?: unknown },
-  fn: (span?: LiveSpan) => Promise<T>,
+async function trace<T>(
+  spanType: "AGENT" | "TOOL",
+  name: string,
+  inputs: unknown,
+  fn: (span: SpanRecorder) => Promise<T>,
 ): Promise<T> {
-  if (!enabled || !mlflow) return fn();
-  const spanType =
-    options.type === "AGENT" ? mlflow.SpanType.AGENT : mlflow.SpanType.TOOL;
+  if (!enabled || !mlflow) return fn(noopRecorder);
+  const type =
+    spanType === "AGENT" ? mlflow.SpanType.AGENT : mlflow.SpanType.TOOL;
   return await mlflow.withSpan<T>(
-    (span) => {
-      if (options.inputs !== undefined) span.setInputs(options.inputs);
-      return fn(span);
+    async (span) => {
+      if (inputs !== undefined) span.setInputs(inputs);
+      let outputsSet = false;
+      const result = await fn({
+        setOutputs(outputs) {
+          outputsSet = true;
+          span.setOutputs(outputs);
+        },
+      });
+      if (!outputsSet && result !== undefined) span.setOutputs(result);
+      return result;
     },
-    { name: options.name, spanType },
+    { name, spanType: type },
   );
+}
+
+/** Trace a turn's root AGENT span. See {@link trace}. */
+export function traceAgent<T>(
+  name: string,
+  inputs: unknown,
+  fn: (span: SpanRecorder) => Promise<T>,
+): Promise<T> {
+  return trace("AGENT", name, inputs, fn);
+}
+
+/** Trace a TOOL span, nested under the active AGENT span. See {@link trace}. */
+export function traceTool<T>(
+  name: string,
+  inputs: unknown,
+  fn: (span: SpanRecorder) => Promise<T>,
+): Promise<T> {
+  return trace("TOOL", name, inputs, fn);
 }
 
 /**

--- a/packages/appkit/src/plugins/agents/mlflow.ts
+++ b/packages/appkit/src/plugins/agents/mlflow.ts
@@ -151,13 +151,3 @@ export function linkTraceToRun(runId: string): void {
     logger.warn("Failed to link trace to run %s: %O", runId, err);
   }
 }
-
-/** Flush buffered traces (e.g. on shutdown). No-op when tracing is disabled. */
-export async function flushAgentTraces(): Promise<void> {
-  if (!enabled || !mlflow) return;
-  try {
-    await mlflow.flushTraces();
-  } catch (err) {
-    logger.warn("MLflow trace flush failed: %O", err);
-  }
-}

--- a/packages/appkit/src/plugins/agents/mlflow.ts
+++ b/packages/appkit/src/plugins/agents/mlflow.ts
@@ -1,0 +1,126 @@
+import type { LiveSpan } from "mlflow-tracing";
+import { createLogger } from "../../logging/logger";
+
+const logger = createLogger("agents");
+
+type MlflowModule = typeof import("mlflow-tracing");
+
+let mlflow: MlflowModule | undefined;
+let enabled = false;
+let initStarted = false;
+
+/** The bound MLflow experiment id, from the optional `experiment` resource. */
+function experimentId(): string | undefined {
+  const id = process.env.MLFLOW_EXPERIMENT_ID?.trim();
+  return id || undefined;
+}
+
+/**
+ * Databricks host with a scheme. The mlflow-tracing SDK uses `DATABRICKS_HOST`
+ * verbatim to build request URLs and doesn't add `https://`, so a bare host
+ * (`workspace.cloud.databricks.com`) makes `new URL()` throw. Pass an explicit
+ * normalized host when the env var is set; when it isn't (profile-based auth),
+ * return undefined and let the SDK read the host from `~/.databrickscfg`.
+ */
+function normalizedDatabricksHost(): string | undefined {
+  const raw = process.env.DATABRICKS_HOST?.trim();
+  if (!raw) return undefined;
+  return /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
+}
+
+/**
+ * Initialize MLflow agent tracing once, when an experiment is bound — i.e. the
+ * agents plugin's optional `experiment` resource is set (`MLFLOW_EXPERIMENT_ID`).
+ *
+ * Auth is resolved by the `mlflow-tracing` SDK from the app's own Databricks
+ * credentials — `DATABRICKS_HOST`/`DATABRICKS_TOKEN` or a `~/.databrickscfg`
+ * profile (`MLFLOW_TRACKING_URI=databricks://profile`) — so no tokens or OTLP
+ * headers are wired by hand. A failure (missing creds, bad experiment) logs and
+ * leaves tracing disabled rather than breaking the agent.
+ *
+ * Safe to call repeatedly; only the first call does work.
+ */
+export async function initAgentTracing(): Promise<void> {
+  if (initStarted) return;
+  initStarted = true;
+
+  const id = experimentId();
+  if (!id) return;
+
+  try {
+    mlflow = await import("mlflow-tracing");
+    const host = normalizedDatabricksHost();
+    mlflow.init({
+      trackingUri: process.env.MLFLOW_TRACKING_URI?.trim() || "databricks",
+      experimentId: id,
+      ...(host ? { host } : {}),
+    });
+    enabled = true;
+    logger.info("MLflow agent tracing enabled (experiment %s)", id);
+  } catch (err) {
+    logger.warn("MLflow agent tracing disabled: %O", err);
+  }
+}
+
+export type AgentSpanType = "AGENT" | "TOOL";
+
+/**
+ * Run `fn` inside an MLflow span when tracing is enabled, otherwise just run it
+ * (zero overhead). Spans auto-nest via the SDK's active context, so a TOOL span
+ * opened inside an AGENT span's callback becomes its child. The callback gets
+ * the span (or `undefined` when disabled) to record outputs.
+ */
+export async function withAgentSpan<T>(
+  options: { name: string; type: AgentSpanType; inputs?: unknown },
+  fn: (span?: LiveSpan) => Promise<T>,
+): Promise<T> {
+  if (!enabled || !mlflow) return fn();
+  const spanType =
+    options.type === "AGENT" ? mlflow.SpanType.AGENT : mlflow.SpanType.TOOL;
+  return await mlflow.withSpan<T>(
+    (span) => {
+      if (options.inputs !== undefined) span.setInputs(options.inputs);
+      return fn(span);
+    },
+    { name: options.name, spanType },
+  );
+}
+
+/**
+ * The MLflow trace id for the active turn, when tracing is enabled. Read inside
+ * an agent span so eval runs can correlate the turn to its trace and attach
+ * assessments. Returns undefined when tracing is off.
+ */
+export function currentTraceId(): string | undefined {
+  if (!enabled || !mlflow) return undefined;
+  try {
+    return mlflow.getLastActiveTraceId();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Link the active turn's trace to an MLflow run by id, via the `mlflow.sourceRun`
+ * trace metadata. Used by eval runs so each case's trace shows under the run.
+ * Must be called while a trace is active (inside an agent span). No-op when
+ * tracing is disabled.
+ */
+export function linkTraceToRun(runId: string): void {
+  if (!enabled || !mlflow) return;
+  try {
+    mlflow.updateCurrentTrace({ metadata: { "mlflow.sourceRun": runId } });
+  } catch (err) {
+    logger.warn("Failed to link trace to run %s: %O", runId, err);
+  }
+}
+
+/** Flush buffered traces (e.g. on shutdown). No-op when tracing is disabled. */
+export async function flushAgentTraces(): Promise<void> {
+  if (!enabled || !mlflow) return;
+  try {
+    await mlflow.flushTraces();
+  } catch (err) {
+    logger.warn("MLflow trace flush failed: %O", err);
+  }
+}

--- a/packages/appkit/src/plugins/agents/mlflow.ts
+++ b/packages/appkit/src/plugins/agents/mlflow.ts
@@ -124,14 +124,18 @@ export function traceTool<T>(
 }
 
 /**
- * The MLflow trace id for the active turn, when tracing is enabled. Read inside
- * an agent span so eval runs can correlate the turn to its trace and attach
- * assessments. Returns undefined when tracing is off.
+ * The MLflow trace id for the active turn, when tracing is enabled. Must be
+ * read inside an agent span so eval runs can correlate the turn to its trace
+ * and attach assessments. Returns undefined when tracing is off.
+ *
+ * Reads the context-active span rather than `getLastActiveTraceId()`: the
+ * latter is only populated when a root span *ends* (on export), so mid-turn it
+ * returns the previous turn's id — or, under concurrent turns, another turn's.
  */
 export function currentTraceId(): string | undefined {
   if (!enabled || !mlflow) return undefined;
   try {
-    return mlflow.getLastActiveTraceId();
+    return mlflow.getCurrentActiveSpan()?.traceId;
   } catch {
     return undefined;
   }

--- a/packages/appkit/src/plugins/agents/schemas.ts
+++ b/packages/appkit/src/plugins/agents/schemas.ts
@@ -36,9 +36,10 @@ export const chatRequestSchema = z.object({
   agent: z.string().optional(),
   /**
    * MLflow run id to link this turn's trace to (via `mlflow.sourceRun`), set by
-   * the eval runner so each case's trace shows under the evaluation run.
+   * the eval runner so each case's trace shows under the evaluation run. Capped
+   * to a run-id-shaped length since it reaches trace metadata and logs.
    */
-  mlflowRunId: z.string().optional(),
+  mlflowRunId: z.string().max(64).optional(),
 });
 
 const messageItemSchema = z.object({

--- a/packages/appkit/src/plugins/agents/schemas.ts
+++ b/packages/appkit/src/plugins/agents/schemas.ts
@@ -34,6 +34,11 @@ export const chatRequestSchema = z.object({
     ),
   threadId: z.string().optional(),
   agent: z.string().optional(),
+  /**
+   * MLflow run id to link this turn's trace to (via `mlflow.sourceRun`), set by
+   * the eval runner so each case's trace shows under the evaluation run.
+   */
+  mlflowRunId: z.string().optional(),
 });
 
 const messageItemSchema = z.object({

--- a/packages/appkit/src/plugins/agents/schemas.ts
+++ b/packages/appkit/src/plugins/agents/schemas.ts
@@ -65,6 +65,13 @@ export const invocationsRequestSchema = z.object({
       ),
   ]),
   model: z.string().optional(),
+  /**
+   * MLflow run id to link this turn's trace to, same as {@link chatRequestSchema}.
+   * The non-streaming invoke surface returns the trace id in the response body
+   * (`mlflow_trace_id`) rather than a `metadata` event, so an eval runner can
+   * attach assessments to the trace.
+   */
+  mlflowRunId: z.string().max(64).optional(),
 });
 
 export const approvalRequestSchema = z.object({

--- a/packages/appkit/src/plugins/agents/schemas.ts
+++ b/packages/appkit/src/plugins/agents/schemas.ts
@@ -66,10 +66,9 @@ export const invocationsRequestSchema = z.object({
   ]),
   model: z.string().optional(),
   /**
-   * MLflow run id to link this turn's trace to, same as {@link chatRequestSchema}.
-   * The non-streaming invoke surface returns the trace id in the response body
-   * (`mlflow_trace_id`) rather than a `metadata` event, so an eval runner can
-   * attach assessments to the trace.
+   * MLflow run id to link this turn's trace to. Same as `chatRequestSchema`,
+   * but the trace id comes back in the response body (`mlflow_trace_id`) since
+   * this surface has no `metadata` event.
    */
   mlflowRunId: z.string().max(64).optional(),
 });

--- a/packages/appkit/src/plugins/agents/tests/mlflow.test.ts
+++ b/packages/appkit/src/plugins/agents/tests/mlflow.test.ts
@@ -19,7 +19,6 @@ function stubSdk(overrides: Record<string, unknown> = {}) {
     // root span that *ended*, i.e. a previous/other turn.
     getLastActiveTraceId: vi.fn(() => "tr-STALE"),
     updateCurrentTrace: vi.fn(),
-    flushTraces: vi.fn(),
     ...overrides,
   };
   vi.doMock("mlflow-tracing", () => sdk);

--- a/packages/appkit/src/plugins/agents/tests/mlflow.test.ts
+++ b/packages/appkit/src/plugins/agents/tests/mlflow.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+/**
+ * The tracing module keeps module-level singleton state (`enabled`,
+ * `initStarted`) and lazily `import()`s `mlflow-tracing`. Each test resets the
+ * module registry and re-mocks the SDK so init runs fresh.
+ */
+
+function stubSdk(overrides: Record<string, unknown> = {}) {
+  const setInputs = vi.fn();
+  const setOutputs = vi.fn();
+  const span = { setInputs, setOutputs };
+  const sdk = {
+    init: vi.fn(),
+    SpanType: { AGENT: "AGENT", TOOL: "TOOL" },
+    withSpan: vi.fn(async (fn: (s: unknown) => unknown) => fn(span)),
+    getCurrentActiveSpan: vi.fn(() => ({ traceId: "tr-active" })),
+    // Must NOT be consulted by currentTraceId — it only reflects the last
+    // root span that *ended*, i.e. a previous/other turn.
+    getLastActiveTraceId: vi.fn(() => "tr-STALE"),
+    updateCurrentTrace: vi.fn(),
+    flushTraces: vi.fn(),
+    ...overrides,
+  };
+  vi.doMock("mlflow-tracing", () => sdk);
+  return { sdk, span, setInputs, setOutputs };
+}
+
+describe("agent tracing (mlflow)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    delete process.env.MLFLOW_EXPERIMENT_ID;
+  });
+
+  afterEach(() => {
+    vi.doUnmock("mlflow-tracing");
+    delete process.env.MLFLOW_EXPERIMENT_ID;
+  });
+
+  test("disabled (no experiment bound): still runs fn and returns its value", async () => {
+    const mod = await import("../mlflow");
+    await mod.initAgentTracing();
+
+    const fn = vi.fn(async () => "result");
+    await expect(mod.traceTool("t", { a: 1 }, fn)).resolves.toBe("result");
+    expect(fn).toHaveBeenCalledOnce();
+    expect(mod.currentTraceId()).toBeUndefined();
+  });
+
+  test("currentTraceId reads the context-active span, not getLastActiveTraceId", async () => {
+    process.env.MLFLOW_EXPERIMENT_ID = "exp-123";
+    const { sdk } = stubSdk();
+    const mod = await import("../mlflow");
+    await mod.initAgentTracing();
+
+    let seen: string | undefined;
+    await mod.traceAgent("agent", { messages: [] }, async () => {
+      seen = mod.currentTraceId();
+    });
+
+    expect(seen).toBe("tr-active");
+    expect(sdk.getCurrentActiveSpan).toHaveBeenCalled();
+    expect(sdk.getLastActiveTraceId).not.toHaveBeenCalled();
+  });
+
+  test("auto-captures the callback's return value as span outputs", async () => {
+    process.env.MLFLOW_EXPERIMENT_ID = "exp-123";
+    const { setOutputs } = stubSdk();
+    const mod = await import("../mlflow");
+    await mod.initAgentTracing();
+
+    await mod.traceTool("t", { a: 1 }, async () => ({ ok: true }));
+    expect(setOutputs).toHaveBeenCalledExactlyOnceWith({ ok: true });
+  });
+
+  test("explicit setOutputs wins over auto-capture (no double-set)", async () => {
+    process.env.MLFLOW_EXPERIMENT_ID = "exp-123";
+    const { setOutputs } = stubSdk();
+    const mod = await import("../mlflow");
+    await mod.initAgentTracing();
+
+    await mod.traceAgent("agent", { messages: [] }, async (span) => {
+      span.setOutputs({ role: "assistant", content: "hi" });
+      return "ignored-return";
+    });
+    expect(setOutputs).toHaveBeenCalledExactlyOnceWith({
+      role: "assistant",
+      content: "hi",
+    });
+  });
+});

--- a/packages/appkit/src/plugins/agents/tests/route-handler-errors.test.ts
+++ b/packages/appkit/src/plugins/agents/tests/route-handler-errors.test.ts
@@ -3,6 +3,27 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { CacheManager } from "../../../cache";
 import { AgentsPlugin } from "../agents";
 
+// Partial-mock the tracing module: keep traceAgent/traceTool executing their
+// callbacks (so the turn runs), but make the trace id deterministic and spy on
+// run-linking so the invoke-surface wiring can be asserted.
+const linkTraceToRun = vi.hoisted(() => vi.fn());
+let mockTraceId: string | undefined;
+vi.mock("../mlflow", () => ({
+  initAgentTracing: vi.fn(async () => {}),
+  traceAgent: (
+    _name: string,
+    _inputs: unknown,
+    fn: (span: { setOutputs: () => void }) => Promise<unknown>,
+  ) => fn({ setOutputs: () => {} }),
+  traceTool: (
+    _name: string,
+    _inputs: unknown,
+    fn: (span: { setOutputs: () => void }) => Promise<unknown>,
+  ) => fn({ setOutputs: () => {} }),
+  currentTraceId: () => mockTraceId,
+  linkTraceToRun,
+}));
+
 /**
  * Surface-level guarantees on the agents plugin's HTTP route handlers when
  * downstream dependencies fail. Prior to PR #305 review finding #1+#2,
@@ -19,6 +40,8 @@ import { AgentsPlugin } from "../agents";
  */
 
 beforeEach(() => {
+  linkTraceToRun.mockClear();
+  mockTraceId = undefined;
   // biome-ignore lint/suspicious/noExplicitAny: test seam, mirrors other suites
   (CacheManager as any).instance = {
     get: vi.fn(),
@@ -390,6 +413,80 @@ describe("POST /invocations & /responses — successful invoke", () => {
       type: "output_text",
       text: "hello world",
     });
+  });
+
+  function seedEchoPlugin(): AgentsPlugin {
+    const plugin = new AgentsPlugin({ dir: false });
+    // biome-ignore lint/suspicious/noExplicitAny: seed
+    (plugin as any).agents.set("default", {
+      name: "default",
+      instructions: "hi",
+      adapter: {
+        async *run() {
+          yield { type: "message_delta", content: "ok" };
+        },
+      },
+      toolIndex: new Map(),
+    });
+    // biome-ignore lint/suspicious/noExplicitAny: seed
+    (plugin as any).defaultAgentName = "default";
+    // biome-ignore lint/suspicious/noExplicitAny: stub
+    (plugin as any).threadStore = {
+      create: vi.fn().mockResolvedValue({ id: "t-new", messages: [] }),
+      addMessage: vi.fn(),
+      delete: vi.fn(),
+    };
+    return plugin;
+  }
+
+  async function invoke(
+    plugin: AgentsPlugin,
+    body: unknown,
+  ): Promise<Record<string, unknown>> {
+    const { res, json } = mockRes();
+    await (
+      plugin as unknown as {
+        _handleInvoke: (
+          r: express.Request,
+          w: express.Response,
+        ) => Promise<void>;
+      }
+    )._handleInvoke(mockReq(body), res);
+    return json.mock.calls[0]?.[0] as Record<string, unknown>;
+  }
+
+  test("links the trace to the run and echoes mlflow_trace_id when tracing is on", async () => {
+    mockTraceId = "tr-abc123";
+    const plugin = seedEchoPlugin();
+
+    const payload = await invoke(plugin, {
+      input: "hi",
+      mlflowRunId: "run-99",
+    });
+
+    expect(linkTraceToRun).toHaveBeenCalledWith("run-99");
+    expect(payload.mlflow_trace_id).toBe("tr-abc123");
+  });
+
+  test("omits mlflow_trace_id and does not link when tracing is off", async () => {
+    mockTraceId = undefined; // currentTraceId() no-ops when disabled
+    const plugin = seedEchoPlugin();
+
+    const payload = await invoke(plugin, { input: "hi" });
+
+    expect(linkTraceToRun).not.toHaveBeenCalled();
+    expect(payload).not.toHaveProperty("mlflow_trace_id");
+  });
+
+  test("does not link when no run id is supplied even if tracing is on", async () => {
+    mockTraceId = "tr-standalone";
+    const plugin = seedEchoPlugin();
+
+    const payload = await invoke(plugin, { input: "hi" });
+
+    expect(linkTraceToRun).not.toHaveBeenCalled();
+    // Trace still exists and its id is surfaced — just not linked to a run.
+    expect(payload.mlflow_trace_id).toBe("tr-standalone");
   });
 });
 

--- a/packages/appkit/src/plugins/agents/tests/route-handler-errors.test.ts
+++ b/packages/appkit/src/plugins/agents/tests/route-handler-errors.test.ts
@@ -3,9 +3,8 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { CacheManager } from "../../../cache";
 import { AgentsPlugin } from "../agents";
 
-// Partial-mock the tracing module: keep traceAgent/traceTool executing their
-// callbacks (so the turn runs), but make the trace id deterministic and spy on
-// run-linking so the invoke-surface wiring can be asserted.
+// Partial-mock the tracing module: traceAgent/traceTool still run their
+// callbacks, but the trace id is deterministic and run-linking is a spy.
 const linkTraceToRun = vi.hoisted(() => vi.fn());
 let mockTraceId: string | undefined;
 vi.mock("../mlflow", () => ({
@@ -83,13 +82,13 @@ function mockRes() {
   };
 }
 
-function seedPlugin(): AgentsPlugin {
+function seedPlugin(adapter: unknown = { async *run() {} }): AgentsPlugin {
   const plugin = new AgentsPlugin({ dir: false });
   // biome-ignore lint/suspicious/noExplicitAny: seed private state
   (plugin as any).agents.set("default", {
     name: "default",
     instructions: "hi",
-    adapter: { async *run() {} },
+    adapter,
     toolIndex: new Map(),
   });
   // biome-ignore lint/suspicious/noExplicitAny: seed private state
@@ -416,20 +415,11 @@ describe("POST /invocations & /responses — successful invoke", () => {
   });
 
   function seedEchoPlugin(): AgentsPlugin {
-    const plugin = new AgentsPlugin({ dir: false });
-    // biome-ignore lint/suspicious/noExplicitAny: seed
-    (plugin as any).agents.set("default", {
-      name: "default",
-      instructions: "hi",
-      adapter: {
-        async *run() {
-          yield { type: "message_delta", content: "ok" };
-        },
+    const plugin = seedPlugin({
+      async *run() {
+        yield { type: "message_delta", content: "ok" };
       },
-      toolIndex: new Map(),
     });
-    // biome-ignore lint/suspicious/noExplicitAny: seed
-    (plugin as any).defaultAgentName = "default";
     // biome-ignore lint/suspicious/noExplicitAny: stub
     (plugin as any).threadStore = {
       create: vi.fn().mockResolvedValue({ id: "t-new", messages: [] }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -326,6 +326,9 @@ importers:
       magic-string:
         specifier: 0.30.21
         version: 0.30.21
+      mlflow-tracing:
+        specifier: ^0.1.3
+        version: 0.1.3
       obug:
         specifier: 2.1.1
         version: 2.1.1
@@ -1958,6 +1961,10 @@ packages:
     engines: {node: ^20 || ^22 || ^24 || ^25, pnpm: '>=10'}
     hasBin: true
 
+  '@databricks/sdk-experimental@0.15.0':
+    resolution: {integrity: sha512-HkoMiF7dNDt6WRW0xhi7oPlBJQfxJ9suJhEZRFt08VwLMaWcw2PiF8monfHlkD4lkufEYV6CTxi5njQkciqiHA==}
+    engines: {node: '>=22.0', npm: '>=10.0.0'}
+
   '@databricks/sdk-experimental@0.17.0':
     resolution: {integrity: sha512-dOJIt4F2nBk6HKObnv7Xbmy/qLYTy2835qhXSuW0Qw1QAXui9plmCet1KqG3yeQcMTyncWGbnhjGdQi8GEGQSA==}
     engines: {node: '>=22.0', npm: '>=10.0.0'}
@@ -2790,6 +2797,10 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
+  '@opentelemetry/api-logs@0.205.0':
+    resolution: {integrity: sha512-wBlPk1nFB37Hsm+3Qy73yQSobVn28F4isnWIBvKpd5IUH/eat8bwcL02H9yzmHyyPmukeccSl2mbN5sDQZYnPg==}
+    engines: {node: '>=8.0.0'}
+
   '@opentelemetry/api-logs@0.219.0':
     resolution: {integrity: sha512-FFx7YnaYJlIjqWW/AG/yAZ0L/NEY724PipXXXQLdtZPbLwBGbUMTGL1i/esI56TWfTUXxhLfpgrnWJCG8aUJyg==}
     engines: {node: '>=8.0.0'}
@@ -2811,6 +2822,12 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
 
+  '@opentelemetry/context-async-hooks@2.1.0':
+    resolution: {integrity: sha512-zOyetmZppnwTyPrt4S7jMfXiSX9yyfF0hxlA8B5oo2TtKl+/RGCy7fi4DrBfIf3lCPrkKsRBWZZD7RFojK7FDg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
   '@opentelemetry/context-async-hooks@2.8.0':
     resolution: {integrity: sha512-/3FIraneMcng67SUJCxvyInk/oxzwsxyadufk0wwfOBLf5wqtAGX4MoQASwSbndBPeARzBryUM9Azr5kHIdWLw==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -2823,8 +2840,20 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
+  '@opentelemetry/exporter-logs-otlp-grpc@0.205.0':
+    resolution: {integrity: sha512-jQlw7OHbqZ8zPt+pOrW2KGN7T55P50e3NXBMr4ckPOF+DWDwSy4W7mkG09GpYWlQAQ5C9BXg5gfUlv5ldTgWsw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/exporter-logs-otlp-grpc@0.219.0':
     resolution: {integrity: sha512-7SvzDCIclHWAcCwZ1MTOLcwn4BVNPGI3QxS/DJraPNe1TTL+4TvUBq5zeQV8tsnYvtDN7wKW2qocVmaCP2l7sQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-http@0.205.0':
+    resolution: {integrity: sha512-5JteMyVWiro4ghF0tHQjfE6OJcF7UBUcoEqX3UIQ5jutKP1H+fxFdyhqjjpmeHMFxzOHaYuLlNR1Bn7FOjGyJg==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -2835,8 +2864,20 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/exporter-logs-otlp-proto@0.205.0':
+    resolution: {integrity: sha512-q3VS9wS+lpZ01txKxiDGBtBpTNge3YhbVEFDgem9ZQR9eI3EZ68+9tVZH9zJcSxI37nZPJ6lEEZO58yEjYZsVA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/exporter-logs-otlp-proto@0.219.0':
     resolution: {integrity: sha512-Ayw4Gf71PS9jhBVaYywa4WsajnqfDehMkTdVH3TSAVHqPcsAv/AhH/wTNRYNt99szeYr6Gbd/D6RjZD77wAxHg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.205.0':
+    resolution: {integrity: sha512-1Vxlo4lUwqSKYX+phFkXHKYR3DolFHxCku6lVMP1H8sVE3oj4wwmwxMzDsJ7zF+sXd8M0FCr+ckK4SnNNKkV+w==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -2847,8 +2888,20 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/exporter-metrics-otlp-http@0.205.0':
+    resolution: {integrity: sha512-fFxNQ/HbbpLmh1pgU6HUVbFD1kNIjrkoluoKJkh88+gnmpFD92kMQ8WFNjPnSbjg2mNVnEkeKXgCYEowNW+p1w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/exporter-metrics-otlp-http@0.219.0':
     resolution: {integrity: sha512-6CaDRbMVHZSDWzNXwrR8y/H4B/Z1eMNnkHiPQlTx3Ojz2OHY4X/aff/UC4P/3pHUQSuTfi3oh2UsPPZppw+Vrg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-proto@0.205.0':
+    resolution: {integrity: sha512-qIbNnedw9QfFjwpx4NQvdgjK3j3R2kWH/2T+7WXAm1IfMFe9fwatYxE61i7li4CIJKf8HgUC3GS8Du0C3D+AuQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -2859,8 +2912,20 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/exporter-prometheus@0.205.0':
+    resolution: {integrity: sha512-xsot/Qm9VLDTag4GEwAunD1XR1U8eBHTLAgO7IZNo2JuD/c/vL7xmDP7mQIUr6Lk3gtj/yGGIR2h3vhTeVzv4w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/exporter-prometheus@0.219.0':
     resolution: {integrity: sha512-TxOnJ85eWJY5JyOJsNMXiRTYlkDcOv0u3KbXEzWCc+tUS9sjL/BC6BcdxZ0B9r2OFVqsrZFXUzSD2sZUy42Ucw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-grpc@0.205.0':
+    resolution: {integrity: sha512-ZBksUk84CcQOuDJB65yu5A4PORkC4qEsskNwCrPZxDLeWjPOFZNSWt0E0jQxKCY8PskLhjNXJYo12YaqsYvGFA==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -2871,8 +2936,20 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/exporter-trace-otlp-http@0.205.0':
+    resolution: {integrity: sha512-vr2bwwPCSc9u7rbKc74jR+DXFvyMFQo9o5zs+H/fgbK672Whw/1izUKVf+xfWOdJOvuwTnfWxy+VAY+4TSo74Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/exporter-trace-otlp-http@0.219.0':
     resolution: {integrity: sha512-9t6SvBXXBEjOBcIzgozvBbd3jWrv3Gt3ngGhl1fhdZ/zRc7oZDVOFEqbi2zlBpW9BXhgDMKv422J0DL/3iQWfw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.205.0':
+    resolution: {integrity: sha512-bGtFzqiENO2GpJk988mOBMe0MfeNpTQjbLm/LBijas6VRyEDQarUzdBHpFlu89A25k1+BCntdWGsWTa9Ai4FyA==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -2882,6 +2959,12 @@ packages:
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-zipkin@2.1.0':
+    resolution: {integrity: sha512-0mEI0VDZrrX9t5RE1FhAyGz+jAGt96HSuXu73leswtY3L5YZD11gtcpARY2KAx/s6Z2+rj5Mhj566JsI2C7mfA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
 
   '@opentelemetry/exporter-zipkin@2.8.0':
     resolution: {integrity: sha512-Mj84UkEa17BK2o903VTXW3wM8CrSZexGs4tRGVZVIMM9ni1T6TuGx5IrRfoWKAbshx42D5/kc7YV+axypLPYyA==}
@@ -3135,8 +3218,20 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/instrumentation@0.205.0':
+    resolution: {integrity: sha512-cgvm7tvQdu9Qo7VurJP84wJ7ZV9F6WqDDGZpUc6rUEXwjV7/bXWs0kaYp9v+1Vh1+3TZCD3i6j/lUBcPhu8NhA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/instrumentation@0.219.0':
     resolution: {integrity: sha512-X5t7I8GyIO9rmGHwoedZLREpQqrF1WW2nxzNNym6HOKpFiE+rvqV3ngC0xcZVO2YwIGf3KKmRdWrYwdwz3H9RQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.205.0':
+    resolution: {integrity: sha512-2MN0C1IiKyo34M6NZzD6P9Nv9Dfuz3OJ3rkZwzFmF6xzjDfqqCTatc9v1EpNfaP55iDOCLHFyYNCgs61FFgtUQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -3147,8 +3242,20 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/otlp-grpc-exporter-base@0.205.0':
+    resolution: {integrity: sha512-AeuLfrciGYffqsp4EUTdYYc6Ee2BQS+hr08mHZk1C524SFWx0WnfcTnV0NFXbVURUNU6DZu1DhS89zRRrcx/hg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/otlp-grpc-exporter-base@0.219.0':
     resolution: {integrity: sha512-iIk/s8QQu39zpTrRRmsW/Eg3SE2+Hg8tLWepr2FLRgmwUpNd0IpCTLJEHJ77hpt4hgIS8MAh44UYI4xQPZwWlw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.205.0':
+    resolution: {integrity: sha512-KmObgqPtk9k/XTlWPJHdMbGCylRAmMJNXIRh6VYJmvlRDMfe+DonH41G7eenG8t4FXn3fxOGh14o/WiMRR6vPg==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -3165,8 +3272,20 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
+  '@opentelemetry/propagator-b3@2.1.0':
+    resolution: {integrity: sha512-yOdHmFseIChYanddMMz0mJIFQHyjwbNhoxc65fEAA8yanxcBPwoFDoh1+WBUWAO/Z0NRgk+k87d+aFIzAZhcBw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
   '@opentelemetry/propagator-b3@2.8.0':
     resolution: {integrity: sha512-SazlvuSKi5533rPHTW2TwBwdMakhjZST4SYs0YauuvfGDkT13KbG1gJS75hV0uWVeevhtVP9sAIlaZLTHdSbMg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/propagator-jaeger@2.1.0':
+    resolution: {integrity: sha512-QYo7vLyMjrBCUTpwQBF/e+rvP7oGskrSELGxhSvLj5gpM0az9oJnu/0O4l2Nm7LEhAff80ntRYKkAcSwVgvSVQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
@@ -3211,11 +3330,23 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.0.0
 
+  '@opentelemetry/resources@2.1.0':
+    resolution: {integrity: sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
   '@opentelemetry/resources@2.8.0':
     resolution: {integrity: sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.205.0':
+    resolution: {integrity: sha512-nyqhNQ6eEzPWQU60Nc7+A5LIq8fz3UeIzdEVBQYefB4+msJZ2vuVtRuk9KxPMw1uHoHDtYEwkr2Ct0iG29jU8w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
 
   '@opentelemetry/sdk-logs@0.219.0':
     resolution: {integrity: sha512-s6lTKRakaPClvKoWHRChxnXjDMkM/TQ30ff78jN6EBGf7MI7VzANE5PU3f4z9qDUudWjvZjOLHG0rBnBKYvoXA==}
@@ -3223,14 +3354,32 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.4.0 <1.10.0'
 
+  '@opentelemetry/sdk-metrics@2.1.0':
+    resolution: {integrity: sha512-J9QX459mzqHLL9Y6FZ4wQPRZG4TOpMCyPOh6mkr/humxE1W2S3Bvf4i75yiMW9uyed2Kf5rxmLhTm/UK8vNkAw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
   '@opentelemetry/sdk-metrics@2.8.0':
     resolution: {integrity: sha512-UDBGaj6W0Rgy5rTTaoxs8gVGF/aGkAKyjurJv7se6wjRxJu7FoquTLT/vt54DZfo4crbprYfhX/SOK9+BPw1qg==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.9.0 <1.10.0'
 
+  '@opentelemetry/sdk-node@0.205.0':
+    resolution: {integrity: sha512-Y4Wcs8scj/Wy1u61pX1ggqPXPtCsGaqx/UnFu7BtRQE1zCQR+b0h56K7I0jz7U2bRlPUZIFdnNLtoaJSMNzz2g==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
   '@opentelemetry/sdk-node@0.219.0':
     resolution: {integrity: sha512-NWLpWLEb8gV3+JBHYoIrktbM385wyHpRJoh3J/4Q52d4PR+AlPMNGJT3DzBUrDSUEVbKAXoHR+EDAPxtiNcj8g==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.1.0':
+    resolution: {integrity: sha512-uTX9FBlVQm4S2gVQO1sb5qyBLq/FPjbp+tmGoxu4tIgtYGmBYB44+KX/725RFDe30yBSaA9Ml9fqphe1hbUyLQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
@@ -3240,6 +3389,12 @@ packages:
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-node@2.1.0':
+    resolution: {integrity: sha512-SvVlBFc/jI96u/mmlKm86n9BbTCbQ35nsPoOohqJX6DXH92K0kTe73zGY5r8xoI1QkjR9PizszVJLzMC966y9Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
   '@opentelemetry/sdk-trace-node@2.8.0':
     resolution: {integrity: sha512-nZt9OGufioAc3AfoLTqA9bsAeaMJAictYDdI2VcNQ+PmT+3rfKjAZDZvgPfd8VPX0O5Bw1hdQF6kDK8VSpZiWg==}
@@ -7117,6 +7272,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
@@ -7795,6 +7953,9 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
+  import-in-the-middle@1.15.0:
+    resolution: {integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==}
+
   import-in-the-middle@3.0.1:
     resolution: {integrity: sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==}
     engines: {node: '>=18'}
@@ -7842,6 +8003,10 @@ packages:
   ini@4.1.1:
     resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  ini@5.0.0:
+    resolution: {integrity: sha512-+N0ngpO3e7cRUWOJAS7qw0IZIVc6XPrW4MlFBdD066F2L4k1L6ker3hLqSq7iXxU5tgS4WGkIUElWn5vogAEnw==}
+    engines: {node: ^18.17.0 || >=20.5.0}
 
   ini@6.0.0:
     resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
@@ -8890,6 +9055,10 @@ packages:
     resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
     engines: {node: '>=10'}
     hasBin: true
+
+  mlflow-tracing@0.1.3:
+    resolution: {integrity: sha512-Koqkwaid5ubGHuLprBP6J7Su70WddlD11f2vgzgxbFFHYKsAsJatMGvjIck5CkyhT/gMUyBqpA3Lkl+zC3W3uQ==}
+    engines: {node: '>=18'}
 
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
@@ -10198,6 +10367,10 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  require-in-the-middle@7.5.2:
+    resolution: {integrity: sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==}
+    engines: {node: '>=8.6.0'}
 
   require-in-the-middle@8.0.1:
     resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
@@ -13579,6 +13752,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@databricks/sdk-experimental@0.15.0':
+    dependencies:
+      google-auth-library: 10.5.0
+      ini: 6.0.0
+      reflect-metadata: 0.2.2
+      semver: 7.7.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@databricks/sdk-experimental@0.17.0':
     dependencies:
       google-auth-library: 10.5.0
@@ -15013,6 +15195,10 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
+  '@opentelemetry/api-logs@0.205.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
   '@opentelemetry/api-logs@0.219.0':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -15081,6 +15267,10 @@ snapshots:
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
       yaml: 2.8.2
 
+  '@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
   '@opentelemetry/context-async-hooks@2.8.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -15089,6 +15279,16 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.38.0
+
+  '@opentelemetry/exporter-logs-otlp-grpc@0.205.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.4
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.205.0(@opentelemetry/api@1.9.0)
 
   '@opentelemetry/exporter-logs-otlp-grpc@0.219.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -15100,6 +15300,15 @@ snapshots:
       '@opentelemetry/otlp-transformer': 0.219.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-logs': 0.219.0(@opentelemetry/api@1.9.0)
 
+  '@opentelemetry/exporter-logs-otlp-http@0.205.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.205.0
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.205.0(@opentelemetry/api@1.9.0)
+
   '@opentelemetry/exporter-logs-otlp-http@0.219.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -15108,6 +15317,17 @@ snapshots:
       '@opentelemetry/otlp-exporter-base': 0.219.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/otlp-transformer': 0.219.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-logs': 0.219.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.205.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.205.0
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.1.0(@opentelemetry/api@1.9.0)
 
   '@opentelemetry/exporter-logs-otlp-proto@0.219.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -15119,6 +15339,18 @@ snapshots:
       '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-logs': 0.219.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.205.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.4
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.1.0(@opentelemetry/api@1.9.0)
 
   '@opentelemetry/exporter-metrics-otlp-grpc@0.219.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -15132,6 +15364,15 @@ snapshots:
       '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 2.8.0(@opentelemetry/api@1.9.0)
 
+  '@opentelemetry/exporter-metrics-otlp-http@0.205.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.1.0(@opentelemetry/api@1.9.0)
+
   '@opentelemetry/exporter-metrics-otlp-http@0.219.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -15140,6 +15381,16 @@ snapshots:
       '@opentelemetry/otlp-transformer': 0.219.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 2.8.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-metrics-otlp-proto@0.205.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.1.0(@opentelemetry/api@1.9.0)
 
   '@opentelemetry/exporter-metrics-otlp-proto@0.219.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -15151,6 +15402,13 @@ snapshots:
       '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 2.8.0(@opentelemetry/api@1.9.0)
 
+  '@opentelemetry/exporter-prometheus@0.205.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.1.0(@opentelemetry/api@1.9.0)
+
   '@opentelemetry/exporter-prometheus@0.219.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -15158,6 +15416,17 @@ snapshots:
       '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.38.0
+
+  '@opentelemetry/exporter-trace-otlp-grpc@0.205.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.4
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.1.0(@opentelemetry/api@1.9.0)
 
   '@opentelemetry/exporter-trace-otlp-grpc@0.219.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -15170,6 +15439,15 @@ snapshots:
       '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.0)
 
+  '@opentelemetry/exporter-trace-otlp-http@0.205.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.1.0(@opentelemetry/api@1.9.0)
+
   '@opentelemetry/exporter-trace-otlp-http@0.219.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -15179,6 +15457,15 @@ snapshots:
       '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.0)
 
+  '@opentelemetry/exporter-trace-otlp-proto@0.205.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.1.0(@opentelemetry/api@1.9.0)
+
   '@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -15187,6 +15474,14 @@ snapshots:
       '@opentelemetry/otlp-transformer': 0.219.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-zipkin@2.1.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.38.0
 
   '@opentelemetry/exporter-zipkin@2.8.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -15547,6 +15842,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/instrumentation@0.205.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.205.0
+      import-in-the-middle: 1.15.0
+      require-in-the-middle: 7.5.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@opentelemetry/instrumentation@0.219.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -15556,11 +15860,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/otlp-exporter-base@0.205.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.205.0(@opentelemetry/api@1.9.0)
+
   '@opentelemetry/otlp-exporter-base@0.219.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/otlp-transformer': 0.219.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.205.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.4
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.205.0(@opentelemetry/api@1.9.0)
 
   '@opentelemetry/otlp-grpc-exporter-base@0.219.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -15569,6 +15887,17 @@ snapshots:
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/otlp-exporter-base': 0.219.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/otlp-transformer': 0.219.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/otlp-transformer@0.205.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.205.0
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.1.0(@opentelemetry/api@1.9.0)
+      protobufjs: 7.6.2
 
   '@opentelemetry/otlp-transformer@0.219.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -15584,7 +15913,17 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
 
+  '@opentelemetry/propagator-b3@2.1.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
+
   '@opentelemetry/propagator-b3@2.8.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/propagator-jaeger@2.1.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
@@ -15631,11 +15970,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/resources@2.1.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.38.0
+
   '@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.38.0
+
+  '@opentelemetry/sdk-logs@0.205.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.205.0
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.1.0(@opentelemetry/api@1.9.0)
 
   '@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -15645,11 +15997,45 @@ snapshots:
       '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.38.0
 
+  '@opentelemetry/sdk-metrics@2.1.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.1.0(@opentelemetry/api@1.9.0)
+
   '@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-node@0.205.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.205.0
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-logs-otlp-grpc': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-logs-otlp-http': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-logs-otlp-proto': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-grpc': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-proto': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-prometheus': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-grpc': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-http': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-proto': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-zipkin': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/propagator-b3': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/propagator-jaeger': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-node': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.38.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@opentelemetry/sdk-node@0.219.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -15683,12 +16069,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.38.0
+
   '@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.38.0
+
+  '@opentelemetry/sdk-trace-node@2.1.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/context-async-hooks': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.1.0(@opentelemetry/api@1.9.0)
 
   '@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -19640,6 +20040,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-safe-stringify@2.1.1: {}
+
   fast-uri@3.1.0: {}
 
   fastq@1.19.1:
@@ -20554,6 +20956,13 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  import-in-the-middle@1.15.0:
+    dependencies:
+      acorn: 8.15.0
+      acorn-import-attributes: 1.9.5(acorn@8.15.0)
+      cjs-module-lexer: 1.4.3
+      module-details-from-path: 1.0.4
+
   import-in-the-middle@3.0.1:
     dependencies:
       acorn: 8.15.0
@@ -20584,6 +20993,8 @@ snapshots:
   ini@2.0.0: {}
 
   ini@4.1.1: {}
+
+  ini@5.0.0: {}
 
   ini@6.0.0: {}
 
@@ -21874,6 +22285,17 @@ snapshots:
   mkdirp@0.3.0: {}
 
   mkdirp@3.0.1: {}
+
+  mlflow-tracing@0.1.3:
+    dependencies:
+      '@databricks/sdk-experimental': 0.15.0
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/sdk-node': 0.205.0(@opentelemetry/api@1.9.0)
+      bignumber.js: 9.3.1
+      fast-safe-stringify: 2.1.1
+      ini: 5.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   mlly@1.8.0:
     dependencies:
@@ -23392,6 +23814,14 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  require-in-the-middle@7.5.2:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+      resolve: 1.22.10
+    transitivePeerDependencies:
+      - supports-color
 
   require-in-the-middle@8.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,7 +327,7 @@ importers:
         specifier: 0.30.21
         version: 0.30.21
       mlflow-tracing:
-        specifier: ^0.1.3
+        specifier: 0.1.3
         version: 0.1.3
       obug:
         specifier: 2.1.1

--- a/template/appkit.plugins.json
+++ b/template/appkit.plugins.json
@@ -23,6 +23,20 @@
                 "origin": "user"
               }
             }
+          },
+          {
+            "type": "experiment",
+            "alias": "MLflow experiment for agent traces",
+            "resourceKey": "agents-mlflow-experiment",
+            "description": "When bound, agent turns and tool calls are traced to this MLflow experiment via OpenTelemetry. Tracing is a no-op when unset.",
+            "permission": "CAN_EDIT",
+            "fields": {
+              "experimentId": {
+                "env": "MLFLOW_EXPERIMENT_ID",
+                "description": "MLflow experiment id traces are logged to",
+                "origin": "user"
+              }
+            }
           }
         ]
       },


### PR DESCRIPTION
Stack 1/5 · targets `main`.

Adds MLflow tracing to the agents plugin. Agent turns and tool calls are traced to a bound MLflow experiment via the `mlflow-tracing` SDK (OpenTelemetry under the hood). Tracing is a no-op unless the plugin's optional `experiment` resource is set (`MLFLOW_EXPERIMENT_ID`); auth is resolved from the app's own Databricks credentials, so no tokens or OTLP headers are wired by hand.

- `withAgentSpan` wraps each turn (AGENT span) and tool dispatch (TOOL span, auto-nested).
- Sets trace-table Request/Response previews and the `mlflow.traceName` tag.
- `experiment` optional resource in the agents manifest.

This is the base of a 5-PR stack that builds out an agent evaluation framework. Reviewable on its own — touches only the agents plugin.
