### PR TITLE
fix(appkit): report only the actually-missing env vars in resource errors

### DIFF
--- a/docs/docs/api/appkit/Class.ResourceRegistry.md
+++ b/docs/docs/api/appkit/Class.ResourceRegistry.md
@@ -244,7 +244,7 @@ const registry = ResourceRegistry.getInstance();
 const result = registry.validate();
 
 if (!result.valid) {
-  console.error("Missing resources:", result.missing.map(r => Object.values(r.fields).map(f => f.env)));
+  console.error(ResourceRegistry.formatMissingResources(result.missing));
 }
 ```
 

--- a/packages/appkit/src/registry/resource-registry.ts
+++ b/packages/appkit/src/registry/resource-registry.ts
@@ -416,14 +416,33 @@ export class ResourceRegistry {
    * @param missing - Array of missing resource entries
    * @returns Formatted error message string
    */
+  /**
+   * Env var names for an entry's fields that are actually unset (undefined or
+   * empty), skipping fields that declare no env var (e.g. discovery-only
+   * fields resolved at deploy time). Mirrors the resolution check in
+   * {@link validate} so error output lists exactly what the caller must set —
+   * not every field on the resource.
+   */
+  private static unsetEnvVars(entry: ResourceEntry): string[] {
+    const unset: string[] = [];
+    for (const field of Object.values(entry.fields)) {
+      if (!field.env) continue;
+      const val = process.env[field.env];
+      if (val === undefined || val === "") {
+        unset.push(field.env);
+      }
+    }
+    return unset;
+  }
+
   public static formatMissingResources(missing: ResourceEntry[]): string {
     if (missing.length === 0) {
       return "No missing resources";
     }
 
     const lines = missing.map((entry) => {
-      const envVars = Object.values(entry.fields).map((f) => f.env);
-      const envHint = ` (set ${envVars.join(", ")})`;
+      const envVars = ResourceRegistry.unsetEnvVars(entry);
+      const envHint = envVars.length > 0 ? ` (set ${envVars.join(", ")})` : "";
       return `  - ${entry.type}:${entry.alias} [${entry.plugin}]${envHint}`;
     });
 
@@ -444,11 +463,13 @@ export class ResourceRegistry {
     ];
 
     for (const entry of missing) {
-      const envVars = Object.values(entry.fields).map((f) => f.env);
+      const envVars = ResourceRegistry.unsetEnvVars(entry);
       contentLines.push(
         `  ${entry.type}:${entry.alias}  (plugin: ${entry.plugin})`,
       );
-      contentLines.push(`    Set: ${envVars.join(", ")}`);
+      if (envVars.length > 0) {
+        contentLines.push(`    Set: ${envVars.join(", ")}`);
+      }
     }
 
     contentLines.push("");

--- a/packages/appkit/src/registry/resource-registry.ts
+++ b/packages/appkit/src/registry/resource-registry.ts
@@ -304,7 +304,7 @@ export class ResourceRegistry {
    * const result = registry.validate();
    *
    * if (!result.valid) {
-   *   console.error("Missing resources:", result.missing.map(r => Object.values(r.fields).map(f => f.env)));
+   *   console.error(ResourceRegistry.formatMissingResources(result.missing));
    * }
    * ```
    */
@@ -392,7 +392,7 @@ export class ResourceRegistry {
               type: r.type,
               alias: r.alias,
               plugin: r.plugin,
-              envVars: Object.values(r.fields).map((f) => f.env),
+              envVars: ResourceRegistry.unsetEnvVars(r),
             })),
           },
         });
@@ -410,12 +410,6 @@ export class ResourceRegistry {
     return validation;
   }
 
