### PR TITLE
ci: fix devhub-validation (build with pnpm) and add a nightly DevHub build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,13 +338,21 @@ jobs:
       - name: Clone DevHub
         run: git clone --depth 1 https://github.com/databricks/devhub.git /tmp/devhub
 
+      # DevHub is a pnpm-only repo (commits pnpm-lock.yaml, packageManager: pnpm@10.11.0).
+      # Build it the way DevHub builds itself so the install is reproducible; using npm here
+      # ignored the committed lock and did a floating resolve on every run.
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 10.11.0
+          run_install: false
+
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
 
       - name: Install DevHub dependencies
         working-directory: /tmp/devhub
-        run: npm install
+        run: pnpm install --frozen-lockfile
 
       - name: Sync AppKit docs from PR branch
         working-directory: /tmp/devhub
@@ -355,5 +363,5 @@ jobs:
 
       - name: Build DevHub
         working-directory: /tmp/devhub
-        run: npm run build
+        run: pnpm build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,13 +338,12 @@ jobs:
       - name: Clone DevHub
         run: git clone --depth 1 https://github.com/databricks/devhub.git /tmp/devhub
 
-      # DevHub is a pnpm-only repo (commits pnpm-lock.yaml, packageManager: pnpm@10.11.0).
-      # Build it the way DevHub builds itself so the install is reproducible; using npm here
-      # ignored the committed lock and did a floating resolve on every run.
+      # DevHub is a pnpm-only repo (commits pnpm-lock.yaml). Build it the way DevHub builds
+      # itself so the install is reproducible; using npm here ignored the committed lock and
+      # did a floating resolve on every run. No `version:` input — action-setup reads it from
+      # this repo's packageManager field, matching the other jobs (pnpm 10.x reads DevHub's
+      # lockfileVersion 9.0 fine).
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        with:
-          version: 10.11.0
-          run_install: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,11 +338,6 @@ jobs:
       - name: Clone DevHub
         run: git clone --depth 1 https://github.com/databricks/devhub.git /tmp/devhub
 
-      # DevHub is a pnpm-only repo (commits pnpm-lock.yaml). Build it the way DevHub builds
-      # itself so the install is reproducible; using npm here ignored the committed lock and
-      # did a floating resolve on every run. No `version:` input — action-setup reads it from
-      # this repo's packageManager field, matching the other jobs (pnpm 10.x reads DevHub's
-      # lockfileVersion 9.0 fine).
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,37 +325,11 @@ jobs:
     name: DevHub Build Validation
     needs: detect-changes
     if: needs.detect-changes.outputs.docs == 'true'
-    runs-on:
-      group: databricks-protected-runner-group
-      labels: linux-ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Setup JFrog npm
-        uses: ./.github/actions/setup-jfrog-npm
-
-      - name: Clone DevHub
-        run: git clone --depth 1 https://github.com/databricks/devhub.git /tmp/devhub
-
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 22
-
-      - name: Install DevHub dependencies
-        working-directory: /tmp/devhub
-        run: pnpm install --frozen-lockfile
-
-      - name: Sync AppKit docs from PR branch
-        working-directory: /tmp/devhub
-        env:
-          APPKIT_REMOTE: ${{ github.event.pull_request.head.repo.clone_url || format('https://github.com/{0}.git', github.repository) }}
-          APPKIT_BRANCH: ${{ github.head_ref || github.ref_name }}
-        run: node scripts/sync-appkit-docs.mjs --force
-
-      - name: Build DevHub
-        working-directory: /tmp/devhub
-        run: pnpm build
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/devhub-build.yml
+    with:
+      appkit-remote: ${{ github.event.pull_request.head.repo.clone_url || format('https://github.com/{0}.git', github.repository) }}
+      appkit-ref: ${{ github.head_ref || github.ref_name }}
 

--- a/.github/workflows/devhub-build.yml
+++ b/.github/workflows/devhub-build.yml
@@ -1,8 +1,7 @@
 name: DevHub Build
 
