### PR TITLE
fix(cli): match lint test-file exclusion relative to scan root

### DIFF
--- a/packages/shared/src/cli/commands/lint.ts
+++ b/packages/shared/src/cli/commands/lint.ts
@@ -40,9 +40,14 @@ const rules: Rule[] = [
   },
 ];
 
-function isTestFile(filePath: string): boolean {
+function isTestFile(filePath: string, rootDir: string): boolean {
+  // Match against the path relative to the scan root, not the absolute path:
+  // an ancestor directory named `tests` (e.g. `~/Developer/tests/my-app`)
+  // must not classify the whole project as tests and disable every
+  // `includeTests: false` rule.
+  const rel = path.relative(rootDir, filePath);
   return (
-    /\.(test|spec)\.(ts|tsx)$/.test(filePath) || filePath.includes("/tests/")
+    /\.(test|spec)\.(ts|tsx)$/.test(rel) || /(^|[/\\])tests[/\\]/.test(rel)
   );
 }
 
@@ -73,11 +78,11 @@ interface Violation {
   code: string;
 }
 
-function lintFile(filePath: string, rules: Rule[]): Violation[] {
+function lintFile(filePath: string, rules: Rule[], rootDir: string): Violation[] {
   const violations: Violation[] = [];
   const content = fs.readFileSync(filePath, "utf-8");
   const lang = filePath.endsWith(".tsx") ? Lang.Tsx : Lang.TypeScript;
-  const testFile = isTestFile(filePath);
+  const testFile = isTestFile(filePath, rootDir);
 
   const ast = parse(lang, content);
   const root = ast.root();
@@ -120,7 +125,7 @@ function runLint() {
   const allViolations: Violation[] = [];
 
   for (const file of files) {
-    const violations = lintFile(file, rules);
+    const violations = lintFile(file, rules, rootDir);
     allViolations.push(...violations);
   }
 

--- a/packages/shared/src/cli/commands/lint.ts
+++ b/packages/shared/src/cli/commands/lint.ts
@@ -41,10 +41,7 @@ const rules: Rule[] = [
 ];
 
 function isTestFile(filePath: string, rootDir: string): boolean {
-  // Match against the path relative to the scan root, not the absolute path:
-  // an ancestor directory named `tests` (e.g. `~/Developer/tests/my-app`)
-  // must not classify the whole project as tests and disable every
-  // `includeTests: false` rule.
+  // Relative to scan root: an ancestor `tests` dir must not mark the whole project as tests.
   const rel = path.relative(rootDir, filePath);
   return (
     /\.(test|spec)\.(ts|tsx)$/.test(rel) || /(^|[/\\])tests[/\\]/.test(rel)
@@ -78,7 +75,11 @@ interface Violation {
   code: string;
 }
 
-function lintFile(filePath: string, rules: Rule[], rootDir: string): Violation[] {
+function lintFile(
+  filePath: string,
+  rules: Rule[],
+  rootDir: string,
+): Violation[] {
   const violations: Violation[] = [];
   const content = fs.readFileSync(filePath, "utf-8");
   const lang = filePath.endsWith(".tsx") ? Lang.Tsx : Lang.TypeScript;


### PR DESCRIPTION
## Problem

`appkit lint`'s `isTestFile` substring-matched `"/tests/"` against the **absolute** file path:

```ts
filePath.includes("/tests/")
```

Any ancestor directory named `tests` — e.g. an app scaffolded under `~/Developer/personal/tests/my-app` — makes every file in the project match, so it's treated as a test file. Rules marked `includeTests: false` (`no-variants-in-prod`, `no-as-any`) are then **silently skipped for the entire project**, and `appkit lint` reports no violations even when they exist.

This defeats the `no-variants-in-prod` guardrail exactly where it matters: a leftover dev-only `<Variants>` block can ship to production while the lint stays green, purely because of an unlucky (and common) parent directory name.

## Fix

Match against the path **relative to the scan root**, with path-segment boundaries, instead of a substring of the absolute path. `rootDir` is threaded from `runLint` → `lintFile` → `isTestFile`.

## Verification

- `tsc --noEmit` on the changed file: clean.
- Behavioral before/after:

  | scenario | old | new |
  |---|---|---|
  | app under a `tests/` ancestor (`…/personal/tests/app/src/Foo.tsx`) | `true` (bug) | `false` ✓ |
  | real test file (`src/foo.spec.tsx`) | `true` | `true` ✓ |
  | project-local `tests/` dir (`tests/smoke.ts`) | `true` | `true` ✓ |
  | normal source (`src/App.tsx`) | `false` | `false` ✓ |

Reproduced originally by scaffolding an app under a `tests/` parent directory and observing `no-variants-in-prod` never fire on a real `<Variants>` block in the app source.
