### PR TITLE
docs: metric-view runtime endpoint

### DIFF
--- a/docs/docs/plugins/analytics.md
+++ b/docs/docs/plugins/analytics.md
@@ -103,11 +103,134 @@ The analytics plugin exposes these endpoints (mounted under `/api/analytics`):
 
 - `POST /api/analytics/query/:query_key`
 - `GET /api/analytics/arrow-result/:jobId`
+- `POST /api/analytics/metric/:key` — measure a Unity Catalog Metric View (see [Metric views](#metric-views))
 
 ## Format options
 
 - `format: "JSON"` (default) returns JSON rows
 - `format: "ARROW"` returns an Arrow "statement_id" payload over SSE, then the client fetches binary Arrow from `/api/analytics/arrow-result/:jobId`
+
+## Metric views
+
+`POST /api/analytics/metric/:key` measures a [Unity Catalog Metric View](https://docs.databricks.com/en/metric-views/index.html) that you declared in `config/queries/metric-views.json`. Instead of writing SQL, the caller sends a structured request — which measures to aggregate, which dimensions to group by, and an optional filter — and the plugin builds and runs the `SELECT MEASURE(...) ... GROUP BY ALL` for you against the view.
+
+The route is **dormant until `metric-views.json` exists**: with no config file, every metric key returns `404`. Declaring the file (and generating types) is covered in [Metric-view types](../development/type-generation.md#metric-view-types); this section documents the runtime endpoint that config activates.
+
+### Request body
+
+```
+POST /api/analytics/metric/:key
+Content-Type: application/json
+
+{
+  "measures": ["arr", "revenue"],
+  "dimensions": ["region", "order_date"],
+  "timeGrain": "month",
+  "timeDimension": "order_date",
+  "filter": { "member": "region", "operator": "in", "values": ["EMEA", "APAC"] },
+  "limit": 100
+}
+```
+
+`:key` is a metric key from `metric-views.json`. The body fields:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `measures` | `string[]` | yes | Measures to aggregate. At least 1, at most 50. Each becomes `MEASURE(<name>) AS <name>`. |
+| `dimensions` | `string[]` | no | Dimensions to group by (max 20). Selected verbatim and grouped via `GROUP BY ALL`. |
+| `filter` | object | no | Structured predicate tree translated into a parameterized `WHERE` clause (see [Filters](#filters)). |
+| `timeGrain` | `string` | no | Bucket a time dimension via `date_trunc('<grain>', …)` — e.g. `day`, `month`. Requires `timeDimension`. |
+| `timeDimension` | `string` | no | The single dimension `timeGrain` buckets. Must be one of `dimensions`. Required whenever `timeGrain` is set. |
+| `limit` | `number` | no | Positive integer row cap (max 100000). |
+| `format` | `string` | no | Only `JSON_ARRAY` is supported at v1. (Arrow streaming is not yet wired on this route.) |
+
+Measures and dimensions must be unique across both lists — a name cannot repeat, nor appear as both a measure and a dimension.
+
+### How the request becomes SQL
+
+Given a view registered as `catalog.schema.revenue_metrics`, the request above produces (measures and dimensions are sorted for a deterministic SELECT list):
+
+```sql
+SELECT MEASURE(`arr`) AS `arr`, MEASURE(`revenue`) AS `revenue`,
+       date_trunc('month', `order_date`) AS `order_date`, `region`
+FROM `catalog`.`schema`.`revenue_metrics`
+WHERE `region` IN (:f_0, :f_1)
+GROUP BY ALL
+LIMIT 100
+```
+
+The metric view's FQN and every measure/dimension identifier are backtick-quoted; filter values are bound as parameters (`:f_0`, `:f_1`, …), never interpolated into the SQL string.
+
+### Filters
+
+`filter` is a recursive tree. A leaf is a single predicate:
+
+```json
+{ "member": "region", "operator": "equals", "values": ["EMEA"] }
+```
+
+Predicates combine with `and` / `or` groups, which can nest:
+
+```json
+{
+  "and": [
+    { "member": "region", "operator": "in", "values": ["EMEA", "APAC"] },
+    {
+      "or": [
+        { "member": "segment", "operator": "equals", "values": ["Enterprise"] },
+        { "member": "deal_size", "operator": "gt", "values": [50000] }
+      ]
+    }
+  ]
+}
+```
+
+The v1 operator vocabulary:
+
+| Operator | SQL | Values |
+|----------|-----|--------|
+| `equals` | `=` | exactly one |
+| `notEquals` | `<>` | exactly one |
+| `in` | `IN (…)` | one or more |
+| `notIn` | `NOT IN (…)` | one or more |
+| `gt` / `gte` / `lt` / `lte` | `>` / `>=` / `<` / `<=` | exactly one |
+| `contains` | `LIKE '%value%'` | exactly one string |
+| `notContains` | `NOT LIKE '%value%'` | exactly one string |
+| `set` | `IS NOT NULL` | none |
+| `notSet` | `IS NULL` | none |
+
+Filters are bounded to keep hostile input from exhausting the server: nesting depth ≤ 8, ≤ 100 children per `and` / `or` group, and ≤ 1000 values per predicate. A request that exceeds a cap is rejected with `400`.
+
+### Executors (cache scope)
+
+Each entry in `metric-views.json` names the executor the query runs as, which also sets the cache scope. This is fixed by config, not the request:
+
+| `executor` | Runs as | Cache |
+|------------|---------|-------|
+| `app_service_principal` (default) | The app service principal | Shared across all users |
+| `user` | The requesting user (on-behalf-of) | Per user |
+
+This mirrors the `<key>.sql` vs `<key>.obo.sql` distinction for [file-based queries](#execution-context).
+
+### Response
+
+The response is the same SSE stream as `POST /api/analytics/query/:query_key`. If the SQL warehouse is cold it first emits `warehouse_status` events (see [Warehouse readiness](#warehouse-readiness)), then a single `result` event with the rows as objects:
+
+```json
+{ "type": "result", "data": [{ "region": "EMEA", "order_date": "2025-01-01", "arr": 1200000, "revenue": 340000 }] }
+```
+
+On failure it emits an `error` event instead.
+
+### Errors and behavior
+
+| Status | Body | When |
+|--------|------|------|
+| `404` | `{ "error": "Metric not found" }` | `:key` is not declared in `metric-views.json` (also the response for every key when the file is absent). |
+| `400` | `{ "error": "Invalid metric request body (fields: …)", "code": … }` | The request body fails validation. The message names only the offending field paths, never the submitted values. |
+| `503` | `{ "error": "Metric registry not available", "code": "METRIC_REGISTRY_LOAD_FAILED" }` | `metric-views.json` is present but malformed or unreadable. |
+
+Editing `metric-views.json` is picked up on the next request — no server restart is needed. A previously malformed file that you fix likewise starts working on the next request.
 
 ## Frontend usage
 

--- a/docs/docs/plugins/analytics.md
+++ b/docs/docs/plugins/analytics.md
@@ -7,6 +7,7 @@ sidebar_position: 3
 Enables SQL query execution against Databricks SQL Warehouses.
 
 **Key features:**
+
 - File-based SQL queries with automatic type generation
 - Parameterized queries with type-safe [SQL helpers](../api/appkit/Variable.sql.md)
 - JSON and Arrow format support
@@ -35,7 +36,6 @@ await createApp({
 
 The execution context is determined by the SQL file name, not by the hook call.
 
-
 ## SQL parameters
 
 Use `:paramName` placeholders and optionally annotate parameter types using SQL comments:
@@ -56,6 +56,7 @@ Annotate with `INT`, or use `sql.number()` (auto-infers `INT` for values in
 at the call site.
 
 **Supported `-- @param` types** (case-insensitive):
+
 - `STRING`, `BOOLEAN`, `DATE`, `TIMESTAMP`, `BINARY`
 - `INT`, `BIGINT`, `TINYINT`, `SMALLINT` — bind via `sql.int()` / `sql.bigint()`
 - `FLOAT`, `DOUBLE` — bind via `sql.float()` / `sql.double()`
@@ -134,15 +135,15 @@ Content-Type: application/json
 
 `:key` is a metric key from `metric-views.json`. The body fields:
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `measures` | `string[]` | yes | Measures to aggregate. At least 1, at most 50. Each becomes `MEASURE(<name>) AS <name>`. |
-| `dimensions` | `string[]` | no | Dimensions to group by (max 20). Selected verbatim and grouped via `GROUP BY ALL`. |
-| `filter` | object | no | Structured predicate tree translated into a parameterized `WHERE` clause (see [Filters](#filters)). |
-| `timeGrain` | `string` | no | Bucket a time dimension via `date_trunc('<grain>', …)` — e.g. `day`, `month`. Requires `timeDimension`. |
-| `timeDimension` | `string` | no | The single dimension `timeGrain` buckets. Must be one of `dimensions`. Required whenever `timeGrain` is set. |
-| `limit` | `number` | no | Positive integer row cap (max 100000). |
-| `format` | `string` | no | Only `JSON_ARRAY` is supported at v1. (Arrow streaming is not yet wired on this route.) |
+| Field           | Type       | Required | Description                                                                                                  |
+| --------------- | ---------- | -------- | ------------------------------------------------------------------------------------------------------------ |
+| `measures`      | `string[]` | yes      | Measures to aggregate. At least 1, at most 50. Each becomes `MEASURE(<name>) AS <name>`.                     |
+| `dimensions`    | `string[]` | no       | Dimensions to group by (max 20). Selected verbatim and grouped via `GROUP BY ALL`.                           |
+| `filter`        | object     | no       | Structured predicate tree translated into a parameterized `WHERE` clause (see [Filters](#filters)).          |
+| `timeGrain`     | `string`   | no       | Bucket a time dimension via `date_trunc('<grain>', …)` — e.g. `day`, `month`. Requires `timeDimension`.      |
+| `timeDimension` | `string`   | no       | The single dimension `timeGrain` buckets. Must be one of `dimensions`. Required whenever `timeGrain` is set. |
+| `limit`         | `number`   | no       | Positive integer row cap (max 100000).                                                                       |
+| `format`        | `string`   | no       | Only `JSON_ARRAY` is supported. (Arrow streaming is not yet wired on this route.)                            |
 
 Measures and dimensions must be unique across both lists — a name cannot repeat, nor appear as both a measure and a dimension.
 
@@ -185,19 +186,19 @@ Predicates combine with `and` / `or` groups, which can nest:
 }
 ```
 
-The v1 operator vocabulary:
+The operator vocabulary:
 
-| Operator | SQL | Values |
-|----------|-----|--------|
-| `equals` | `=` | exactly one |
-| `notEquals` | `<>` | exactly one |
-| `in` | `IN (…)` | one or more |
-| `notIn` | `NOT IN (…)` | one or more |
-| `gt` / `gte` / `lt` / `lte` | `>` / `>=` / `<` / `<=` | exactly one |
-| `contains` | `LIKE '%value%'` | exactly one string |
-| `notContains` | `NOT LIKE '%value%'` | exactly one string |
-| `set` | `IS NOT NULL` | none |
-| `notSet` | `IS NULL` | none |
+| Operator                    | SQL                     | Values             |
+| --------------------------- | ----------------------- | ------------------ |
+| `equals`                    | `=`                     | exactly one        |
+| `notEquals`                 | `<>`                    | exactly one        |
+| `in`                        | `IN (…)`                | one or more        |
+| `notIn`                     | `NOT IN (…)`            | one or more        |
+| `gt` / `gte` / `lt` / `lte` | `>` / `>=` / `<` / `<=` | exactly one        |
+| `contains`                  | `LIKE '%value%'`        | exactly one string |
+| `notContains`               | `NOT LIKE '%value%'`    | exactly one string |
+| `set`                       | `IS NOT NULL`           | none               |
+| `notSet`                    | `IS NULL`               | none               |
 
 Filters are bounded to keep hostile input from exhausting the server: nesting depth ≤ 8, ≤ 100 children per `and` / `or` group, and ≤ 1000 values per predicate. A request that exceeds a cap is rejected with `400`.
 
@@ -205,10 +206,10 @@ Filters are bounded to keep hostile input from exhausting the server: nesting de
 
 Each entry in `metric-views.json` names the executor the query runs as, which also sets the cache scope. This is fixed by config, not the request:
 
-| `executor` | Runs as | Cache |
-|------------|---------|-------|
-| `app_service_principal` (default) | The app service principal | Shared across all users |
-| `user` | The requesting user (on-behalf-of) | Per user |
+| `executor`                        | Runs as                            | Cache                   |
+| --------------------------------- | ---------------------------------- | ----------------------- |
+| `app_service_principal` (default) | The app service principal          | Shared across all users |
+| `user`                            | The requesting user (on-behalf-of) | Per user                |
 
 This mirrors the `<key>.sql` vs `<key>.obo.sql` distinction for [file-based queries](#execution-context).
 
@@ -217,18 +218,28 @@ This mirrors the `<key>.sql` vs `<key>.obo.sql` distinction for [file-based quer
 The response is the same SSE stream as `POST /api/analytics/query/:query_key`. If the SQL warehouse is cold it first emits `warehouse_status` events (see [Warehouse readiness](#warehouse-readiness)), then a single `result` event with the rows as objects:
 
 ```json
-{ "type": "result", "data": [{ "region": "EMEA", "order_date": "2025-01-01", "arr": 1200000, "revenue": 340000 }] }
+{
+  "type": "result",
+  "data": [
+    {
+      "region": "EMEA",
+      "order_date": "2025-01-01",
+      "arr": 1200000,
+      "revenue": 340000
+    }
+  ]
+}
 ```
 
 On failure it emits an `error` event instead.
 
 ### Errors and behavior
 
-| Status | Body | When |
-|--------|------|------|
-| `404` | `{ "error": "Metric not found" }` | `:key` is not declared in `metric-views.json` (also the response for every key when the file is absent). |
-| `400` | `{ "error": "Invalid metric request body (fields: …)", "code": … }` | The request body fails validation. The message names only the offending field paths, never the submitted values. |
-| `503` | `{ "error": "Metric registry not available", "code": "METRIC_REGISTRY_LOAD_FAILED" }` | `metric-views.json` is present but malformed or unreadable. |
+| Status | Body                                                                                  | When                                                                                                             |
+| ------ | ------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `404`  | `{ "error": "Metric not found" }`                                                     | `:key` is not declared in `metric-views.json` (also the response for every key when the file is absent).         |
+| `400`  | `{ "error": "Invalid metric request body (fields: …)", "code": … }`                   | The request body fails validation. The message names only the offending field paths, never the submitted values. |
+| `503`  | `{ "error": "Metric registry not available", "code": "METRIC_REGISTRY_LOAD_FAILED" }` | `metric-views.json` is present but malformed or unreadable.                                                      |
 
 Editing `metric-views.json` is picked up on the next request — no server restart is needed. A previously malformed file that you fix likewise starts working on the next request.
 
@@ -241,15 +252,19 @@ React hook that subscribes to an analytics query over SSE and returns its latest
 ```ts
 import { useAnalyticsQuery } from "@databricks/appkit-ui/react";
 
-const { data, loading, error } = useAnalyticsQuery(queryKey, parameters, options);
+const { data, loading, error } = useAnalyticsQuery(
+  queryKey,
+  parameters,
+  options,
+);
 ```
 
 **Return type:**
 
 ```ts
 {
-  data: T | null;      // query result (typed array for JSON, TypedArrowTable for ARROW)
-  loading: boolean;    // true while the query is executing
+  data: T | null; // query result (typed array for JSON, TypedArrowTable for ARROW)
+  loading: boolean; // true while the query is executing
   error: string | null; // error message, or null on success
   warehouseStatus: WarehouseStatus | null; // see "Warehouse readiness" below
 }
@@ -257,11 +272,11 @@ const { data, loading, error } = useAnalyticsQuery(queryKey, parameters, options
 
 **Options:**
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `format` | `"JSON" \| "ARROW"` | `"JSON"` | Response format |
-| `maxParametersSize` | `number` | `102400` | Max serialized parameters size in bytes |
-| `autoStart` | `boolean` | `true` | Start query on mount |
+| Option              | Type                | Default  | Description                             |
+| ------------------- | ------------------- | -------- | --------------------------------------- |
+| `format`            | `"JSON" \| "ARROW"` | `"JSON"` | Response format                         |
+| `maxParametersSize` | `number`            | `102400` | Max serialized parameters size in bytes |
+| `autoStart`         | `boolean`           | `true`   | Start query on mount                    |
 
 ### Warehouse readiness
 
@@ -277,8 +292,10 @@ This means a cold start no longer freezes the UI on a stalled spinner. Render th
 import { useAnalyticsQuery } from "@databricks/appkit-ui/react";
 
 function SpendTable() {
-  const { data, loading, error, warehouseStatus } =
-    useAnalyticsQuery("spend_summary", params);
+  const { data, loading, error, warehouseStatus } = useAnalyticsQuery(
+    "spend_summary",
+    params,
+  );
 
   if (warehouseStatus && warehouseStatus.state !== "RUNNING") {
     return <div>Warehouse is {warehouseStatus.state.toLowerCase()}…</div>;
@@ -320,10 +337,7 @@ export function AppShell({ children }) {
 If you already render your own `<Toaster />` for unrelated app toasts, drop the indicator and call `useResourceStatusToaster()` instead so resource-status toasts share that single Toaster:
 
 ```tsx
-import {
-  useResourceStatusToaster,
-  Toaster,
-} from "@databricks/appkit-ui/react";
+import { useResourceStatusToaster, Toaster } from "@databricks/appkit-ui/react";
 
 function App() {
   useResourceStatusToaster();
@@ -342,7 +356,8 @@ For a fully custom toast body, pass `render` (rendered through `toast.custom`):
 <ResourceStatusIndicator
   render={(agg) => (
     <div className="rounded-lg border bg-background p-3 shadow">
-      {agg.worst?.kind} {agg.worst?.state.toLowerCase()} ({agg.activeCount} waiting)
+      {agg.worst?.kind} {agg.worst?.state.toLowerCase()} ({agg.activeCount}{" "}
+      waiting)
     </div>
   )}
 />
@@ -355,8 +370,7 @@ To override copy for a specific kind without rewriting the whole UI, pass `rende
   renderers={{
     warehouse: {
       title: () => "Spinning up your data",
-      description: (_s, agg) =>
-        `${agg.affectedLabels.length} chart(s) waiting`,
+      description: (_s, agg) => `${agg.affectedLabels.length} chart(s) waiting`,
     },
   }}
 />
@@ -386,11 +400,9 @@ import { useEffect, useId } from "react";
 
 function useLakebaseReadiness() {
   const id = useId();
-  const { publish, unpublish } = useResourceStatusPublisher(
-    id,
-    "lakebase",
-    { kindHint: "lakebase" },
-  );
+  const { publish, unpublish } = useResourceStatusPublisher(id, "lakebase", {
+    kindHint: "lakebase",
+  });
 
   useEffect(() => {
     publish({
@@ -406,10 +418,10 @@ function useLakebaseReadiness() {
 
 **Server config (in `analytics({...})`):**
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `warehouseStartupTimeoutMs` | `number` | `300000` (5 min) | Maximum time to wait for the warehouse to reach `RUNNING` before failing the request |
-| `autoStartWarehouse` | `boolean` | `true` | When `true`, a `STOPPED` warehouse is auto-started on the first request. Set to `false` for cost-controlled deployments where billable warehouse starts must not be triggered by user requests; in that case `STOPPED` surfaces as a `ConfigurationError` |
+| Option                      | Type      | Default          | Description                                                                                                                                                                                                                                               |
+| --------------------------- | --------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `warehouseStartupTimeoutMs` | `number`  | `300000` (5 min) | Maximum time to wait for the warehouse to reach `RUNNING` before failing the request                                                                                                                                                                      |
+| `autoStartWarehouse`        | `boolean` | `true`           | When `true`, a `STOPPED` warehouse is auto-started on the first request. Set to `false` for cost-controlled deployments where billable warehouse starts must not be triggered by user requests; in that case `STOPPED` surfaces as a `ConfigurationError` |
 
 **Example with loading/error/empty handling:**
 
@@ -419,21 +431,27 @@ import { sql } from "@databricks/appkit-ui/js";
 import { Skeleton } from "@databricks/appkit-ui";
 
 function SpendTable() {
-  const params = useMemo(() => ({
-    startDate: sql.date("2025-01-01"),
-    endDate: sql.date("2025-12-31"),
-  }), []);
+  const params = useMemo(
+    () => ({
+      startDate: sql.date("2025-01-01"),
+      endDate: sql.date("2025-12-31"),
+    }),
+    [],
+  );
 
   const { data, loading, error } = useAnalyticsQuery("spend_summary", params);
 
   if (loading) return <Skeleton className="h-32 w-full" />;
   if (error) return <div className="text-destructive">{error}</div>;
-  if (!data?.length) return <div className="text-muted-foreground">No results</div>;
+  if (!data?.length)
+    return <div className="text-muted-foreground">No results</div>;
 
   return (
     <ul>
       {data.map((row) => (
-        <li key={row.id}>{row.name}: ${row.cost_usd}</li>
+        <li key={row.id}>
+          {row.name}: ${row.cost_usd}
+        </li>
       ))}
     </ul>
   );

--- a/docs/docs/plugins/analytics.md
+++ b/docs/docs/plugins/analytics.md
@@ -143,7 +143,7 @@ Content-Type: application/json
 | `timeGrain`     | `string`   | no       | Bucket a time dimension via `date_trunc('<grain>', …)` — e.g. `day`, `month`. Requires `timeDimension`.      |
 | `timeDimension` | `string`   | no       | The single dimension `timeGrain` buckets. Must be one of `dimensions`. Required whenever `timeGrain` is set. |
 | `limit`         | `number`   | no       | Positive integer row cap (max 100000).                                                                       |
-| `format`        | `string`   | no       | Only `JSON_ARRAY` is supported. (Arrow streaming is not yet wired on this route.)                            |
+| `format`        | `string`   | no       | `JSON_ARRAY` (default). `JSON` is accepted as a deprecated alias for it; Arrow formats (`ARROW`, `ARROW_STREAM`) are rejected on this route. |
 
 Measures and dimensions must be unique across both lists — a name cannot repeat, nor appear as both a measure and a dimension.
 
@@ -195,10 +195,14 @@ The operator vocabulary:
 | `in`                        | `IN (…)`                | one or more        |
 | `notIn`                     | `NOT IN (…)`            | one or more        |
 | `gt` / `gte` / `lt` / `lte` | `>` / `>=` / `<` / `<=` | exactly one        |
-| `contains`                  | `LIKE '%value%'`        | exactly one string |
-| `notContains`               | `NOT LIKE '%value%'`    | exactly one string |
+| `contains`                  | `LIKE :param`           | exactly one string |
+| `notContains`               | `NOT LIKE :param`       | exactly one string |
 | `set`                       | `IS NOT NULL`           | none               |
 | `notSet`                    | `IS NULL`               | none               |
+
+For `contains` / `notContains`, the `%…%` wildcards are applied to the *bound parameter value* (`%value%`), not written into the SQL text — so the value is never interpolated, consistent with every other operator.
+
+An empty `or` group (`{ "or": [] }`) is rejected with `400`; an empty `and` group (`{ "and": [] }`) is accepted and contributes no `WHERE` clause (a no-op). Keep this in mind when building filter trees programmatically.
 
 Filters are bounded to keep hostile input from exhausting the server: nesting depth ≤ 8, ≤ 100 children per `and` / `or` group, and ≤ 1000 values per predicate. A request that exceeds a cap is rejected with `400`.
 


### PR DESCRIPTION
Stacked on #474 (base `mv-runtime`).

Documents the user-facing surface of the metric-view runtime that #474 adds — the `POST /api/analytics/metric/:key` endpoint — in the analytics plugin docs.

## What's here

A new **Metric views** section in `docs/docs/plugins/analytics.md` covering:

- The endpoint and its **request body** (measures, dimensions, filter, `timeGrain`/`timeDimension`, limit, format), with a field table.
- **How the request becomes SQL** — a worked example showing the `SELECT MEASURE(...) ... GROUP BY ALL` the plugin builds, noting FQN/identifier backtick-quoting and parameter binding.
- **Filters** — the recursive `and`/`or` tree and the full v1 operator vocabulary as a table, plus the cardinality/depth caps.
- **Executors** — `app_service_principal` (shared cache) vs `user` (per-user OBO cache), fixed by `metric-views.json`.
- **Response** — the shared SSE envelope (`warehouse_status` → `result`), cross-linked to the existing warehouse-readiness docs.
- **Errors and behavior** — the `404` / `400` / `503` responses, dormant-when-absent, and hot-reload on edit.

Every SQL/JSON example is grounded in the runtime handler and the metric test suite, not invented.

## Scope

- **Runtime endpoint only.** No React hook ships on this branch, so no hook docs — those land with the hook PR.
- The config half (declaring `metric-views.json`, type generation) is already documented in `type-generation.md#metric-view-types`; this section links to it rather than repeating it.
- Docs only — no source changes.

## Verification

- `pnpm docs:build` — succeeds, no broken-link/anchor errors.
- `pnpm docs:check` — clean.

This pull request and its description were written by Isaac.
