### PR TITLE
chore: ignore .isaac/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ coverage
 
 .claude/scheduled_tasks.lock
 internal
+
+.isaac/


### PR DESCRIPTION
Add `.isaac/` to `.gitignore` so Isaac Review scratch/config artifacts aren't tracked.

This pull request and its description were written by Isaac.