### PR TITLE
fix(type-generator): treat empty/un-rendered definitions.json as no metric views

### DIFF
--- a/packages/appkit/src/type-generator/mv-registry/config.ts
+++ b/packages/appkit/src/type-generator/mv-registry/config.ts
@@ -46,11 +46,17 @@ function compareKeys(a: string, b: string): number {
  * Read {@link METRIC_CONFIG_FILE} from a metric-views folder
  * (`config/metric-views/`).
  *
- * Returns `null` if the file does not exist (the metric-view path is
- * additive — apps without definitions.json must not be penalized). There is
- * deliberately no fallback to a legacy filename.
+ * Returns `null` if the file does not exist, is empty, or has not been rendered
+ * yet (the metric-view path is additive — apps without a defined
+ * definitions.json must not be penalized). The template ships definitions.json
+ * wrapped in a `{{if .plugins.analytics}}` guard, so scaffolding without the
+ * analytics plugin leaves the file empty, and running typegen against the raw
+ * (un-rendered) template leaves the literal `{{...}}` in place — neither is a
+ * misconfiguration, so both are treated the same as an absent file rather than
+ * a fatal parse error. There is deliberately no fallback to a legacy filename.
  *
- * Throws on JSON parse errors so misconfiguration surfaces loudly.
+ * Throws on JSON parse errors in a *non-empty, rendered* file so genuine
+ * misconfiguration still surfaces loudly.
  */
 export async function readMetricConfig(
   metricViewsFolder: string,
@@ -64,6 +70,14 @@ export async function readMetricConfig(
       return null;
     }
     throw err;
+  }
+
+  // An empty file (analytics plugin off → the `{{if}}` guard renders nothing)
+  // or an un-rendered template (raw `{{...}}` left in place during typegen on
+  // the template itself) means "no metric views" — treat like an absent file.
+  const trimmed = raw.trim();
+  if (trimmed === "" || trimmed.startsWith("{{")) {
+    return null;
   }
 
   let parsed: unknown;

--- a/packages/appkit/src/type-generator/tests/mv-registry.test.ts
+++ b/packages/appkit/src/type-generator/tests/mv-registry.test.ts
@@ -94,6 +94,29 @@ describe("readMetricConfig", () => {
     expect(await readMetricConfig(tmpDir)).toBeNull();
   });
 
+  test("returns null for an empty definitions.json (analytics plugin off)", async () => {
+    // The template wraps definitions.json in `{{if .plugins.analytics}}`, so
+    // scaffolding without the analytics plugin renders an empty file. That's
+    // "no metric views", not a parse error.
+    await fs.writeFile(path.join(tmpDir, "definitions.json"), "");
+    expect(await readMetricConfig(tmpDir)).toBeNull();
+  });
+
+  test("returns null for a whitespace-only definitions.json", async () => {
+    await fs.writeFile(path.join(tmpDir, "definitions.json"), "\n  \n");
+    expect(await readMetricConfig(tmpDir)).toBeNull();
+  });
+
+  test("returns null for an un-rendered template definitions.json", async () => {
+    // Running typegen against the raw template (e.g. npm-install warmup before
+    // `appkit setup`) leaves the Go-template guard literal in place.
+    await fs.writeFile(
+      path.join(tmpDir, "definitions.json"),
+      '{{if .plugins.analytics -}}\n{ "metricViews": {} }\n{{- end}}\n',
+    );
+    expect(await readMetricConfig(tmpDir)).toBeNull();
+  });
+
   test("parses a valid definitions.json", async () => {
     await fs.writeFile(
       path.join(tmpDir, "definitions.json"),


### PR DESCRIPTION
## Summary

`readMetricConfig` threw a fatal `Failed to parse definitions.json` whenever `config/metric-views/definitions.json` was **empty** or still held its **un-rendered Go-template guard**.

The template ships that file wrapped in `{{if .plugins.analytics}}`:
```
{{if .plugins.analytics -}}
{ "$schema": "...", "metricViews": {} }
{{- end}}
```
So two entirely normal situations produced invalid JSON:
- **Scaffolding an app without the analytics plugin** → the guard renders nothing → empty file.
- **Running typegen against the raw template** (e.g. an `npm install` `postinstall` → `appkit generate-types` warmup, before `appkit setup` renders anything) → the literal `{{...}}` is still present.

Both are "no metric views defined" — an additive, non-error state the function already documents (`Returns null if the file does not exist ... apps without definitions.json must not be penalized`). But `JSON.parse("")` / `JSON.parse("{{...")` threw, aborting `appkit generate-types` and thus failing `npm install` for any analytics-off app and any tool that warms the raw template.

## Fix

Treat empty / whitespace-only / un-rendered (`{{`-prefixed) content the same as an absent file — `return null`. A non-empty, rendered file with genuinely malformed JSON **still throws loudly**, so real misconfiguration is unaffected.

## How I found it

Discovered while running the Databricks app-evals harness against the `latest` AppKit template (`template-v0.48.0`): the eval cluster's template npm-warmup and the agent's `appkit setup` both died with `FATAL config/metric-views/definitions.json: Failed to parse definitions.json ... Expected property name or '}' in JSON`.

## Testing

Added `mv-registry` tests for the empty, whitespace-only, and un-rendered cases (each expects `null`); the existing "throws on malformed JSON" test still guards that genuine bad JSON errors. Verified the branch logic against all six cases (absent / empty / whitespace / unrendered / valid / malformed).

This pull request and its description were written by Isaac.