-  /**
-   * Formats missing resources into a human-readable error message.
-   *
-   * @param missing - Array of missing resource entries
-   * @returns Formatted error message string
-   */
   /**
    * Env var names for an entry's fields that are actually unset (undefined or
    * empty), skipping fields that declare no env var (e.g. discovery-only
@@ -435,6 +429,12 @@ export class ResourceRegistry {
     return unset;
   }
 
+  /**
+   * Formats missing resources into a human-readable error message.
+   *
+   * @param missing - Array of missing resource entries
+   * @returns Formatted error message string
+   */
   public static formatMissingResources(missing: ResourceEntry[]): string {
     if (missing.length === 0) {
       return "No missing resources";

--- a/packages/appkit/src/registry/tests/resource-registry.test.ts
+++ b/packages/appkit/src/registry/tests/resource-registry.test.ts
@@ -528,6 +528,77 @@ describe("ResourceRegistry", () => {
         else delete process.env.DATABRICKS_WAREHOUSE_ID;
       }
     });
+
+    it("should list only the unset env vars, not the ones already set", () => {
+      const prevScope = process.env.SECRET_SCOPE;
+      const prevKey = process.env.SECRET_KEY;
+      process.env.SECRET_SCOPE = "my-scope";
+      delete process.env.SECRET_KEY;
+      try {
+        const registry = new ResourceRegistry();
+        registry.register("analytics", {
+          type: ResourceType.SECRET,
+          alias: "creds",
+          resourceKey: "creds",
+          description: "Credentials",
+          permission: "READ",
+          required: true,
+          fields: {
+            scope: { env: "SECRET_SCOPE" },
+            key: { env: "SECRET_KEY" },
+          },
+        });
+
+        const result = registry.validate();
+        expect(result.valid).toBe(false);
+
+        const formatted = ResourceRegistry.formatMissingResources(
+          result.missing,
+        );
+        // Only the genuinely-missing var is reported; the one already set is not.
+        expect(formatted).toContain("SECRET_KEY");
+        expect(formatted).not.toContain("SECRET_SCOPE");
+      } finally {
+        if (prevScope !== undefined) process.env.SECRET_SCOPE = prevScope;
+        else delete process.env.SECRET_SCOPE;
+        if (prevKey !== undefined) process.env.SECRET_KEY = prevKey;
+        else delete process.env.SECRET_KEY;
+      }
+    });
+
+    it("should omit fields that declare no env var (e.g. discovery-only fields)", () => {
+      const prevHost = process.env.PGHOST_TEST;
+      delete process.env.PGHOST_TEST;
+      try {
+        const registry = new ResourceRegistry();
+        registry.register("lakebase", {
+          type: ResourceType.POSTGRES,
+          alias: "Postgres",
+          resourceKey: "postgres",
+          description: "Lakebase Postgres",
+          permission: "CAN_CONNECT_AND_CREATE",
+          required: true,
+          fields: {
+            // Discovery-only field: no env var, resolved at deploy time.
+            project: { description: "Project resource name" },
+            host: { env: "PGHOST_TEST" },
+          },
+        });
+
+        const result = registry.validate();
+        const formatted = ResourceRegistry.formatMissingResources(
+          result.missing,
+        );
+        // The one real missing env var is present…
+        expect(formatted).toContain("PGHOST_TEST");
+        // …and there are no stray empty entries from the env-less field.
+        expect(formatted).not.toContain("(set , ");
+        expect(formatted).not.toContain(", )");
+      } finally {
+        if (prevHost !== undefined) process.env.PGHOST_TEST = prevHost;
+        else delete process.env.PGHOST_TEST;
+      }
+    });
   });
 
   describe("collectResources with getResourceRequirements", () => {


### PR DESCRIPTION
## Problem

`ResourceRegistry.formatMissingResources` (and the dev-mode warning banner) printed **every** field's env var for a missing resource via `Object.values(entry.fields).map((f) => f.env)` — regardless of whether that var was already set, and including env-less discovery-only fields (which map to `undefined` and render as stray empty entries).

For a multi-field resource like Lakebase Postgres, a single unset variable produced a confusing message listing all seven fields plus empty slots:

```
Missing required resources:
  - postgres:Postgres [lakebase] (set , , , PGHOST, PGDATABASE, LAKEBASE_ENDPOINT, PGPORT, PGSSLMODE)
```

…even when only `PGPORT` was actually missing. The real problem was buried.

## Fix

Add a private `unsetEnvVars()` helper that returns only the env vars that are actually unset/empty, skipping fields that declare no `env` — mirroring the exact resolution check already in `validate()`. Both `formatMissingResources` and `formatDevWarningBanner` now use it, so the error lists exactly what the caller must set:

```
Missing required resources:
  - postgres:Postgres [lakebase] (set PGPORT)
```

## Tests

- New: a partially-configured multi-field resource reports **only** the unset var, not the one already set.
- New: env-less discovery-only fields never appear (no stray empty entries).
- A mutation reverting the fix fails exactly these two tests.
- Full `resource-registry` suite: 26/26 pass; appkit typecheck + biome clean.

## Scope

This is a **reporting** fix only. Separately, fields with a static `"value"` default in the manifest (e.g. `PGPORT: "5432"`) are still reported as missing because `validate()` reads only `process.env` and ignores the `"value"` fallback — a deeper bug left out of this PR.

Branched from `main`; independent of the graceful-shutdown work in #441.

---
_This PR was created with [GitHub MCP](http://go/mcps)._