-# Reusable workflow: clones DevHub, syncs AppKit docs from the given ref, and runs
-# DevHub's build to validate that our docs build inside the actual consumer site.
-# Called by ci.yml (per-PR) and devhub-nightly.yml (scheduled against main).
+# Builds DevHub with AppKit docs synced from the given ref.
+# Called by ci.yml (per-PR) and devhub-nightly.yml.
 
 on:
   workflow_call:

--- a/.github/workflows/devhub-build.yml
+++ b/.github/workflows/devhub-build.yml
@@ -1,0 +1,58 @@
+name: DevHub Build
+
+# Reusable workflow: clones DevHub, syncs AppKit docs from the given ref, and runs
+# DevHub's build to validate that our docs build inside the actual consumer site.
+# Called by ci.yml (per-PR) and devhub-nightly.yml (scheduled against main).
+
+on:
+  workflow_call:
+    inputs:
+      appkit-remote:
+        description: "Git URL to sync AppKit docs from"
+        type: string
+        default: "https://github.com/databricks/appkit.git"
+      appkit-ref:
+        description: "AppKit branch/ref to sync docs from"
+        type: string
+        default: "main"
+
+permissions:
+  contents: read
+  id-token: write # required for the JFrog OIDC token exchange in setup-jfrog-npm
+
+jobs:
+  build:
+    name: Build DevHub
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup JFrog npm
+        uses: ./.github/actions/setup-jfrog-npm
+
+      - name: Clone DevHub
+        run: git clone --depth 1 https://github.com/databricks/devhub.git /tmp/devhub
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+
+      - name: Install DevHub dependencies
+        working-directory: /tmp/devhub
+        run: pnpm install --frozen-lockfile
+
+      - name: Sync AppKit docs
+        working-directory: /tmp/devhub
+        env:
+          APPKIT_REMOTE: ${{ inputs.appkit-remote }}
+          APPKIT_BRANCH: ${{ inputs.appkit-ref }}
+        run: node scripts/sync-appkit-docs.mjs --force
+
+      - name: Build DevHub
+        working-directory: /tmp/devhub
+        run: pnpm build

--- a/.github/workflows/devhub-nightly.yml
+++ b/.github/workflows/devhub-nightly.yml
@@ -6,7 +6,7 @@ name: DevHub Nightly Build
 on:
   schedule:
     - cron: "0 6 * * *" # 06:00 UTC daily
-  workflow_dispatch: # allow manual re-run
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -14,5 +14,5 @@ permissions:
 
 jobs:
   devhub-build:
-    # No inputs → defaults sync databricks/appkit main and build it against DevHub.
+    # Defaults build databricks/appkit main against DevHub.
     uses: ./.github/workflows/devhub-build.yml

--- a/.github/workflows/devhub-nightly.yml
+++ b/.github/workflows/devhub-nightly.yml
@@ -1,0 +1,20 @@
+name: DevHub Nightly Build
+
+# Daily validation that AppKit main docs still build inside DevHub. Catches breaks
+# introduced by DevHub-side changes (their deps/framework) between AppKit docs PRs,
+# which the per-PR devhub-validation job cannot see. Failures surface via GitHub's
+# built-in scheduled-workflow-failure email to whoever last edited this file.
+
+on:
+  schedule:
+    - cron: "0 6 * * *" # 06:00 UTC daily
+  workflow_dispatch: # allow manual re-run
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  devhub-build:
+    # No inputs → defaults sync databricks/appkit main and build it against DevHub.
+    uses: ./.github/workflows/devhub-build.yml

--- a/.github/workflows/devhub-nightly.yml
+++ b/.github/workflows/devhub-nightly.yml
@@ -1,9 +1,7 @@
 name: DevHub Nightly Build
 
-# Daily validation that AppKit main docs still build inside DevHub. Catches breaks
-# introduced by DevHub-side changes (their deps/framework) between AppKit docs PRs,
-# which the per-PR devhub-validation job cannot see. Failures surface via GitHub's
-# built-in scheduled-workflow-failure email to whoever last edited this file.
+# Daily check that AppKit main docs still build inside DevHub, catching DevHub-side
+# breaks that land between docs PRs. Failures surface via GitHub's scheduled-failure email.
 
 on:
   schedule:

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,3 @@ The `pnpm build` command:
 2. Runs `apply-redirects` — replaces HTML pages with redirect pages pointing to developers.databricks.com
 
 Static files remain served from GitHub Pages: JSON schemas (`/schemas/`), `llms.txt`, and `.md` files (used by `npx @databricks/appkit docs` for npm-bundled documentation).
-
-<!-- ci: temporary touch to run devhub-validation via the reusable workflow; reverted before merge -->
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,3 @@ The `pnpm build` command:
 2. Runs `apply-redirects` — replaces HTML pages with redirect pages pointing to developers.databricks.com
 
 Static files remain served from GitHub Pages: JSON schemas (`/schemas/`), `llms.txt`, and `.md` files (used by `npx @databricks/appkit docs` for npm-bundled documentation).
-
-<!-- ci: touch to run devhub-validation (docs path filter); safe to drop before merge -->
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,3 +37,6 @@ The `pnpm build` command:
 2. Runs `apply-redirects` — replaces HTML pages with redirect pages pointing to developers.databricks.com
 
 Static files remain served from GitHub Pages: JSON schemas (`/schemas/`), `llms.txt`, and `.md` files (used by `npx @databricks/appkit docs` for npm-bundled documentation).
+
+<!-- ci: temporary touch to run devhub-validation via the reusable workflow; reverted before merge -->
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,3 +37,6 @@ The `pnpm build` command:
 2. Runs `apply-redirects` — replaces HTML pages with redirect pages pointing to developers.databricks.com
 
 Static files remain served from GitHub Pages: JSON schemas (`/schemas/`), `llms.txt`, and `.md` files (used by `npx @databricks/appkit docs` for npm-bundled documentation).
+
+<!-- ci: touch to run devhub-validation (docs path filter); safe to drop before merge -->
+


### PR DESCRIPTION
## What

- Build DevHub with **pnpm** instead of npm in the `devhub-validation` job (`pnpm install --frozen-lockfile` + `pnpm build`).
- Extract the DevHub build into a **reusable workflow** (`devhub-build.yml`) so the per-PR job and the new nightly share one definition.
- Add a **nightly** scheduled build (`devhub-nightly.yml`) that validates AppKit `main` docs against DevHub daily.

## Why

DevHub migrated from npm to pnpm (dropping `package-lock.json` for `pnpm-lock.yaml`), but this job kept installing it with `npm install`:

- npm ignores a pnpm lockfile, so it did a **floating, non-reproducible resolve on every run**.
- A transitive dependency publishing a new version then silently changed the installed tree with **no commit on either side** — the job passed one run and failed the next.
- That drift pulled `@databricks/appkit-ui/react` into Next's react-server graph, where React 19 omits `createContext`, crashing `next build` on `/_not-found` with `TypeError: b.createContext is not a function`.

`pnpm install --frozen-lockfile` pins the exact tree DevHub itself ships, so the job is reproducible and can only go red on a real change — broken AppKit docs (the signal we want) or a genuine DevHub-side change.

## Nightly build

The per-PR job only runs on docs PRs, so a DevHub-side breakage can go unnoticed until the next docs change. The nightly runs the same build against `main` once a day. Failures surface via GitHub's built-in scheduled-workflow-failure email — no extra secrets or notification code.

## Notes

- Both callers grant `id-token: write` so the JFrog OIDC step keeps working. DevHub's lockfile (v9.0) uses integrity-only resolutions, so `--frozen-lockfile` is registry-agnostic through the JFrog proxy.
- **Latent, out of scope**: appkit-ui's `/react` barrel re-exports modules that top-level-call `createContext` without `"use client"`. It only bites under an npm flat-hoist + RSC combo DevHub never uses, and this job compiles the *published* appkit-ui, not PR code. Tracked separately.

This pull request and its description were written by Isaac.
