### PR TITLE
feat: CI-resilient `--wait` typegen with committed-types fallback

### DIFF
--- a/docs/docs/development/type-generation.md
+++ b/docs/docs/development/type-generation.md
@@ -82,7 +82,22 @@ Pass `--wait` for CI and production builds, where accurate types must be present
 npx @databricks/appkit generate-types --wait
 ```
 
-In blocking mode the generator starts a stopped warehouse, waits (bounded) for it to reach `RUNNING`, and then describes your queries. It fails only when the configured warehouse no longer exists (deleted/deleting), so a transient outage or a cold warehouse degrades gracefully rather than breaking the build. The app template wires this up for you: `postinstall` and `predev` run the non-blocking default, while `prebuild` runs `--wait`.
+#### CI resilience: committed types as fallback
+
+In blocking mode (`--wait`), the generator attempts to fetch real types from your warehouse, but delegates to **committed `.d.ts` files** (`shared/appkit-types/analytics.d.ts`, `metric-views.d.ts`) as the fallback when the warehouse is unreachable. These committed files should be part of your repository. On a fresh CI checkout, every build attempts to DESCRIBE against the warehouse; the committed types are used only when that cannot complete.
+
+The generator **never overwrites committed types with degraded (`result: unknown`) types** — it writes real types, or it does not write at all.
+
+A **two-bucket failure taxonomy** determines whether the build crashes or falls back to committed types:
+
+- **Deterministic failures (always crash):** SQL syntax errors in your queries (genuine DESCRIBE failure against a reachable warehouse), HTTP 404 (bad or unknown warehouse ID), HTTP 400 (malformed request). These are developer or configuration errors that committed types must not hide.
+- **Environmental failures (gate on committed types):** Authentication failures (401/403), network unreachability, warehouse unavailability (cold, deleting, or deleted), wait timeout on `RUNNING`, or any unrecognized failure. If committed types exist, the build **keeps them, emits a loud warning to stderr, and succeeds (exit 0)**. If no committed types exist, the build **crashes** with a message instructing you to run `npx @databricks/appkit generate-types --wait` locally (against a reachable warehouse) and commit the `.d.ts` files.
+
+The loud warning is a single greppable stderr line naming the coarse cause (auth blocked / warehouse unreachable / warehouse unavailable) and the warehouse ID, so CI logs surface that the build fell back to committed types.
+
+**Note:** If your app declares only metric views and no `config/queries/`, the first build still writes an empty `analytics.d.ts`, which counts as "committed types present" for the gate. An environmental failure will then fall back and warn rather than crash, even on a first build — an accepted v1 simplification.
+
+The app template wires this up for you: `postinstall` and `predev` run the non-blocking default, while `prebuild` runs `--wait`.
 
 ## Metric-view types
 
@@ -90,7 +105,7 @@ In blocking mode the generator starts a stopped warehouse, waits (bounded) for i
 
 - `metric-views.d.ts` — augments the `MetricRegistry` interface so `useMetricView('<key>', …)` is autocompleted and type-checked. Each view's measures, dimensions, and their semantic metadata (SQL type, display name, format, time grains) are encoded at the type level.
 
-If `config/metric-views/definitions.json` is absent the metric path stays dormant (nothing is emitted). When present it follows the **same** warehouse-readiness contract as query types: in the default non-blocking run a view that can't be described yet — a cold warehouse, or a bad/unreachable source — is written with permissive types and a warning, while under `--wait` that same situation fails the build so CI never ships incomplete metric types. A malformed `definitions.json` (invalid JSON, or a source that isn't a three-part UC FQN) fails fast in every mode.
+If `config/metric-views/definitions.json` is absent the metric path stays dormant (nothing is emitted). When present it follows the **same** warehouse-readiness contract as query types: in the default non-blocking run a view that can't be described yet — a cold warehouse, or a bad/unreachable source — is written with permissive types and a warning, while under `--wait` metric views obey the [two-bucket taxonomy](#ci-resilience-committed-types-as-fallback) (environmental failures gate to committed `metric-views.d.ts` + warn; deterministic failures like malformed definitions crash the build). A malformed `definitions.json` (invalid JSON, or a source that isn't a three-part UC FQN) fails fast in every mode.
 
 `definitions.json` is keyed by metric key; each entry names the three-part UC FQN of the view and, optionally, the executor it runs as (`app_service_principal`, the default, or `user`):
 

--- a/packages/appkit/src/type-generator/errors.ts
+++ b/packages/appkit/src/type-generator/errors.ts
@@ -193,3 +193,37 @@ export function classifyBlockingFailure(
   // timeout messages, plain Error objects) → environmental.
   return "environmental";
 }
+
+/**
+ * Coarse cause label for an environmental failure, used by the `--wait`
+ * committed-types warning so the log says *why* generation fell back.
+ *
+ * Returns:
+ * - "unreachable": transport/connectivity failure (see {@link isConnectivityError}).
+ * - "auth": HTTP 401/403, including a status carried on `response.status` or
+ *   wrapped in a `cause`/`AggregateError` chain.
+ * - "unavailable": everything else (DELETED/DELETING, wait timeouts, degraded
+ *   DESCRIBEs).
+ */
+export function classifyEnvironmentalCause(
+  error: unknown,
+): "auth" | "unreachable" | "unavailable" {
+  if (isConnectivityError(error)) return "unreachable";
+
+  // Walk the error chain so a wrapped 401/403 is still labeled as auth.
+  const seen = new Set<unknown>();
+  const stack = [error];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (current === undefined || seen.has(current)) continue;
+    seen.add(current);
+
+    const status = getErrorStatus(current);
+    if (status !== undefined && AUTH_ERROR_STATUSES.has(status)) return "auth";
+
+    stack.push(...getErrorChildren(current));
+  }
+
+  return "unavailable";
+}

--- a/packages/appkit/src/type-generator/errors.ts
+++ b/packages/appkit/src/type-generator/errors.ts
@@ -139,3 +139,57 @@ export function isConnectivityError(error: unknown): boolean {
 
   return false;
 }
+
+const AUTH_ERROR_STATUSES = new Set([401, 403]);
+
+/**
+ * Classifies a thrown failure into one of two buckets: deterministic failures
+ * that must be surfaced (bad warehouse id, malformed request) or environmental
+ * issues (connectivity, auth, deleted warehouse, timeouts) that the has-types
+ * gate will handle later.
+ *
+ * Returns:
+ * - "deterministic": HTTP 404 (bad warehouse id) or 400 (malformed request).
+ *   The build must fail.
+ * - "environmental": Everything else — auth (401/403), connectivity errors,
+ *   warehouse state changes (DELETED/DELETING), wait-for-RUNNING timeouts,
+ *   unrecognized failures. Default = environmental.
+ *
+ * Walks `cause`/`AggregateError` chains when checking for deterministic status,
+ * so a wrapped 404 is still recognized as deterministic.
+ */
+export function classifyBlockingFailure(
+  error: unknown,
+): "deterministic" | "environmental" {
+  // Deterministic: check first so they're never swallowed by environmental rules.
+  // Walk the error chain to find any deterministic status.
+  const seen = new Set<unknown>();
+  const stack = [error];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (current === undefined || seen.has(current)) continue;
+    seen.add(current);
+
+    const status = getErrorStatus(current);
+    if (status === 404 || status === 400) {
+      return "deterministic";
+    }
+
+    stack.push(...getErrorChildren(current));
+  }
+
+  // Environmental: auth, connectivity, unrecognized, default.
+  const topLevelStatus = getErrorStatus(error);
+  if (topLevelStatus !== undefined && AUTH_ERROR_STATUSES.has(topLevelStatus)) {
+    return "environmental";
+  }
+
+  if (isConnectivityError(error)) {
+    return "environmental";
+  }
+
+  // Default: any unrecognized failure or no status (DELETED/DELETING messages,
+  // timeout messages, plain Error objects) → environmental.
+  return "environmental";
+}

--- a/packages/appkit/src/type-generator/index.ts
+++ b/packages/appkit/src/type-generator/index.ts
@@ -462,10 +462,13 @@ export async function generateFromEntryPoint(options: {
     environmentalCause =
       environmentalCause ?? mvResult.environmentalCause ?? undefined;
 
-    // Blocking (`--wait` / prod Vite) escalates per-key DESCRIBE failures — a bad or unreachable source, i.e. a config error
-    // to build failures so the end-of-run throw fails after the writes.
+    // Blocking (`--wait` / prod Vite) escalates only deterministic per-key
+    // DESCRIBE failures. Transient connectivity failures are already recorded
+    // as environmental by syncMetricViewsTypes and fall through to the
+    // committed-types gate below.
     if (mode === "blocking") {
       for (const failure of mvResult.failures) {
+        if (failure.transient) continue;
         fatalErrors.push({
           name: failure.key,
           message: `metric view ${failure.key} (${failure.source}) could not be described: ${failure.reason}`,
@@ -773,6 +776,14 @@ export async function syncMetricViewsTypes(options: {
           f.reason,
         );
       }
+    }
+
+    // A rejected DESCRIBE with a connectivity signal is expected to recover on
+    // a later pass. In blocking mode, route it through the same committed-types
+    // gate as preflight outages instead of treating it as a configuration error.
+    if (mode === "blocking" && failures.some((failure) => failure.transient)) {
+      hadEnvironmentalFailure = true;
+      environmentalCause = environmentalCause ?? "unreachable";
     }
 
     // Degraded-but-not-failed keys: the warehouse answered with a non-terminal

--- a/packages/appkit/src/type-generator/index.ts
+++ b/packages/appkit/src/type-generator/index.ts
@@ -101,15 +101,9 @@ function hasCommittedTypes(
   return hasAnalytics || hasMetrics;
 }
 
-/**
- * Detects if a query schema has degraded to `result: unknown`.
- * A degraded query cannot be distinguished from a successful one that simply
- * has no result columns (both emit `result: unknown`), so we conservatively
- * treat any `result: unknown` as potentially degraded for write-suppression
- * purposes in blocking mode.
- */
+/** Detects whether query generation explicitly marked a schema as degraded. */
 function isQueryDegraded(schema: QuerySchema): boolean {
-  return schema.type.includes("result: unknown");
+  return schema.degraded === true;
 }
 
 /**
@@ -403,10 +397,17 @@ export async function generateFromEntryPoint(options: {
 
   const typeDeclarations = generateTypeDeclarations(queryRegistry);
 
-  // In blocking mode, never overwrite committed types with a degraded result:
-  // if any query degraded to `result: unknown`, skip the write and leave the
-  // committed .d.ts as the fallback of record. Non-blocking mode always writes.
+  // In blocking mode, never overwrite committed types with a schema explicitly
+  // marked degraded. Leave the committed .d.ts as the fallback of record.
+  // Non-blocking mode always writes.
   const hasAnyDegradedQuery = queryRegistry.some(isQueryDegraded);
+  if (mode === "blocking" && hasAnyDegradedQuery) {
+    // A degraded schema always participates in the committed-types gate. Keep
+    // this invariant next to write suppression so a new producer cannot update
+    // one decision without the other.
+    hadEnvironmentalFailure = true;
+    environmentalCause = environmentalCause ?? "unavailable";
+  }
   const shouldWriteQueries = mode !== "blocking" || !hasAnyDegradedQuery;
 
   if (shouldWriteQueries) {

--- a/packages/appkit/src/type-generator/index.ts
+++ b/packages/appkit/src/type-generator/index.ts
@@ -14,6 +14,7 @@ import {
 } from "./cache";
 import {
   classifyBlockingFailure,
+  classifyEnvironmentalCause,
   getErrorDiagnostic,
   isConnectivityError,
 } from "./errors";
@@ -48,25 +49,6 @@ import {
 dotenv.config();
 
 const logger = createLogger("type-generator");
-
-/**
- * Classify an environmental failure into one of three coarse cause labels
- * for the warning message.
- */
-function classifyEnvironmentalCause(
-  error: unknown,
-): "auth" | "unreachable" | "unavailable" {
-  if (isConnectivityError(error)) return "unreachable";
-  if (typeof error === "object" && error !== null) {
-    const err = error as Record<string, unknown>;
-    const status = err.status ?? err.statusCode;
-    if (typeof status === "number" && (status === 401 || status === 403)) {
-      return "auth";
-    }
-  }
-  // Default for other environmental failures (DELETED/DELETING, timeouts, etc.)
-  return "unavailable";
-}
 
 /**
  * Upper bound (~5 min) on how long the Metric Views path's `blocking`-mode preflight

--- a/packages/appkit/src/type-generator/index.ts
+++ b/packages/appkit/src/type-generator/index.ts
@@ -57,7 +57,6 @@ function classifyEnvironmentalCause(
   error: unknown,
 ): "auth" | "unreachable" | "unavailable" {
   if (isConnectivityError(error)) return "unreachable";
-  // Check for auth status (401/403)
   if (typeof error === "object" && error !== null) {
     const err = error as Record<string, unknown>;
     const status = err.status ?? err.statusCode;
@@ -83,7 +82,7 @@ const MV_PREFLIGHT_WAIT_MAX_MS = 300_000;
  * @param warehouseId - the warehouse ID
  */
 function determineWarningMessage(
-  cause: "auth" | "unreachable" | "unavailable" = "unavailable",
+  cause: "auth" | "unreachable" | "unavailable",
   warehouseId: string,
 ): string {
   const causeLabel =
@@ -419,12 +418,9 @@ export async function generateFromEntryPoint(options: {
 
   const typeDeclarations = generateTypeDeclarations(queryRegistry);
 
-  // In blocking mode, suppress writes when any query is degraded AND there are
-  // no syntax/fatal errors to preserve committed .d.ts files as the fallback of
-  // record. Degraded writes still happen when there are preflight errors (which
-  // write before throwing). Non-blocking mode always writes. The throw still
-  // fires at the end if there are errors — this just prevents overwriting
-  // committed good types with degraded ones from pure connectivity failures.
+  // In blocking mode, never overwrite committed types with a degraded result:
+  // if any query degraded to `result: unknown`, skip the write and leave the
+  // committed .d.ts as the fallback of record. Non-blocking mode always writes.
   const hasAnyDegradedQuery = queryRegistry.some(isQueryDegraded);
   const shouldWriteQueries = mode !== "blocking" || !hasAnyDegradedQuery;
 
@@ -496,8 +492,8 @@ export async function generateFromEntryPoint(options: {
   await removeOldGeneratedTypes(projectRoot, "appKitTypes.d.ts");
   await migrateProjectConfig(projectRoot);
 
-  // Phase 3: Unified terminal decision combining deterministic & environmental failures
-  // with a has-types gate in blocking mode.
+  // Unified terminal decision: deterministic failures crash; environmental
+  // failures fall to the has-types gate in blocking mode.
 
   // Deterministic failures (SQL syntax errors or 404/400 HTTP) always crash regardless of mode.
   if (syntaxErrors.length > 0) {
@@ -757,14 +753,12 @@ export async function syncMetricViewsTypes(options: {
     // degrade silently. The degraded schemas are not cached (see the write
     // block), so a later pass re-probes.
     described = describeNeeded.map(emptyMetricSchema);
+    // Only deterministic fatals (404/400) record errors; environmental failures
+    // degrade silently for the has-types gate to handle.
     if (!hadEnvironmentalFailure) {
-      // Only deterministic fatals (404/400) record errors.
       for (const entry of describeNeeded) {
         fatalErrors.push({ name: entry.key, message: preflightFatalMessage });
       }
-    } else {
-      // Environmental failure: don't record in fatalErrors, let the has-types
-      // gate handle it later.
     }
   } else if (describeNeeded.length === 0) {
     // Nothing left to describe — every configured key was a cache hit.
@@ -876,12 +870,9 @@ export async function syncMetricViewsTypes(options: {
     return emptyMetricSchema(entry);
   });
 
-  // In blocking mode, suppress writes when any metric is degraded AND there are
-  // no failures to preserve committed .d.ts files as the fallback of record.
-  // Degraded writes still happen when there are preflight fatals or sync failures
-  // (which throw after writing). Non-blocking mode always writes. This just
-  // prevents overwriting committed good types with degraded ones from pure
-  // warehouse-not-ready scenarios.
+  // Same anti-clobber rule as the query path: when suppressDegradedWrite is set
+  // (blocking mode), skip the write if any metric degraded, preserving the
+  // committed metric-views.d.ts. Non-blocking mode always writes.
   const shouldWriteMetrics =
     !suppressDegradedWrite || !hasAnyDegradedMetrics(schemas);
 

--- a/packages/appkit/src/type-generator/index.ts
+++ b/packages/appkit/src/type-generator/index.ts
@@ -62,9 +62,7 @@ const MV_PREFLIGHT_WAIT_MAX_MS = 300_000;
 
 /**
  * Generate a loud warning message for environmental failures with committed types present.
- * The message includes a coarse cause label and the warehouse ID.
  * @param cause - coarse cause label: "auth" (401/403), "unreachable" (connectivity), or "unavailable" (other)
- * @param warehouseId - the warehouse ID
  */
 function determineWarningMessage(
   cause: "auth" | "unreachable" | "unavailable",
@@ -101,14 +99,10 @@ function hasCommittedTypes(
   return hasAnalytics || hasMetrics;
 }
 
-/** Detects whether query generation explicitly marked a schema as degraded. */
 function isQueryDegraded(schema: QuerySchema): boolean {
   return schema.degraded === true;
 }
 
-/**
- * Detects if any metric schemas are degraded (marked with `degraded: true`).
- */
 function hasAnyDegradedMetrics(schemas: MetricSchema[]): boolean {
   return schemas.some((s) => s.degraded === true);
 }
@@ -481,9 +475,6 @@ export async function generateFromEntryPoint(options: {
   await removeOldGeneratedTypes(projectRoot, "appKitTypes.d.ts");
   await migrateProjectConfig(projectRoot);
 
-  // Unified terminal decision: deterministic failures crash; environmental
-  // failures fall to the has-types gate in blocking mode.
-
   // Deterministic failures (SQL syntax errors or 404/400 HTTP) always crash regardless of mode.
   if (syntaxErrors.length > 0) {
     throw new TypegenSyntaxError(syntaxErrors, warehouseId, fatalErrors);
@@ -800,7 +791,7 @@ export async function syncMetricViewsTypes(options: {
         degradedKeys.length,
         degradedKeys.join(", "),
       );
-      hadEnvironmentalFailure = true; // Mark as environmental if any metric degraded.
+      hadEnvironmentalFailure = true;
       environmentalCause = environmentalCause ?? "unavailable";
     }
   } else {
@@ -814,7 +805,7 @@ export async function syncMetricViewsTypes(options: {
       describeNeeded.length,
       describeNeeded.map((e) => e.key).join(", "),
     );
-    hadEnvironmentalFailure = true; // Mark as environmental when not describing.
+    hadEnvironmentalFailure = true;
     environmentalCause = environmentalCause ?? "unavailable";
   }
 

--- a/packages/appkit/src/type-generator/index.ts
+++ b/packages/appkit/src/type-generator/index.ts
@@ -57,6 +57,24 @@ function plural(count: number, singular: string, pluralForm = `${singular}s`) {
   return count === 1 ? singular : pluralForm;
 }
 
+/**
+ * Detects if a query schema has degraded to `result: unknown`.
+ * A degraded query cannot be distinguished from a successful one that simply
+ * has no result columns (both emit `result: unknown`), so we conservatively
+ * treat any `result: unknown` as potentially degraded for write-suppression
+ * purposes in blocking mode.
+ */
+function isQueryDegraded(schema: QuerySchema): boolean {
+  return schema.type.includes("result: unknown");
+}
+
+/**
+ * Detects if any metric schemas are degraded (marked with `degraded: true`).
+ */
+function hasAnyDegradedMetrics(schemas: MetricSchema[]): boolean {
+  return schemas.some((s) => s.degraded === true);
+}
+
 function formatFailureRows(
   label: string,
   queries: TypegenFailure[],
@@ -331,8 +349,19 @@ export async function generateFromEntryPoint(options: {
 
   const typeDeclarations = generateTypeDeclarations(queryRegistry);
 
-  await fs.mkdir(path.dirname(outFile), { recursive: true });
-  await fs.writeFile(outFile, typeDeclarations, "utf-8");
+  // In blocking mode, suppress writes when any query is degraded AND there are
+  // no syntax/fatal errors to preserve committed .d.ts files as the fallback of
+  // record. Degraded writes still happen when there are preflight errors (which
+  // write before throwing). Non-blocking mode always writes. The throw still
+  // fires at the end if there are errors — this just prevents overwriting
+  // committed good types with degraded ones from pure connectivity failures.
+  const hasAnyDegradedQuery = queryRegistry.some(isQueryDegraded);
+  const shouldWriteQueries = mode !== "blocking" || !hasAnyDegradedQuery;
+
+  if (shouldWriteQueries) {
+    await fs.mkdir(path.dirname(outFile), { recursive: true });
+    await fs.writeFile(outFile, typeDeclarations, "utf-8");
+  }
 
   // Metric-view types: emit whenever a metric-views folder is resolved (gated
   // on the metric config's own dir, NOT the queries folder — an app can declare
@@ -351,6 +380,10 @@ export async function generateFromEntryPoint(options: {
         cache: !noCache,
         metricFetcher,
         mode,
+        // In blocking mode, only suppress writes for pure degradation (no failures).
+        // If there are preflight fatals or sync failures, degraded artifacts are
+        // still written before the throw.
+        suppressDegradedWrite: mode === "blocking",
       });
     } catch (configError) {
       // syncMetricViewsTypes only throws for a malformed definitions.json — re-throw as a message-only TypegenFatalError.
@@ -433,7 +466,11 @@ export interface SyncMetricViewsTypesResult {
  * @param options.metricOutFile - output path for the MetricRegistry `.d.ts`.
  * @param options.cache - cache toggle, default ON. Only `cache === false` disables it (so `undefined`/`true` keep caching).
  * @param options.metricFetcher - optional injected {@link DescribeFetcher}
- * @param options.mode - preflight/gate policy, default `"describe-now"`.
+ * @param options.mode - preflight/gate policy, default `"describe-now"`. When set to `"blocking"`,
+ *   metric-view .d.ts writes are suppressed if any metric is degraded (to preserve committed files).
+ * @param options.suppressDegradedWrite - when true (only in `mode === "blocking"` context), skip
+ *   the metricOutFile write if any metric schema has `degraded === true`. Used to prevent
+ *   overwriting committed .d.ts files with degraded types in blocking mode.
  */
 export async function syncMetricViewsTypes(options: {
   metricViewsFolder: string;
@@ -442,6 +479,7 @@ export async function syncMetricViewsTypes(options: {
   cache?: boolean;
   metricFetcher?: DescribeFetcher;
   mode?: "describe-now" | "non-blocking" | "blocking";
+  suppressDegradedWrite?: boolean;
 }): Promise<SyncMetricViewsTypesResult> {
   const {
     metricViewsFolder,
@@ -450,6 +488,7 @@ export async function syncMetricViewsTypes(options: {
     cache: cacheEnabled,
     metricFetcher,
     mode = "describe-now",
+    suppressDegradedWrite,
   } = options;
 
   // Only `cache === false` disables caching; `undefined`/`true` keep it on.
@@ -683,12 +722,23 @@ export async function syncMetricViewsTypes(options: {
     return emptyMetricSchema(entry);
   });
 
-  await fs.mkdir(path.dirname(metricOutFile), { recursive: true });
-  await fs.writeFile(
-    metricOutFile,
-    generateMetricTypeDeclarations(schemas),
-    "utf-8",
-  );
+  // In blocking mode, suppress writes when any metric is degraded AND there are
+  // no failures to preserve committed .d.ts files as the fallback of record.
+  // Degraded writes still happen when there are preflight fatals or sync failures
+  // (which throw after writing). Non-blocking mode always writes. This just
+  // prevents overwriting committed good types with degraded ones from pure
+  // warehouse-not-ready scenarios.
+  const shouldWriteMetrics =
+    !suppressDegradedWrite || !hasAnyDegradedMetrics(schemas);
+
+  if (shouldWriteMetrics) {
+    await fs.mkdir(path.dirname(metricOutFile), { recursive: true });
+    await fs.writeFile(
+      metricOutFile,
+      generateMetricTypeDeclarations(schemas),
+      "utf-8",
+    );
+  }
 
   logger.debug(
     "Wrote MetricRegistry augmentation for %d metric(s)%s",

--- a/packages/appkit/src/type-generator/index.ts
+++ b/packages/appkit/src/type-generator/index.ts
@@ -428,9 +428,9 @@ export async function generateFromEntryPoint(options: {
         cache: !noCache,
         metricFetcher,
         mode,
-        // In blocking mode, only suppress writes for pure degradation (no failures).
-        // If there are preflight fatals or sync failures, degraded artifacts are
-        // still written before the throw.
+        // In blocking mode, never overwrite committed metric types with a
+        // degraded result — including on runs that go on to throw, so a failing
+        // build leaves the committed .d.ts intact. Non-blocking always writes.
         suppressDegradedWrite: mode === "blocking",
       });
     } catch (configError) {
@@ -533,9 +533,10 @@ export interface SyncMetricViewsTypesResult {
   noConfig: boolean;
   /**
    * Per-key fatal preflight errors (empty except in the `blocking`-mode
-   * deleted/deleting-warehouse and deterministic-preflight-failure cases). The
-   * artifacts are still written; {@link generateFromEntryPoint} surfaces these
-   * by throwing {@link TypegenFatalError} after the writes. A `"describe-now"`
+   * deleted/deleting-warehouse and deterministic-preflight-failure cases).
+   * {@link generateFromEntryPoint} surfaces these by throwing
+   * {@link TypegenFatalError}; when the run also degraded, `suppressDegradedWrite`
+   * means no artifact was written and the committed types stand. A `"describe-now"`
    * run sets no blocking preflight, so for that mode this is always empty.
    * ONLY contains deterministic failures (404/400).
    */

--- a/packages/appkit/src/type-generator/index.ts
+++ b/packages/appkit/src/type-generator/index.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { WorkspaceClient } from "@databricks/sdk-experimental";
@@ -11,7 +12,11 @@ import {
   metricCacheHash,
   saveCache,
 } from "./cache";
-import { getErrorDiagnostic, isConnectivityError } from "./errors";
+import {
+  classifyBlockingFailure,
+  getErrorDiagnostic,
+  isConnectivityError,
+} from "./errors";
 import {
   migrateProjectConfig,
   removeOldGeneratedTypes,
@@ -45,16 +50,71 @@ dotenv.config();
 const logger = createLogger("type-generator");
 
 /**
+ * Classify an environmental failure into one of three coarse cause labels
+ * for the warning message.
+ */
+function classifyEnvironmentalCause(
+  error: unknown,
+): "auth" | "unreachable" | "unavailable" {
+  if (isConnectivityError(error)) return "unreachable";
+  // Check for auth status (401/403)
+  if (typeof error === "object" && error !== null) {
+    const err = error as Record<string, unknown>;
+    const status = err.status ?? err.statusCode;
+    if (typeof status === "number" && (status === 401 || status === 403)) {
+      return "auth";
+    }
+  }
+  // Default for other environmental failures (DELETED/DELETING, timeouts, etc.)
+  return "unavailable";
+}
+
+/**
  * Upper bound (~5 min) on how long the Metric Views path's `blocking`-mode preflight
  * waits for a warehouse to reach RUNNING. Mirrors the query path's (unexported)
  * `PREFLIGHT_WAIT_MAX_MS` in query-registry.ts.
  */
 const MV_PREFLIGHT_WAIT_MAX_MS = 300_000;
 
+/**
+ * Generate a loud warning message for environmental failures with committed types present.
+ * The message includes a coarse cause label and the warehouse ID.
+ * @param cause - coarse cause label: "auth" (401/403), "unreachable" (connectivity), or "unavailable" (other)
+ * @param warehouseId - the warehouse ID
+ */
+function determineWarningMessage(
+  cause: "auth" | "unreachable" | "unavailable" = "unavailable",
+  warehouseId: string,
+): string {
+  const causeLabel =
+    cause === "auth"
+      ? "auth blocked"
+      : cause === "unreachable"
+        ? "warehouse unreachable"
+        : "warehouse unavailable";
+  // Use a stable prefix for greppability and CI log matching.
+  return `AppKit typegen: using committed types — warehouse ${warehouseId} ${causeLabel}; please check warehouse status and retry`;
+}
+
 type TypegenFailure = QuerySyntaxError | QueryFatalError;
 
 function plural(count: number, singular: string, pluralForm = `${singular}s`) {
   return count === 1 ? singular : pluralForm;
+}
+
+/**
+ * Check if committed type artifacts exist (at least one of the requested surfaces).
+ * Serving types are excluded (gitignored, never part of the gate).
+ * Returns true if either the analytics or metric-views committed .d.ts file exists.
+ */
+function hasCommittedTypes(
+  analyticsOutFile: string,
+  metricViewsOutFile: string | undefined,
+): boolean {
+  const hasAnalytics = existsSync(analyticsOutFile);
+  const hasMetrics =
+    metricViewsOutFile !== undefined && existsSync(metricViewsOutFile);
+  return hasAnalytics || hasMetrics;
 }
 
 /**
@@ -336,7 +396,13 @@ export async function generateFromEntryPoint(options: {
 
   let queryRegistry: QuerySchema[] = [];
   let syntaxErrors: QuerySyntaxError[] = [];
+  // Deterministic fatal errors only (404/400).
   let fatalErrors: QueryFatalError[] = [];
+  // Track whether an environmental failure occurred in blocking mode.
+  let hadEnvironmentalFailure = false;
+  // Track the coarse cause of the environmental failure for the warning message.
+  let environmentalCause: "auth" | "unreachable" | "unavailable" | undefined;
+
   if (queryFolder) {
     const result = await generateQueriesFromDescribe(queryFolder, warehouseId, {
       noCache,
@@ -345,6 +411,10 @@ export async function generateFromEntryPoint(options: {
     queryRegistry = result.schemas;
     syntaxErrors = result.syntaxErrors ?? [];
     fatalErrors = result.fatalErrors ?? [];
+    hadEnvironmentalFailure =
+      hadEnvironmentalFailure || (result.hadEnvironmentalFailure ?? false);
+    environmentalCause =
+      environmentalCause ?? result.environmentalCause ?? undefined;
   }
 
   const typeDeclarations = generateTypeDeclarations(queryRegistry);
@@ -400,9 +470,16 @@ export async function generateFromEntryPoint(options: {
 
     // Deleted/deleting-warehouse fatal preflight (blocking mode only);
     // empty (no-op) when definitions.json is absent or in non-blocking mode.
+    // Only deterministic fatals are recorded in fatalErrors.
     for (const fe of mvResult.fatalErrors) {
       fatalErrors.push(fe);
     }
+
+    // Thread through the environmental failure flag and cause.
+    hadEnvironmentalFailure =
+      hadEnvironmentalFailure || (mvResult.hadEnvironmentalFailure ?? false);
+    environmentalCause =
+      environmentalCause ?? mvResult.environmentalCause ?? undefined;
 
     // Blocking (`--wait` / prod Vite) escalates per-key DESCRIBE failures — a bad or unreachable source, i.e. a config error
     // to build failures so the end-of-run throw fails after the writes.
@@ -419,12 +496,44 @@ export async function generateFromEntryPoint(options: {
   await removeOldGeneratedTypes(projectRoot, "appKitTypes.d.ts");
   await migrateProjectConfig(projectRoot);
 
-  // Types are always written above — including `result: unknown` for any Metric View that could not be described.
+  // Phase 3: Unified terminal decision combining deterministic & environmental failures
+  // with a has-types gate in blocking mode.
+
+  // Deterministic failures (SQL syntax errors or 404/400 HTTP) always crash regardless of mode.
   if (syntaxErrors.length > 0) {
     throw new TypegenSyntaxError(syntaxErrors, warehouseId, fatalErrors);
   }
   if (fatalErrors.length > 0) {
     throw new TypegenFatalError(fatalErrors, warehouseId);
+  }
+
+  // Environmental failures (in blocking mode) trigger the has-types gate.
+  if (mode === "blocking" && hadEnvironmentalFailure) {
+    // Determine resolved metric-views file for the has-types check.
+    const resolvedMvFile =
+      options.mvOutFile ?? path.join(path.dirname(outFile), METRIC_TYPES_FILE);
+
+    const hasTypes = hasCommittedTypes(outFile, resolvedMvFile);
+
+    if (hasTypes) {
+      // Committed types present: emit loud warning and exit 0.
+      const warningMessage = determineWarningMessage(
+        environmentalCause ?? "unavailable",
+        warehouseId,
+      );
+      logger.warn(warningMessage);
+    } else {
+      // No committed types: crash with a generic message.
+      throw new TypegenFatalError(
+        [
+          {
+            name: "type-generator",
+            message: `Warehouse ${warehouseId} could not be reached and no committed types exist. Run 'npx @databricks/appkit generate-types --wait' locally and commit the generated .d.ts files.`,
+          },
+        ],
+        warehouseId,
+      );
+    }
   }
 
   logger.debug("Type generation complete!");
@@ -450,8 +559,23 @@ export interface SyncMetricViewsTypesResult {
    * artifacts are still written; {@link generateFromEntryPoint} surfaces these
    * by throwing {@link TypegenFatalError} after the writes. A `"describe-now"`
    * run sets no blocking preflight, so for that mode this is always empty.
+   * ONLY contains deterministic failures (404/400).
    */
   fatalErrors: Array<{ name: string; message: string }>;
+  /**
+   * `true` when an environmental failure occurred in blocking mode (auth, connectivity,
+   * DELETED/DELETING, wait-timeout, or other unrecognized failures). Used by
+   * {@link generateFromEntryPoint} to decide whether to apply the has-types gate.
+   * Does not directly cause a throw — the gate decides that. Always false in
+   * non-blocking or describe-now mode.
+   */
+  hadEnvironmentalFailure?: boolean;
+  /**
+   * Coarse cause label for the environmental failure, one of "auth" (401/403),
+   * "unreachable" (connectivity), or "unavailable" (other). Only set when
+   * hadEnvironmentalFailure is true; used by the warning message.
+   */
+  environmentalCause?: "auth" | "unreachable" | "unavailable";
 }
 
 /**
@@ -549,6 +673,8 @@ export async function syncMetricViewsTypes(options: {
   // Blocking-mode preflight: ensure the warehouse is running before the MV DESCRIBE
   // batch (probe → decide → wait / start+wait; only DELETED/DELETING is fatal). Two softenings vs the query preflight: a failed probe and a timed-out wait are NOT fatal here — we fall through to syncMetrics, which classifies a still-not-ready warehouse as degraded rather than failing the build. Skipped for `describe-now`/`non-blocking` (only `mode === "blocking"` enters here).
   let preflightFatalMessage: string | undefined;
+  let hadEnvironmentalFailure = false;
+  let environmentalCause: "auth" | "unreachable" | "unavailable" | undefined;
   if (
     mode === "blocking" &&
     metricFetcher === undefined &&
@@ -559,6 +685,9 @@ export async function syncMetricViewsTypes(options: {
       const decision = decidePreflight(state, mode);
       if (decision === "fatal") {
         preflightFatalMessage = `warehouse ${warehouseId} is ${state}`;
+        // State-based DELETED/DELETING is environmental, not deterministic.
+        hadEnvironmentalFailure = true;
+        environmentalCause = "unavailable";
       } else if (decision === "startWaitProceed") {
         // treatStoppedAsTransient rides out the stale pre-start STOPPED/STOPPING
         // reading, same as the query preflight.
@@ -571,21 +700,35 @@ export async function syncMetricViewsTypes(options: {
           // With treatStoppedAsTransient, a non-RUNNING resolve is exactly
           // DELETED/DELETING — the warehouse was deleted while we waited.
           preflightFatalMessage = `warehouse ${warehouseId} is ${settled}`;
+          hadEnvironmentalFailure = true;
         }
       } else if (decision === "waitThenProceed") {
         const settled = await waitUntilRunning(getMvClient(), warehouseId, {
           maxMs: MV_PREFLIGHT_WAIT_MAX_MS,
         });
         if (settled === "DELETED" || settled === "DELETING") {
-          // Deleted mid-wait: fatal.
+          // Deleted mid-wait: fatal. Environmental (state-based).
           preflightFatalMessage = `warehouse ${warehouseId} is ${settled}`;
+          hadEnvironmentalFailure = true;
         }
       }
     } catch (err) {
       // Connectivity blip: fall through to syncMetrics, whose DESCRIBEs degrade
       // a not-ready / unreachable warehouse rather than throwing.
       if (!isConnectivityError(err)) {
-        preflightFatalMessage = `warehouse ${warehouseId}: ${getErrorDiagnostic(err)}`;
+        // Classify: deterministic (404/400) or environmental (auth, etc).
+        const classification = classifyBlockingFailure(err);
+        if (classification === "deterministic") {
+          // Keep as fatal preflight for deterministic errors (404/400).
+          preflightFatalMessage = `warehouse ${warehouseId}: ${getErrorDiagnostic(err)}`;
+        } else {
+          // Environmental: set preflightFatalMessage so DESCRIBE is skipped, but
+          // mark hadEnvironmentalFailure so the gate handles it later (not added
+          // to fatalErrors).
+          preflightFatalMessage = `warehouse ${warehouseId}: ${getErrorDiagnostic(err)}`;
+          hadEnvironmentalFailure = true;
+          environmentalCause = classifyEnvironmentalCause(err);
+        }
       }
     }
   }
@@ -607,14 +750,21 @@ export async function syncMetricViewsTypes(options: {
   let described: MetricSchema[];
   let failures: MetricSyncFailure[] = [];
   if (preflightFatalMessage !== undefined) {
-    // Fatal preflight (deleted/deleting warehouse): fail like the query path —
+    // Fatal preflight (deleted/deleting warehouse or deterministic error):
     // skip DESCRIBE, emit degraded schemas so both artifacts are still written,
     // and record one fatal error per describe-needed key (cache hits are
-    // unaffected). The caller surfaces them after the writes. The degraded
-    // schemas are not cached (see the write block), so a later pass re-probes.
+    // unaffected) ONLY if it's a deterministic error. Environmental failures
+    // degrade silently. The degraded schemas are not cached (see the write
+    // block), so a later pass re-probes.
     described = describeNeeded.map(emptyMetricSchema);
-    for (const entry of describeNeeded) {
-      fatalErrors.push({ name: entry.key, message: preflightFatalMessage });
+    if (!hadEnvironmentalFailure) {
+      // Only deterministic fatals (404/400) record errors.
+      for (const entry of describeNeeded) {
+        fatalErrors.push({ name: entry.key, message: preflightFatalMessage });
+      }
+    } else {
+      // Environmental failure: don't record in fatalErrors, let the has-types
+      // gate handle it later.
     }
   } else if (describeNeeded.length === 0) {
     // Nothing left to describe — every configured key was a cache hit.
@@ -658,11 +808,13 @@ export async function syncMetricViewsTypes(options: {
         degradedKeys.length,
         degradedKeys.join(", "),
       );
+      hadEnvironmentalFailure = true; // Mark as environmental if any metric degraded.
+      environmentalCause = environmentalCause ?? "unavailable";
     }
   } else {
     // Un-probed DESCRIBEs deliberately skipped, not failures: emit each
     // describe-needed key as a degraded schema so both artifacts exist; cache
-    // hits keep serving last-known-good.
+    // hits keep serving last-known-good. This is an environmental failure path.
     described = describeNeeded.map(emptyMetricSchema);
     logger.info(
       "Warehouse %s is not running — wrote degraded metric types (permissive) for %d metric view(s) (%s); they will refresh once the warehouse is available.",
@@ -670,6 +822,8 @@ export async function syncMetricViewsTypes(options: {
       describeNeeded.length,
       describeNeeded.map((e) => e.key).join(", "),
     );
+    hadEnvironmentalFailure = true; // Mark as environmental when not describing.
+    environmentalCause = environmentalCause ?? "unavailable";
   }
 
   // Cache only successful schema results for describe-needed keys; remove stale cache for degraded ones.
@@ -752,6 +906,12 @@ export async function syncMetricViewsTypes(options: {
     failures,
     fatalErrors,
     noConfig: false,
+    hadEnvironmentalFailure:
+      mode === "blocking" ? hadEnvironmentalFailure : undefined,
+    environmentalCause:
+      mode === "blocking" && hadEnvironmentalFailure
+        ? environmentalCause
+        : undefined,
   };
 }
 

--- a/packages/appkit/src/type-generator/query-registry.ts
+++ b/packages/appkit/src/type-generator/query-registry.ts
@@ -944,6 +944,10 @@ export async function generateQueriesFromDescribe(
               // status === "unavailable": non-terminal DESCRIBE (warehouse
               // stopped/cold-starting/busy). Degrade like a transient outage:
               // tag OFFLINE, count as degraded, never cache.
+              if (mode === "blocking") {
+                hadEnvironmentalFailure = true;
+                environmentalCause = environmentalCause ?? "unavailable";
+              }
               logEntries.push({
                 queryName,
                 status: "MISS",

--- a/packages/appkit/src/type-generator/query-registry.ts
+++ b/packages/appkit/src/type-generator/query-registry.ts
@@ -277,12 +277,15 @@ function degradedType(
   queryName: string,
   sql: string,
   sqlHash: string,
-): string {
+): Pick<QuerySchema, "type" | "degraded"> {
   const prior = cache.queries[queryName];
   const canReusePrior = prior?.hash === sqlHash && !prior.retry;
   return canReusePrior
-    ? prior.type
-    : generateUnknownResultQuery(sql, queryName);
+    ? { type: prior.type }
+    : {
+        type: generateUnknownResultQuery(sql, queryName),
+        degraded: true,
+      };
 }
 
 // Single source of truth for the `@param` type alternation, shared by
@@ -800,7 +803,7 @@ export async function generateQueriesFromDescribe(
           index,
           schema: {
             name: queryName,
-            type: degradedType(cache, queryName, sql, sqlHash),
+            ...degradedType(cache, queryName, sql, sqlHash),
           },
         });
         if (decision === "fatal" && !isEnvironmental) {
@@ -871,7 +874,7 @@ export async function generateQueriesFromDescribe(
           return {
             status: "syntax",
             index,
-            schema: { name: queryName, type },
+            schema: { name: queryName, type, degraded: true },
             error: withIdentifierHint(parseError(sqlError), sql),
           };
         }
@@ -888,7 +891,7 @@ export async function generateQueriesFromDescribe(
             index,
             schema: {
               name: queryName,
-              type: degradedType(cache, queryName, sql, sqlHash),
+              ...degradedType(cache, queryName, sql, sqlHash),
             },
           };
         }
@@ -897,7 +900,11 @@ export async function generateQueriesFromDescribe(
         if (!hasResults) {
           // Described, but no result columns. Emit `unknown` and retry next run;
           // do not cache (we never persist `result: unknown`).
-          return { status: "empty", index, schema: { name: queryName, type } };
+          return {
+            status: "empty",
+            index,
+            schema: { name: queryName, type, degraded: true },
+          };
         }
         return {
           status: "ok",
@@ -970,8 +977,11 @@ export async function generateQueriesFromDescribe(
             const priorEntry = cache.queries[queryName];
             const canReusePrior =
               priorEntry?.hash === sqlHash && !priorEntry.retry;
-            const type = degradedType(cache, queryName, sql, sqlHash);
-            freshResults.push({ index, schema: { name: queryName, type } });
+            const degraded = degradedType(cache, queryName, sql, sqlHash);
+            freshResults.push({
+              index,
+              schema: { name: queryName, ...degraded },
+            });
 
             if (!isConnectivityError(entry.reason)) {
               fatalErrors.push({ name: queryName, message: error.message });

--- a/packages/appkit/src/type-generator/query-registry.ts
+++ b/packages/appkit/src/type-generator/query-registry.ts
@@ -5,7 +5,11 @@ import { tableFromIPC } from "apache-arrow";
 import pc from "picocolors";
 import { createLogger } from "../logging/logger";
 import { CACHE_VERSION, hashSQL, loadCache, saveCache } from "./cache";
-import { getErrorDiagnostic, isConnectivityError } from "./errors";
+import {
+  classifyBlockingFailure,
+  getErrorDiagnostic,
+  isConnectivityError,
+} from "./errors";
 import { decidePreflight, type PreflightMode } from "./preflight";
 import { Spinner } from "./spinner";
 import { type DescribeFormatMemo, describeAdaptive } from "./statement-result";
@@ -675,7 +679,12 @@ export async function generateQueriesFromDescribe(
   // Genuine SQL errors (reachable warehouse). Connectivity failures are NOT
   // recorded here — they degrade silently so a transient outage isn't fatal.
   const syntaxErrors: QuerySyntaxError[] = [];
+  // Deterministic fatal errors only (404/400). Environmental failures are
+  // tracked separately below.
   const fatalErrors: QueryFatalError[] = [];
+  // Track whether an environmental failure occurred in blocking mode (for the
+  // has-types gate in generateFromEntryPoint).
+  let hadEnvironmentalFailure = false;
 
   if (uncachedQueries.length > 0) {
     // One-time warehouse preflight (before issuing any DESCRIBE). A single
@@ -685,6 +694,8 @@ export async function generateQueriesFromDescribe(
     // not-ready warehouse degrades exactly like a per-query outage.
     let decision: ReturnType<typeof decidePreflight> = "proceed";
     let fatalMessage = "";
+    // Track whether a non-connectivity environmental failure occurred (for Phase 3).
+    let isEnvironmental = false;
     if (mode === "non-blocking") {
       // `non-blocking` never describes and must make ZERO warehouse round-trips:
       // skip the probe entirely (no getWarehouseState) and go straight to
@@ -697,7 +708,9 @@ export async function generateQueriesFromDescribe(
         const state = await getWarehouseState(client, warehouseId);
         decision = decidePreflight(state, mode);
         if (decision === "fatal") {
+          // DELETED/DELETING is state-based and environmental.
           fatalMessage = `warehouse ${warehouseId} is ${state}`;
+          isEnvironmental = true;
         }
         if (decision === "startWaitProceed") {
           // Stopped/stopping warehouse: nudge it out of the stopped state, then
@@ -714,6 +727,7 @@ export async function generateQueriesFromDescribe(
           } else {
             decision = "fatal";
             fatalMessage = `warehouse ${warehouseId} did not reach RUNNING (now ${final})`;
+            isEnvironmental = true; // DELETED/DELETING or timeout is environmental
           }
         }
         if (decision === "waitThenProceed") {
@@ -725,6 +739,7 @@ export async function generateQueriesFromDescribe(
           } else {
             decision = "fatal";
             fatalMessage = `warehouse ${warehouseId} did not reach RUNNING (now ${final})`;
+            isEnvironmental = true; // DELETED/DELETING or timeout is environmental
           }
         }
       } catch (err) {
@@ -733,18 +748,41 @@ export async function generateQueriesFromDescribe(
           // per-query connectivity failure — never fail a build on a blip.
           decision = "degradeAll";
         } else {
-          // Auth, bad warehouse id, malformed config, or a timed-out wait: fatal.
-          decision = "fatal";
-          fatalMessage = `warehouse ${warehouseId}: ${getErrorDiagnostic(err)}`;
+          // Classify the exception: deterministic (404/400) or environmental (auth, etc).
+          const classification = classifyBlockingFailure(err);
+          if (classification === "deterministic") {
+            // Build-failing deterministic error (bad warehouse id, malformed request).
+            decision = "fatal";
+            fatalMessage = `warehouse ${warehouseId}: ${getErrorDiagnostic(err)}`;
+            isEnvironmental = false;
+          } else {
+            // Environmental: auth, timeouts, unrecognized, etc. Degrade for the
+            // has-types gate to handle later.
+            decision = "degradeAll";
+            isEnvironmental = true;
+            fatalMessage = `warehouse ${warehouseId}: ${getErrorDiagnostic(err)}`;
+          }
         }
       }
+    }
+
+    // Track environmental failures in blocking mode for Phase 3 gate.
+    if (
+      mode === "blocking" &&
+      ((decision === "degradeAll" && isEnvironmental) ||
+        (decision === "fatal" && isEnvironmental))
+    ) {
+      hadEnvironmentalFailure = true;
     }
 
     if (decision !== "proceed") {
       // degradeAll or fatal: skip DESCRIBE entirely. Every uncached query gets a
       // degraded schema (reused cache or `unknown`); fatal additionally records
-      // a fatalError per query so the caller fails the build after writing.
-      const kind = decision === "fatal" ? "fatal" : "connectivity";
+      // a fatalError per query so the caller fails the build after writing. Only
+      // deterministic fatals are recorded; environmental degradations go silent
+      // so the has-types gate can decide.
+      const kind =
+        decision === "fatal" && !isEnvironmental ? "fatal" : "connectivity";
       for (const { index, queryName, sql, sqlHash } of uncachedQueries) {
         freshResults.push({
           index,
@@ -753,7 +791,9 @@ export async function generateQueriesFromDescribe(
             type: degradedType(cache, queryName, sql, sqlHash),
           },
         });
-        if (decision === "fatal") {
+        if (decision === "fatal" && !isEnvironmental) {
+          // Only deterministic fatals record an error; environmental failures
+          // degrade silently for the has-types gate.
           fatalErrors.push({ name: queryName, message: fatalMessage });
           logEntries.push({
             queryName,
@@ -1039,7 +1079,7 @@ export async function generateQueriesFromDescribe(
     .sort((a, b) => a.index - b.index)
     .map((r) => r.schema);
 
-  return { schemas, syntaxErrors, fatalErrors };
+  return { schemas, syntaxErrors, fatalErrors, hadEnvironmentalFailure };
 }
 
 /**

--- a/packages/appkit/src/type-generator/query-registry.ts
+++ b/packages/appkit/src/type-generator/query-registry.ts
@@ -7,6 +7,7 @@ import { createLogger } from "../logging/logger";
 import { CACHE_VERSION, hashSQL, loadCache, saveCache } from "./cache";
 import {
   classifyBlockingFailure,
+  classifyEnvironmentalCause,
   getErrorDiagnostic,
   isConnectivityError,
 } from "./errors";
@@ -683,8 +684,10 @@ export async function generateQueriesFromDescribe(
   // tracked separately below.
   const fatalErrors: QueryFatalError[] = [];
   // Track whether an environmental failure occurred in blocking mode (for the
-  // has-types gate in generateFromEntryPoint).
+  // has-types gate in generateFromEntryPoint), plus its coarse cause so the
+  // gate's warning can say why generation fell back to committed types.
   let hadEnvironmentalFailure = false;
+  let environmentalCause: "auth" | "unreachable" | "unavailable" | undefined;
 
   if (uncachedQueries.length > 0) {
     // One-time warehouse preflight (before issuing any DESCRIBE). A single
@@ -694,8 +697,8 @@ export async function generateQueriesFromDescribe(
     // not-ready warehouse degrades exactly like a per-query outage.
     let decision: ReturnType<typeof decidePreflight> = "proceed";
     let fatalMessage = "";
-    // Track whether a non-connectivity environmental failure occurred so the
-    // caller's has-types gate can decide crash-vs-fall-back.
+    // Track whether an environmental failure occurred so the caller's has-types
+    // gate can decide crash-vs-fall-back.
     let isEnvironmental = false;
     if (mode === "non-blocking") {
       // `non-blocking` never describes and must make ZERO warehouse round-trips:
@@ -712,6 +715,7 @@ export async function generateQueriesFromDescribe(
           // DELETED/DELETING is state-based and environmental.
           fatalMessage = `warehouse ${warehouseId} is ${state}`;
           isEnvironmental = true;
+          environmentalCause = "unavailable";
         }
         if (decision === "startWaitProceed") {
           // Stopped/stopping warehouse: nudge it out of the stopped state, then
@@ -729,6 +733,7 @@ export async function generateQueriesFromDescribe(
             decision = "fatal";
             fatalMessage = `warehouse ${warehouseId} did not reach RUNNING (now ${final})`;
             isEnvironmental = true; // DELETED/DELETING or timeout is environmental
+            environmentalCause = "unavailable";
           }
         }
         if (decision === "waitThenProceed") {
@@ -741,13 +746,18 @@ export async function generateQueriesFromDescribe(
             decision = "fatal";
             fatalMessage = `warehouse ${warehouseId} did not reach RUNNING (now ${final})`;
             isEnvironmental = true; // DELETED/DELETING or timeout is environmental
+            environmentalCause = "unavailable";
           }
         }
       } catch (err) {
         if (isConnectivityError(err)) {
-          // Warehouse unreachable (transient outage): degrade silently like a
-          // per-query connectivity failure — never fail a build on a blip.
+          // Warehouse unreachable (transient outage): degrade rather than fail —
+          // never fail a build on a blip. Still environmental, so the caller's
+          // has-types gate decides warn-and-fall-back (committed types present)
+          // vs crash (fresh checkout with nothing to fall back to).
           decision = "degradeAll";
+          isEnvironmental = true;
+          environmentalCause = "unreachable";
         } else {
           // Classify the exception: deterministic (404/400) or environmental (auth, etc).
           const classification = classifyBlockingFailure(err);
@@ -761,6 +771,7 @@ export async function generateQueriesFromDescribe(
             // has-types gate to handle later.
             decision = "degradeAll";
             isEnvironmental = true;
+            environmentalCause = classifyEnvironmentalCause(err);
             fatalMessage = `warehouse ${warehouseId}: ${getErrorDiagnostic(err)}`;
           }
         }
@@ -969,6 +980,13 @@ export async function generateQueriesFromDescribe(
               continue;
             }
 
+            // Environmental for the same reason as the preflight connectivity
+            // branch above, so the has-types gate still sees it.
+            if (mode === "blocking") {
+              hadEnvironmentalFailure = true;
+              environmentalCause = environmentalCause ?? "unreachable";
+            }
+
             logger.warn(
               "DESCRIBE unreachable for %s: %s — %s",
               queryName,
@@ -1080,7 +1098,15 @@ export async function generateQueriesFromDescribe(
     .sort((a, b) => a.index - b.index)
     .map((r) => r.schema);
 
-  return { schemas, syntaxErrors, fatalErrors, hadEnvironmentalFailure };
+  return {
+    schemas,
+    syntaxErrors,
+    fatalErrors,
+    hadEnvironmentalFailure,
+    environmentalCause: hadEnvironmentalFailure
+      ? environmentalCause
+      : undefined,
+  };
 }
 
 /**

--- a/packages/appkit/src/type-generator/query-registry.ts
+++ b/packages/appkit/src/type-generator/query-registry.ts
@@ -694,7 +694,8 @@ export async function generateQueriesFromDescribe(
     // not-ready warehouse degrades exactly like a per-query outage.
     let decision: ReturnType<typeof decidePreflight> = "proceed";
     let fatalMessage = "";
-    // Track whether a non-connectivity environmental failure occurred (for Phase 3).
+    // Track whether a non-connectivity environmental failure occurred so the
+    // caller's has-types gate can decide crash-vs-fall-back.
     let isEnvironmental = false;
     if (mode === "non-blocking") {
       // `non-blocking` never describes and must make ZERO warehouse round-trips:
@@ -766,7 +767,7 @@ export async function generateQueriesFromDescribe(
       }
     }
 
-    // Track environmental failures in blocking mode for Phase 3 gate.
+    // Record blocking-mode environmental failures for the has-types gate.
     if (
       mode === "blocking" &&
       ((decision === "degradeAll" && isEnvironmental) ||

--- a/packages/appkit/src/type-generator/tests/errors.test.ts
+++ b/packages/appkit/src/type-generator/tests/errors.test.ts
@@ -4,112 +4,117 @@ import { classifyBlockingFailure } from "../errors";
 describe("classifyBlockingFailure", () => {
   describe("deterministic failures", () => {
     it("classifies HTTP 400 as deterministic", () => {
-      const error = new Error("Bad request");
-      (error as any).status = 400;
+      const error = Object.assign(new Error("Bad request"), { status: 400 });
       expect(classifyBlockingFailure(error)).toBe("deterministic");
     });
 
     it("classifies HTTP 404 as deterministic", () => {
-      const error = new Error("Not found");
-      (error as any).status = 404;
+      const error = Object.assign(new Error("Not found"), { status: 404 });
       expect(classifyBlockingFailure(error)).toBe("deterministic");
     });
 
     it("classifies HTTP 404 from response.status as deterministic", () => {
-      const error = new Error("Not found");
-      (error as any).response = { status: 404 };
+      const error = Object.assign(new Error("Not found"), {
+        response: { status: 404 },
+      });
       expect(classifyBlockingFailure(error)).toBe("deterministic");
     });
 
     it("classifies HTTP 404 from statusCode as deterministic", () => {
-      const error = new Error("Not found");
-      (error as any).statusCode = 404;
+      const error = Object.assign(new Error("Not found"), { statusCode: 404 });
       expect(classifyBlockingFailure(error)).toBe("deterministic");
     });
   });
 
   describe("environmental failures - auth", () => {
     it("classifies HTTP 401 as environmental", () => {
-      const error = new Error("Unauthorized");
-      (error as any).status = 401;
+      const error = Object.assign(new Error("Unauthorized"), { status: 401 });
       expect(classifyBlockingFailure(error)).toBe("environmental");
     });
 
     it("classifies HTTP 403 as environmental", () => {
-      const error = new Error("Forbidden");
-      (error as any).status = 403;
+      const error = Object.assign(new Error("Forbidden"), { status: 403 });
       expect(classifyBlockingFailure(error)).toBe("environmental");
     });
   });
 
   describe("environmental failures - other HTTP statuses", () => {
     it("classifies HTTP 500 as environmental (not in deterministic set)", () => {
-      const error = new Error("Internal server error");
-      (error as any).status = 500;
+      const error = Object.assign(new Error("Internal server error"), {
+        status: 500,
+      });
       expect(classifyBlockingFailure(error)).toBe("environmental");
     });
 
     it("classifies HTTP 502 as environmental (via connectivity)", () => {
-      const error = new Error("Bad gateway");
-      (error as any).status = 502;
+      const error = Object.assign(new Error("Bad gateway"), { status: 502 });
       expect(classifyBlockingFailure(error)).toBe("environmental");
     });
 
     it("classifies HTTP 503 as environmental (via connectivity)", () => {
-      const error = new Error("Service unavailable");
-      (error as any).status = 503;
+      const error = Object.assign(new Error("Service unavailable"), {
+        status: 503,
+      });
       expect(classifyBlockingFailure(error)).toBe("environmental");
     });
 
     it("classifies HTTP 504 as environmental (via connectivity)", () => {
-      const error = new Error("Gateway timeout");
-      (error as any).status = 504;
+      const error = Object.assign(new Error("Gateway timeout"), {
+        status: 504,
+      });
       expect(classifyBlockingFailure(error)).toBe("environmental");
     });
   });
 
   describe("environmental failures - connectivity codes", () => {
     it("classifies ECONNREFUSED as environmental", () => {
-      const error = new Error("Connection refused");
-      (error as any).code = "ECONNREFUSED";
+      const error = Object.assign(new Error("Connection refused"), {
+        code: "ECONNREFUSED",
+      });
       expect(classifyBlockingFailure(error)).toBe("environmental");
     });
 
     it("classifies ENOTFOUND as environmental", () => {
-      const error = new Error("ENOTFOUND");
-      (error as any).code = "ENOTFOUND";
+      const error = Object.assign(new Error("ENOTFOUND"), {
+        code: "ENOTFOUND",
+      });
       expect(classifyBlockingFailure(error)).toBe("environmental");
     });
 
     it("classifies ETIMEDOUT as environmental", () => {
-      const error = new Error("Timed out");
-      (error as any).code = "ETIMEDOUT";
+      const error = Object.assign(new Error("Timed out"), {
+        code: "ETIMEDOUT",
+      });
       expect(classifyBlockingFailure(error)).toBe("environmental");
     });
 
     it("classifies ECONNRESET as environmental", () => {
-      const error = new Error("Connection reset");
-      (error as any).code = "ECONNRESET";
+      const error = Object.assign(new Error("Connection reset"), {
+        code: "ECONNRESET",
+      });
       expect(classifyBlockingFailure(error)).toBe("environmental");
     });
 
     it("classifies UND_ERR_* codes as environmental", () => {
-      const error = new Error("undici error");
-      (error as any).code = "UND_ERR_ABORTED";
+      const error = Object.assign(new Error("undici error"), {
+        code: "UND_ERR_ABORTED",
+      });
       expect(classifyBlockingFailure(error)).toBe("environmental");
     });
   });
 
   describe("environmental failures - TLS codes", () => {
     it("classifies CERT_HAS_EXPIRED as environmental", () => {
-      const error = new Error("Certificate has expired");
-      (error as any).code = "CERT_HAS_EXPIRED";
+      const error = Object.assign(new Error("Certificate has expired"), {
+        code: "CERT_HAS_EXPIRED",
+      });
       expect(classifyBlockingFailure(error)).toBe("environmental");
     });
 
     it("classifies DEPTH_ZERO_SELF_SIGNED_CERT as environmental", () => {
-      const error = new Error("Self signed cert");
-      (error as any).code = "DEPTH_ZERO_SELF_SIGNED_CERT";
+      const error = Object.assign(new Error("Self signed cert"), {
+        code: "DEPTH_ZERO_SELF_SIGNED_CERT",
+      });
       expect(classifyBlockingFailure(error)).toBe("environmental");
     });
   });
@@ -179,42 +184,40 @@ describe("classifyBlockingFailure", () => {
 
   describe("wrapped errors", () => {
     it("classifies deterministic status (404) nested under .cause as deterministic", () => {
-      const causedError = new Error("Not found");
-      (causedError as any).status = 404;
-
-      const error = new Error("Outer error");
-      (error as any).cause = causedError;
-
+      const causedError = Object.assign(new Error("Not found"), {
+        status: 404,
+      });
+      const error = Object.assign(new Error("Outer error"), {
+        cause: causedError,
+      });
       expect(classifyBlockingFailure(error)).toBe("deterministic");
     });
 
     it("classifies connectivity code nested under .cause as environmental", () => {
-      const causedError = new Error("Connection refused");
-      (causedError as any).code = "ECONNREFUSED";
-
-      const error = new Error("Outer error");
-      (error as any).cause = causedError;
-
+      const causedError = Object.assign(new Error("Connection refused"), {
+        code: "ECONNREFUSED",
+      });
+      const error = Object.assign(new Error("Outer error"), {
+        cause: causedError,
+      });
       expect(classifyBlockingFailure(error)).toBe("environmental");
     });
 
     it("classifies AggregateError with 404 as deterministic", () => {
-      const statusError = new Error("Not found");
-      (statusError as any).status = 404;
-
+      const statusError = Object.assign(new Error("Not found"), {
+        status: 404,
+      });
       const aggregateError = new AggregateError(
         [statusError],
         "Multiple errors",
       );
-
       expect(classifyBlockingFailure(aggregateError)).toBe("deterministic");
     });
   });
 
   describe("purity", () => {
     it("returns the same classification when called twice with the same input", () => {
-      const error = new Error("Not found");
-      (error as any).status = 404;
+      const error = Object.assign(new Error("Not found"), { status: 404 });
 
       const result1 = classifyBlockingFailure(error);
       const result2 = classifyBlockingFailure(error);
@@ -224,11 +227,12 @@ describe("classifyBlockingFailure", () => {
     });
 
     it("returns the same classification for equivalent errors", () => {
-      const error1 = new Error("Connection refused");
-      (error1 as any).code = "ECONNREFUSED";
-
-      const error2 = new Error("Connection refused");
-      (error2 as any).code = "ECONNREFUSED";
+      const error1 = Object.assign(new Error("Connection refused"), {
+        code: "ECONNREFUSED",
+      });
+      const error2 = Object.assign(new Error("Connection refused"), {
+        code: "ECONNREFUSED",
+      });
 
       expect(classifyBlockingFailure(error1)).toBe(
         classifyBlockingFailure(error2),

--- a/packages/appkit/src/type-generator/tests/errors.test.ts
+++ b/packages/appkit/src/type-generator/tests/errors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { classifyBlockingFailure } from "../errors";
+import { classifyBlockingFailure, classifyEnvironmentalCause } from "../errors";
 
 describe("classifyBlockingFailure", () => {
   describe("deterministic failures", () => {
@@ -239,5 +239,55 @@ describe("classifyBlockingFailure", () => {
       );
       expect(classifyBlockingFailure(error1)).toBe("environmental");
     });
+  });
+});
+
+describe("classifyEnvironmentalCause", () => {
+  it("labels connectivity failures as unreachable", () => {
+    const error = Object.assign(new Error("connect ECONNREFUSED"), {
+      code: "ECONNREFUSED",
+    });
+    expect(classifyEnvironmentalCause(error)).toBe("unreachable");
+  });
+
+  it.each([401, 403])("labels HTTP %i as auth", (status) => {
+    const error = Object.assign(new Error("Denied"), { status });
+    expect(classifyEnvironmentalCause(error)).toBe("auth");
+  });
+
+  it("labels auth status carried on statusCode", () => {
+    const error = Object.assign(new Error("Denied"), { statusCode: 403 });
+    expect(classifyEnvironmentalCause(error)).toBe("auth");
+  });
+
+  it("labels auth status carried on response.status", () => {
+    const error = Object.assign(new Error("Denied"), {
+      response: { status: 401 },
+    });
+    expect(classifyEnvironmentalCause(error)).toBe("auth");
+  });
+
+  it("labels an auth status wrapped in a cause chain", () => {
+    const error = new Error("Request failed", {
+      cause: Object.assign(new Error("Denied"), { status: 403 }),
+    });
+    expect(classifyEnvironmentalCause(error)).toBe("auth");
+  });
+
+  it("prefers unreachable when a failure is both connectivity and status-bearing", () => {
+    // 503 is connectivity; the label should describe the transport problem.
+    const error = Object.assign(new Error("Service unavailable"), {
+      status: 503,
+    });
+    expect(classifyEnvironmentalCause(error)).toBe("unreachable");
+  });
+
+  it.each([
+    ["a warehouse state message", new Error("warehouse wh-1 is DELETED")],
+    ["a plain error", new Error("something went wrong")],
+    ["a non-auth status", Object.assign(new Error("teapot"), { status: 418 })],
+    ["a non-object", "just a string"],
+  ])("labels %s as unavailable", (_name, error) => {
+    expect(classifyEnvironmentalCause(error)).toBe("unavailable");
   });
 });

--- a/packages/appkit/src/type-generator/tests/errors.test.ts
+++ b/packages/appkit/src/type-generator/tests/errors.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from "vitest";
+import { classifyBlockingFailure } from "../errors";
+
+describe("classifyBlockingFailure", () => {
+  describe("deterministic failures", () => {
+    it("classifies HTTP 400 as deterministic", () => {
+      const error = new Error("Bad request");
+      (error as any).status = 400;
+      expect(classifyBlockingFailure(error)).toBe("deterministic");
+    });
+
+    it("classifies HTTP 404 as deterministic", () => {
+      const error = new Error("Not found");
+      (error as any).status = 404;
+      expect(classifyBlockingFailure(error)).toBe("deterministic");
+    });
+
+    it("classifies HTTP 404 from response.status as deterministic", () => {
+      const error = new Error("Not found");
+      (error as any).response = { status: 404 };
+      expect(classifyBlockingFailure(error)).toBe("deterministic");
+    });
+
+    it("classifies HTTP 404 from statusCode as deterministic", () => {
+      const error = new Error("Not found");
+      (error as any).statusCode = 404;
+      expect(classifyBlockingFailure(error)).toBe("deterministic");
+    });
+  });
+
+  describe("environmental failures - auth", () => {
+    it("classifies HTTP 401 as environmental", () => {
+      const error = new Error("Unauthorized");
+      (error as any).status = 401;
+      expect(classifyBlockingFailure(error)).toBe("environmental");
+    });
+
+    it("classifies HTTP 403 as environmental", () => {
+      const error = new Error("Forbidden");
+      (error as any).status = 403;
+      expect(classifyBlockingFailure(error)).toBe("environmental");
+    });
+  });
+
+  describe("environmental failures - other HTTP statuses", () => {
+    it("classifies HTTP 500 as environmental (not in deterministic set)", () => {
+      const error = new Error("Internal server error");
+      (error as any).status = 500;
+      expect(classifyBlockingFailure(error)).toBe("environmental");
+    });
+
+    it("classifies HTTP 502 as environmental (via connectivity)", () => {
+      const error = new Error("Bad gateway");
+      (error as any).status = 502;
+      expect(classifyBlockingFailure(error)).toBe("environmental");
+    });
+
+    it("classifies HTTP 503 as environmental (via connectivity)", () => {
+      const error = new Error("Service unavailable");
+      (error as any).status = 503;
+      expect(classifyBlockingFailure(error)).toBe("environmental");
+    });
+
+    it("classifies HTTP 504 as environmental (via connectivity)", () => {
+      const error = new Error("Gateway timeout");
+      (error as any).status = 504;
+      expect(classifyBlockingFailure(error)).toBe("environmental");
+    });
+  });
+
+  describe("environmental failures - connectivity codes", () => {
+    it("classifies ECONNREFUSED as environmental", () => {
+      const error = new Error("Connection refused");
+      (error as any).code = "ECONNREFUSED";
+      expect(classifyBlockingFailure(error)).toBe("environmental");
+    });
+
+    it("classifies ENOTFOUND as environmental", () => {
+      const error = new Error("ENOTFOUND");
+      (error as any).code = "ENOTFOUND";
+      expect(classifyBlockingFailure(error)).toBe("environmental");
+    });
+
+    it("classifies ETIMEDOUT as environmental", () => {
+      const error = new Error("Timed out");
+      (error as any).code = "ETIMEDOUT";
+      expect(classifyBlockingFailure(error)).toBe("environmental");
+    });
+
+    it("classifies ECONNRESET as environmental", () => {
+      const error = new Error("Connection reset");
+      (error as any).code = "ECONNRESET";
+      expect(classifyBlockingFailure(error)).toBe("environmental");
+    });
+
+    it("classifies UND_ERR_* codes as environmental", () => {
+      const error = new Error("undici error");
+      (error as any).code = "UND_ERR_ABORTED";
+      expect(classifyBlockingFailure(error)).toBe("environmental");
+    });
+  });
+
+  describe("environmental failures - TLS codes", () => {
+    it("classifies CERT_HAS_EXPIRED as environmental", () => {
+      const error = new Error("Certificate has expired");
+      (error as any).code = "CERT_HAS_EXPIRED";
+      expect(classifyBlockingFailure(error)).toBe("environmental");
+    });
+
+    it("classifies DEPTH_ZERO_SELF_SIGNED_CERT as environmental", () => {
+      const error = new Error("Self signed cert");
+      (error as any).code = "DEPTH_ZERO_SELF_SIGNED_CERT";
+      expect(classifyBlockingFailure(error)).toBe("environmental");
+    });
+  });
+
+  describe("environmental failures - connectivity messages", () => {
+    it("classifies connection refused message as environmental", () => {
+      const error = new Error("connection refused");
+      expect(classifyBlockingFailure(error)).toBe("environmental");
+    });
+
+    it("classifies socket hang up message as environmental", () => {
+      const error = new Error("socket hang up");
+      expect(classifyBlockingFailure(error)).toBe("environmental");
+    });
+
+    it("classifies network error message as environmental", () => {
+      const error = new Error("network error");
+      expect(classifyBlockingFailure(error)).toBe("environmental");
+    });
+
+    it("classifies certificate has expired message as environmental", () => {
+      const error = new Error("certificate has expired");
+      expect(classifyBlockingFailure(error)).toBe("environmental");
+    });
+  });
+
+  describe("environmental failures - warehouse state messages", () => {
+    it("classifies DELETED warehouse error as environmental", () => {
+      const error = new Error("warehouse has been DELETED");
+      expect(classifyBlockingFailure(error)).toBe("environmental");
+    });
+
+    it("classifies DELETING warehouse error as environmental", () => {
+      const error = new Error("warehouse is DELETING");
+      expect(classifyBlockingFailure(error)).toBe("environmental");
+    });
+  });
+
+  describe("environmental failures - timeout messages", () => {
+    it("classifies wait-for-RUNNING timeout as environmental", () => {
+      const error = new Error(
+        "warehouse did not reach RUNNING within 300000ms",
+      );
+      expect(classifyBlockingFailure(error)).toBe("environmental");
+    });
+  });
+
+  describe("environmental failures - unrecognized errors", () => {
+    it("classifies plain Error with no status as environmental (default)", () => {
+      const error = new Error("boom");
+      expect(classifyBlockingFailure(error)).toBe("environmental");
+    });
+
+    it("classifies plain object error as environmental", () => {
+      const error = { message: "something went wrong" };
+      expect(classifyBlockingFailure(error)).toBe("environmental");
+    });
+
+    it("classifies null as environmental", () => {
+      expect(classifyBlockingFailure(null)).toBe("environmental");
+    });
+
+    it("classifies undefined as environmental", () => {
+      expect(classifyBlockingFailure(undefined)).toBe("environmental");
+    });
+  });
+
+  describe("wrapped errors", () => {
+    it("classifies deterministic status (404) nested under .cause as deterministic", () => {
+      const causedError = new Error("Not found");
+      (causedError as any).status = 404;
+
+      const error = new Error("Outer error");
+      (error as any).cause = causedError;
+
+      expect(classifyBlockingFailure(error)).toBe("deterministic");
+    });
+
+    it("classifies connectivity code nested under .cause as environmental", () => {
+      const causedError = new Error("Connection refused");
+      (causedError as any).code = "ECONNREFUSED";
+
+      const error = new Error("Outer error");
+      (error as any).cause = causedError;
+
+      expect(classifyBlockingFailure(error)).toBe("environmental");
+    });
+
+    it("classifies AggregateError with 404 as deterministic", () => {
+      const statusError = new Error("Not found");
+      (statusError as any).status = 404;
+
+      const aggregateError = new AggregateError(
+        [statusError],
+        "Multiple errors",
+      );
+
+      expect(classifyBlockingFailure(aggregateError)).toBe("deterministic");
+    });
+  });
+
+  describe("purity", () => {
+    it("returns the same classification when called twice with the same input", () => {
+      const error = new Error("Not found");
+      (error as any).status = 404;
+
+      const result1 = classifyBlockingFailure(error);
+      const result2 = classifyBlockingFailure(error);
+
+      expect(result1).toBe(result2);
+      expect(result1).toBe("deterministic");
+    });
+
+    it("returns the same classification for equivalent errors", () => {
+      const error1 = new Error("Connection refused");
+      (error1 as any).code = "ECONNREFUSED";
+
+      const error2 = new Error("Connection refused");
+      (error2 as any).code = "ECONNREFUSED";
+
+      expect(classifyBlockingFailure(error1)).toBe(
+        classifyBlockingFailure(error2),
+      );
+      expect(classifyBlockingFailure(error1)).toBe("environmental");
+    });
+  });
+});

--- a/packages/appkit/src/type-generator/tests/generate-queries.test.ts
+++ b/packages/appkit/src/type-generator/tests/generate-queries.test.ts
@@ -891,7 +891,7 @@ describe("generateQueriesFromDescribe", () => {
       }
     });
 
-    test("preflight connectivity error — degradeAll, never describes", async () => {
+    test("preflight connectivity error — degradeAll, never describes, flagged environmental for the gate", async () => {
       mocks.readdir.mockResolvedValue(["a.sql"]);
       mocks.readFile.mockResolvedValue("SELECT id FROM a");
       mocks.getWarehouse.mockImplementation(() => {
@@ -901,16 +901,88 @@ describe("generateQueriesFromDescribe", () => {
         );
       });
 
-      const { schemas, syntaxErrors, fatalErrors } =
-        await generateQueriesFromDescribe("/queries", "wh-123", {
-          mode: "blocking",
-        });
+      const {
+        schemas,
+        syntaxErrors,
+        fatalErrors,
+        hadEnvironmentalFailure,
+        environmentalCause,
+      } = await generateQueriesFromDescribe("/queries", "wh-123", {
+        mode: "blocking",
+      });
 
-      // Unreachable warehouse degrades silently — even in blocking mode.
+      // Without the environmental flag a fresh checkout would exit 0 having
+      // written no types at all: degraded queries suppress the write, and
+      // nothing else fails the run.
       expect(mocks.executeStatement).not.toHaveBeenCalled();
       expect(fatalErrors).toEqual([]);
       expect(syntaxErrors).toEqual([]);
       expect(schemas[0].type).toContain("result: unknown");
+      expect(hadEnvironmentalFailure).toBe(true);
+      expect(environmentalCause).toBe("unreachable");
+    });
+
+    test("preflight auth error — environmentalCause is auth, including on response.status", async () => {
+      mocks.readdir.mockResolvedValue(["a.sql"]);
+      mocks.readFile.mockResolvedValue("SELECT id FROM a");
+      // Status carried on `response.status` rather than `status` — some HTTP
+      // clients report it there, and it must still label as auth.
+      mocks.getWarehouse.mockImplementation(() => {
+        throw Object.assign(new Error("PERMISSION_DENIED"), {
+          response: { status: 403 },
+        });
+      });
+
+      const { fatalErrors, hadEnvironmentalFailure, environmentalCause } =
+        await generateQueriesFromDescribe("/queries", "wh-123", {
+          mode: "blocking",
+        });
+
+      expect(mocks.executeStatement).not.toHaveBeenCalled();
+      expect(fatalErrors).toEqual([]);
+      expect(hadEnvironmentalFailure).toBe(true);
+      expect(environmentalCause).toBe("auth");
+    });
+
+    test("per-query DESCRIBE connectivity failure is flagged environmental for the gate", async () => {
+      mocks.readdir.mockResolvedValue(["a.sql"]);
+      mocks.readFile.mockResolvedValue("SELECT id FROM a");
+      mocks.getWarehouse.mockReturnValue({ state: "RUNNING" });
+      mocks.executeStatement.mockRejectedValue(
+        Object.assign(new Error("connect ECONNREFUSED"), {
+          code: "ECONNREFUSED",
+        }),
+      );
+
+      const {
+        schemas,
+        syntaxErrors,
+        fatalErrors,
+        hadEnvironmentalFailure,
+        environmentalCause,
+      } = await generateQueriesFromDescribe("/queries", "wh-123", {
+        mode: "blocking",
+      });
+
+      expect(fatalErrors).toEqual([]);
+      expect(syntaxErrors).toEqual([]);
+      expect(schemas[0].type).toContain("result: unknown");
+      expect(hadEnvironmentalFailure).toBe(true);
+      expect(environmentalCause).toBe("unreachable");
+    });
+
+    test("non-blocking mode never reports an environmental cause", async () => {
+      mocks.readdir.mockResolvedValue(["a.sql"]);
+      mocks.readFile.mockResolvedValue("SELECT id FROM a");
+
+      const { hadEnvironmentalFailure, environmentalCause } =
+        await generateQueriesFromDescribe("/queries", "wh-123", {
+          mode: "non-blocking",
+        });
+
+      // The gate is blocking-only; non-blocking degrades without signaling.
+      expect(hadEnvironmentalFailure).toBe(false);
+      expect(environmentalCause).toBeUndefined();
     });
 
     test("RUNNING preflight — describes normally", async () => {

--- a/packages/appkit/src/type-generator/tests/generate-queries.test.ts
+++ b/packages/appkit/src/type-generator/tests/generate-queries.test.ts
@@ -774,44 +774,46 @@ describe("generateQueriesFromDescribe", () => {
     });
 
     test.each(["DELETED", "DELETING"] as const)(
-      "%s + blocking mode — fatal per query after schemas are written, never describes",
+      "%s + blocking mode — environmental, degrades silently, hadEnvironmentalFailure set for gate",
       async (state) => {
+        // Phase 3: DELETED/DELETING are environmental (state-based fatals).
+        // They degrade silently (fatalErrors empty) but set hadEnvironmentalFailure
+        // for the entry point's has-types gate to handle.
         mocks.readdir.mockResolvedValue(["a.sql", "b.sql"]);
         mocks.readFile
           .mockResolvedValueOnce("SELECT id FROM a")
           .mockResolvedValueOnce("SELECT id FROM b");
         mocks.getWarehouse.mockReturnValue({ state });
 
-        const { schemas, syntaxErrors, fatalErrors } =
+        const { schemas, syntaxErrors, fatalErrors, hadEnvironmentalFailure } =
           await generateQueriesFromDescribe("/queries", "wh-123", {
             mode: "blocking",
           });
 
-        // A deleted/deleting warehouse is the only fatal case: never started,
-        // never described; one fatal entry per uncached query.
+        // Phase 3: environmental failures degrade, not fatal at query level.
         expect(mocks.startWarehouse).not.toHaveBeenCalled();
         expect(mocks.executeStatement).not.toHaveBeenCalled();
-        expect(fatalErrors).toEqual([
-          { name: "a", message: `warehouse wh-123 is ${state}` },
-          { name: "b", message: `warehouse wh-123 is ${state}` },
-        ]);
+        expect(fatalErrors).toEqual([]); // Phase 3: environmental, not fatal
+        expect(hadEnvironmentalFailure).toBe(true); // Phase 3: track for gate
         expect(syntaxErrors).toEqual([]);
         // Schemas are still produced (degraded) so the .d.ts is written before
-        // generateFromEntryPoint throws on the recorded fatalErrors.
+        // generateFromEntryPoint uses the gate to decide throw/warn.
         expect(schemas).toHaveLength(2);
         expect(schemas[0].type).toContain("result: unknown");
         expect(schemas[1].type).toContain("result: unknown");
       },
     );
 
-    test("STOPPED + blocking — start succeeds but warehouse never reaches RUNNING is fatal", async () => {
+    test("STOPPED + blocking — start succeeds but warehouse never reaches RUNNING is environmental, degrades silently", async () => {
+      // Phase 3: wait timeout (non-RUNNING resolve) is environmental (state-based fatal).
+      // It degrades silently (fatalErrors empty) but sets hadEnvironmentalFailure for the gate.
       vi.useFakeTimers();
       try {
         mocks.readdir.mockResolvedValue(["a.sql"]);
         mocks.readFile.mockResolvedValue("SELECT id FROM a");
         // Preflight sees STOPPED → start fires, but the warehouse then reports
         // DELETED (a genuinely terminal state even with treatStoppedAsTransient).
-        // The wait resolves non-RUNNING → fatal; schemas still written.
+        // The wait resolves non-RUNNING → environmental; schemas still written.
         mocks.getWarehouse
           .mockReturnValueOnce({ state: "STOPPED" })
           .mockReturnValue({ state: "DELETED" });
@@ -820,17 +822,14 @@ describe("generateQueriesFromDescribe", () => {
           mode: "blocking",
         });
         await vi.runAllTimersAsync();
-        const { schemas, syntaxErrors, fatalErrors } = await promise;
+        const { schemas, syntaxErrors, fatalErrors, hadEnvironmentalFailure } =
+          await promise;
 
         expect(mocks.startWarehouse).toHaveBeenCalledTimes(1);
         expect(mocks.executeStatement).not.toHaveBeenCalled();
         expect(syntaxErrors).toEqual([]);
-        expect(fatalErrors).toEqual([
-          {
-            name: "a",
-            message: "warehouse wh-123 did not reach RUNNING (now DELETED)",
-          },
-        ]);
+        expect(fatalErrors).toEqual([]); // Phase 3: environmental, not fatal
+        expect(hadEnvironmentalFailure).toBe(true); // Phase 3: track for gate
         expect(schemas[0].type).toContain("result: unknown");
       } finally {
         vi.useRealTimers();

--- a/packages/appkit/src/type-generator/tests/generate-queries.test.ts
+++ b/packages/appkit/src/type-generator/tests/generate-queries.test.ts
@@ -624,16 +624,21 @@ describe("generateQueriesFromDescribe", () => {
       status: { state: "PENDING" },
     });
 
-    const { schemas, syntaxErrors, fatalErrors } = await describeQueries(
-      "/queries",
-      "wh-123",
-    );
+    const {
+      schemas,
+      syntaxErrors,
+      fatalErrors,
+      hadEnvironmentalFailure,
+      environmentalCause,
+    } = await describeQueries("/queries", "wh-123");
 
     expect(schemas).toHaveLength(1);
     expect(schemas[0].name).toBe("users");
     expect(schemas[0].type).toContain("result: unknown");
     expect(syntaxErrors).toEqual([]);
     expect(fatalErrors).toEqual([]);
+    expect(hadEnvironmentalFailure).toBe(true);
+    expect(environmentalCause).toBe("unavailable");
     // a non-ready warehouse must never persist `result: unknown`
     expect(lastSavedQueries()).not.toHaveProperty("users");
   });

--- a/packages/appkit/src/type-generator/tests/generate-queries.test.ts
+++ b/packages/appkit/src/type-generator/tests/generate-queries.test.ts
@@ -776,9 +776,9 @@ describe("generateQueriesFromDescribe", () => {
     test.each(["DELETED", "DELETING"] as const)(
       "%s + blocking mode — environmental, degrades silently, hadEnvironmentalFailure set for gate",
       async (state) => {
-        // Phase 3: DELETED/DELETING are environmental (state-based fatals).
-        // They degrade silently (fatalErrors empty) but set hadEnvironmentalFailure
-        // for the entry point's has-types gate to handle.
+        // DELETED/DELETING are environmental (state-based fatals). They degrade
+        // silently (fatalErrors empty) but set hadEnvironmentalFailure for the
+        // entry point's has-types gate to handle.
         mocks.readdir.mockResolvedValue(["a.sql", "b.sql"]);
         mocks.readFile
           .mockResolvedValueOnce("SELECT id FROM a")
@@ -790,11 +790,11 @@ describe("generateQueriesFromDescribe", () => {
             mode: "blocking",
           });
 
-        // Phase 3: environmental failures degrade, not fatal at query level.
+        // Environmental failures degrade, not fatal at query level.
         expect(mocks.startWarehouse).not.toHaveBeenCalled();
         expect(mocks.executeStatement).not.toHaveBeenCalled();
-        expect(fatalErrors).toEqual([]); // Phase 3: environmental, not fatal
-        expect(hadEnvironmentalFailure).toBe(true); // Phase 3: track for gate
+        expect(fatalErrors).toEqual([]); // environmental, not fatal
+        expect(hadEnvironmentalFailure).toBe(true); // tracked for the gate
         expect(syntaxErrors).toEqual([]);
         // Schemas are still produced (degraded) so the .d.ts is written before
         // generateFromEntryPoint uses the gate to decide throw/warn.
@@ -805,8 +805,9 @@ describe("generateQueriesFromDescribe", () => {
     );
 
     test("STOPPED + blocking — start succeeds but warehouse never reaches RUNNING is environmental, degrades silently", async () => {
-      // Phase 3: wait timeout (non-RUNNING resolve) is environmental (state-based fatal).
-      // It degrades silently (fatalErrors empty) but sets hadEnvironmentalFailure for the gate.
+      // A wait timeout (non-RUNNING resolve) is environmental (state-based
+      // fatal). It degrades silently (fatalErrors empty) but sets
+      // hadEnvironmentalFailure for the gate.
       vi.useFakeTimers();
       try {
         mocks.readdir.mockResolvedValue(["a.sql"]);
@@ -828,8 +829,8 @@ describe("generateQueriesFromDescribe", () => {
         expect(mocks.startWarehouse).toHaveBeenCalledTimes(1);
         expect(mocks.executeStatement).not.toHaveBeenCalled();
         expect(syntaxErrors).toEqual([]);
-        expect(fatalErrors).toEqual([]); // Phase 3: environmental, not fatal
-        expect(hadEnvironmentalFailure).toBe(true); // Phase 3: track for gate
+        expect(fatalErrors).toEqual([]); // environmental, not fatal
+        expect(hadEnvironmentalFailure).toBe(true); // tracked for the gate
         expect(schemas[0].type).toContain("result: unknown");
       } finally {
         vi.useRealTimers();

--- a/packages/appkit/src/type-generator/tests/generate-queries.test.ts
+++ b/packages/appkit/src/type-generator/tests/generate-queries.test.ts
@@ -146,6 +146,7 @@ describe("generateQueriesFromDescribe", () => {
     expect(schemas[0].name).toBe("users");
     expect(schemas[0].type).toContain("id: number");
     expect(schemas[0].type).toContain("name: string");
+    expect(schemas[0].degraded).toBeUndefined();
     expect(mocks.spinnerStop).toHaveBeenCalledWith("");
     expect(mocks.saveCache).toHaveBeenCalledTimes(1);
     // clean success: cached, and not flagged as a syntax error
@@ -609,6 +610,7 @@ describe("generateQueriesFromDescribe", () => {
     );
 
     expect(schemas[0].type).toContain("result: unknown");
+    expect(schemas[0].degraded).toBe(true);
     expect(syntaxErrors).toEqual([]);
     expect(lastSavedQueries()).not.toHaveProperty("empty");
   });

--- a/packages/appkit/src/type-generator/tests/index.test.ts
+++ b/packages/appkit/src/type-generator/tests/index.test.ts
@@ -593,11 +593,11 @@ describe("generateFromEntryPoint — metric-view emission", () => {
     expect((error as Error).message).toContain("revenue");
     expect((error as Error).message).toContain("DESCRIBE exploded");
 
-    // Phase 1: the degraded metric write is suppressed in blocking mode (committed types preserved).
+    // The degraded metric write is suppressed in blocking mode (committed types preserved).
     expect(fs.existsSync(metricFile)).toBe(false);
   });
 
-  test("blocking + a non-terminal DESCRIBE (warehouse not ready): degrades, does NOT escalate, Phase 1 suppresses write", async () => {
+  test("blocking + a non-terminal DESCRIBE (warehouse not ready): degrades, does NOT escalate", async () => {
     writeMetricConfig();
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
@@ -607,8 +607,8 @@ describe("generateFromEntryPoint — metric-view emission", () => {
       // a per-key failure. Unlike a bad source (which `--wait` fails), a not-ready
       // warehouse stays a soft degrade even under `--wait`, so infra flakiness
       // can't break the build (mirrors the STOPPED-resolve preflight case).
-      // Per Phase 1 anti-clobber: degraded artifacts are NOT written in blocking
-      // mode when there are no failures (to preserve committed good types).
+      // Degraded artifacts are NOT written in blocking mode when there are no failures
+      // (to preserve committed good types).
       await expect(
         generateFromEntryPoint({
           outFile,
@@ -624,7 +624,7 @@ describe("generateFromEntryPoint — metric-view emission", () => {
 
       const warned = warnSpy.mock.calls.flat().map(String).join("\n");
       expect(warned).not.toContain("metric sync failed");
-      // Phase 1: degraded artifacts are suppressed, not written (to preserve committed types).
+      // Degraded artifacts are suppressed, not written (to preserve committed types).
       expect(fs.existsSync(metricFile)).toBe(false);
     } finally {
       warnSpy.mockRestore();
@@ -705,7 +705,7 @@ describe("generateFromEntryPoint — metric-view emission", () => {
   });
 
   test("blocking + DELETED: environmental failure with committed types → no throw, warning emitted", async () => {
-    // Phase 3: DELETED is environmental. Since the query path writes analytics.d.ts
+    // DELETED is environmental. Since the query path writes analytics.d.ts
     // (even with empty registry), committed types exist, so emit warning + return 0.
     writeMetricConfig();
     mocks.getWarehouseState.mockResolvedValue("DELETED");
@@ -719,7 +719,7 @@ describe("generateFromEntryPoint — metric-view emission", () => {
         mode: "blocking",
       });
 
-      // Phase 3: environmental failure with committed types → no throw.
+      // Environmental failure with committed types → no throw.
       // The generator returns normally (exit 0).
     } finally {
       warnSpy.mockRestore();
@@ -730,7 +730,7 @@ describe("generateFromEntryPoint — metric-view emission", () => {
     expect(mocks.waitUntilRunning).not.toHaveBeenCalled();
     expect(mocks.executeStatement).not.toHaveBeenCalled();
 
-    // Phase 1: degraded metric artifacts are NOT written in blocking mode (committed types preserved).
+    // Degraded metric artifacts are NOT written in blocking mode (committed types preserved).
     expect(fs.existsSync(metricFile)).toBe(false);
 
     // The degraded outcome is NEVER cached (mirrors the query path): the key is
@@ -741,7 +741,7 @@ describe("generateFromEntryPoint — metric-view emission", () => {
   });
 
   test("blocking + preflight wait rejects with a timeout: environmental failure with committed types → no throw, warning emitted", async () => {
-    // Phase 3: timeout is environmental. Since the query path writes analytics.d.ts,
+    // Timeout is environmental. Since the query path writes analytics.d.ts,
     // committed types exist, so emit warning + return 0.
     writeMetricConfig();
     mocks.getWarehouseState.mockResolvedValue("STARTING");
@@ -761,7 +761,7 @@ describe("generateFromEntryPoint — metric-view emission", () => {
         mode: "blocking",
       });
 
-      // Phase 3: environmental failure with committed types → no throw.
+      // Environmental failure with committed types → no throw.
     } finally {
       warnSpy.mockRestore();
       logSpy.mockRestore();
@@ -776,7 +776,7 @@ describe("generateFromEntryPoint — metric-view emission", () => {
       expect.objectContaining({ maxMs: 300_000 }),
     );
     expect(mocks.executeStatement).not.toHaveBeenCalled();
-    // Phase 1: degraded metric artifacts are NOT written in blocking mode (committed types preserved).
+    // Degraded metric artifacts are NOT written in blocking mode (committed types preserved).
     expect(fs.existsSync(metricFile)).toBe(false);
 
     // The degraded outcome is not cached — the key stays uncached for the next
@@ -785,12 +785,12 @@ describe("generateFromEntryPoint — metric-view emission", () => {
     expect(metrics.revenue).toBeUndefined();
   });
 
-  test("blocking + preflight wait resolves non-RUNNING (STOPPED): degrades, does not throw, Phase 1 suppresses write", async () => {
+  test("blocking + preflight wait resolves non-RUNNING (STOPPED): degrades, does not throw", async () => {
     // A non-RUNNING *resolve* (not a throw) for a startable state is soft: fall
     // through to DESCRIBE, which degrades on the still-cold warehouse. Only a
     // DELETED/DELETING resolve (or a thrown deterministic error) is fatal.
-    // Per Phase 1 anti-clobber: degraded artifacts are NOT written in blocking
-    // mode when there are no failures (to preserve committed good types).
+    // Degraded artifacts are NOT written in blocking mode when there are no failures
+    // (to preserve committed good types).
     writeMetricConfig();
     mocks.getWarehouseState.mockResolvedValue("STARTING");
     mocks.waitUntilRunning.mockResolvedValue("STOPPED");
@@ -831,9 +831,9 @@ describe("generateFromEntryPoint — metric-view emission", () => {
       mocks.waitUntilRunning.mock.calls[0][2].treatStoppedAsTransient,
     ).toBeUndefined();
     // The DESCRIBE batch still ran (fall-through), and its non-terminal answer
-    // degraded the key per Phase 1 semantics.
+    // degraded the key.
     expect(mocks.executeStatement).toHaveBeenCalledTimes(1);
-    // Phase 1: degraded artifacts are suppressed, not written (to preserve committed types).
+    // Degraded artifacts are suppressed, not written (to preserve committed types).
     expect(fs.existsSync(metricFile)).toBe(false);
 
     // The degraded outcome is not cached; the key stays uncached and the next
@@ -852,7 +852,7 @@ describe("generateFromEntryPoint — metric-view emission", () => {
   ])(
     "blocking + warehouse deleted mid-wait (probe read %s): environmental failure with committed types → no throw, warning emitted",
     async (probedState, startsWarehouse) => {
-      // Phase 3: DELETED mid-wait is environmental. Since the query path writes
+      // DELETED mid-wait is environmental. Since the query path writes
       // analytics.d.ts, committed types exist, so emit warning + return 0.
       writeMetricConfig();
       mocks.getWarehouseState.mockResolvedValue(probedState);
@@ -868,7 +868,7 @@ describe("generateFromEntryPoint — metric-view emission", () => {
         mode: "blocking",
       });
 
-      // Phase 3: environmental failure with committed types → no throw.
+      // Environmental failure with committed types → no throw.
 
       expect(mocks.startWarehouse).toHaveBeenCalledTimes(
         startsWarehouse ? 1 : 0,
@@ -876,7 +876,7 @@ describe("generateFromEntryPoint — metric-view emission", () => {
       // The DESCRIBE batch is skipped — nothing can answer it.
       expect(mocks.executeStatement).not.toHaveBeenCalled();
 
-      // Phase 1: degraded metric artifacts are NOT written in blocking mode (committed types preserved).
+      // Degraded metric artifacts are NOT written in blocking mode (committed types preserved).
       expect(fs.existsSync(metricFile)).toBe(false);
 
       // The degraded outcome is not cached — no sticky entry to serve later.
@@ -1779,8 +1779,8 @@ describe("generateFromEntryPoint — metric cache section", () => {
   );
 });
 
-// ── Phase 1: Write suppression for blocking mode with degraded types ──
-describe("generateFromEntryPoint — Phase 1: anti-clobber for blocking mode", () => {
+// ── Write suppression for blocking mode with degraded types ──
+describe("generateFromEntryPoint — anti-clobber for blocking mode", () => {
   const antiClobberDir = path.join(__dirname, "__output_anti_clobber__");
   const queryFolder = path.join(antiClobberDir, "queries");
   const metricViewsFolder = path.join(antiClobberDir, "metric-views");
@@ -1947,7 +1947,7 @@ describe("generateFromEntryPoint — Phase 1: anti-clobber for blocking mode", (
     );
 
     expect(error).toBeInstanceOf(TypegenSyntaxError);
-    // Phase 1: degraded artifacts are NOT written in blocking mode (committed types preserved).
+    // Degraded artifacts are NOT written in blocking mode (committed types preserved).
     expect(fs.existsSync(outFile)).toBe(false);
   });
 
@@ -2080,12 +2080,12 @@ describe("generateFromEntryPoint — Phase 1: anti-clobber for blocking mode", (
     );
 
     expect(error).toBeInstanceOf(TypegenFatalError);
-    // Phase 1: degraded artifacts are NOT written in blocking mode (committed types preserved).
+    // Degraded artifacts are NOT written in blocking mode (committed types preserved).
     expect(fs.existsSync(outFile)).toBe(false);
   });
 });
 
-describe("generateFromEntryPoint — Phase 3: warning message with cause labels", () => {
+describe("generateFromEntryPoint — warning message with cause labels", () => {
   const warningTestDir = path.join(__dirname, "__output_warning__");
   const queryFolder = path.join(warningTestDir, "queries");
   const metricViewsFolder = path.join(warningTestDir, "metric-views");
@@ -2400,7 +2400,7 @@ describe("generateFromEntryPoint — Phase 3: warning message with cause labels"
   });
 });
 
-describe("generateFromEntryPoint — Phase 3: has-types gate crash (no committed types)", () => {
+describe("generateFromEntryPoint — has-types gate crash (no committed types)", () => {
   const gateDir = path.join(__dirname, "__output_gate_crash__");
   const queryFolder = path.join(gateDir, "queries");
   const outFile = path.join(gateDir, "generated", "analytics.d.ts");
@@ -2416,7 +2416,7 @@ describe("generateFromEntryPoint — Phase 3: has-types gate crash (no committed
     // Clean slate: no generated/ dir, so no committed analytics.d.ts / metric-views.d.ts.
     fs.rmSync(gateDir, { recursive: true, force: true });
     fs.mkdirSync(queryFolder, { recursive: true });
-    // A degraded query in blocking mode → write suppressed (Phase 1) → nothing on disk.
+    // A degraded query in blocking mode → write suppressed → nothing on disk.
     mocks.generateQueriesFromDescribe.mockResolvedValue({
       schemas: [degradedSchema("offline_query")],
       syntaxErrors: [],
@@ -2446,7 +2446,7 @@ describe("generateFromEntryPoint — Phase 3: has-types gate crash (no committed
     const message = stripAnsi((err as Error).message);
     expect(message).toContain("generate-types --wait");
     expect(message).toContain("wh-nogate");
-    // Phase 1 suppressed the degraded write, so nothing was written this run either.
+    // The degraded write was suppressed, so nothing was written this run either.
     expect(fs.existsSync(outFile)).toBe(false);
   });
 

--- a/packages/appkit/src/type-generator/tests/index.test.ts
+++ b/packages/appkit/src/type-generator/tests/index.test.ts
@@ -602,6 +602,39 @@ describe("generateFromEntryPoint — metric-view emission", () => {
     expect(fs.existsSync(metricFile)).toBe(false);
   });
 
+  test("blocking + transient metric DESCRIBE failure: warns and preserves committed metric types", async () => {
+    writeMetricConfig();
+    fs.mkdirSync(path.dirname(metricFile), { recursive: true });
+    const committed = "// committed metric types\n";
+    fs.writeFileSync(metricFile, committed, "utf-8");
+
+    const unreachable = Object.assign(
+      new Error("connect ECONNREFUSED 10.0.0.1:443"),
+      { code: "ECONNREFUSED" },
+    );
+    mocks.getWarehouseState.mockRejectedValue(unreachable);
+    mocks.executeStatement.mockRejectedValue(unreachable);
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await expect(
+        generateFromEntryPoint({
+          outFile,
+          queryFolder,
+          warehouseId: "wh-1",
+          mode: "blocking",
+        }),
+      ).resolves.toBeUndefined();
+
+      const warnings = warnSpy.mock.calls.flat().map(String).join("\n");
+      expect(warnings).toContain("AppKit typegen: using committed types");
+      expect(warnings).toContain("warehouse unreachable");
+      expect(fs.readFileSync(metricFile, "utf-8")).toBe(committed);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   test("blocking + a non-terminal DESCRIBE (warehouse not ready): degrades, does NOT escalate", async () => {
     writeMetricConfig();
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/packages/appkit/src/type-generator/tests/index.test.ts
+++ b/packages/appkit/src/type-generator/tests/index.test.ts
@@ -102,6 +102,12 @@ const { hashSQL } = await import("../cache");
 
 const outputDir = path.join(__dirname, "__output__");
 
+// Strip ANSI SGR escape sequences so warning/error messages assert as plain
+// text (and match CI logs). The ESC byte is built via String.fromCharCode so
+// no control character appears in a regex literal (Biome noControlCharactersInRegex).
+const ANSI_SGR = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
+const stripAnsi = (s: string): string => s.replace(ANSI_SGR, "");
+
 describe("generateFromEntryPoint", () => {
   beforeAll(() => {
     // Create output directory once before all tests
@@ -698,35 +704,33 @@ describe("generateFromEntryPoint — metric-view emission", () => {
     );
   });
 
-  test("blocking + DELETED: fails through the query path's fatal pathway (TypegenFatalError, committed types untouched)", async () => {
+  test("blocking + DELETED: environmental failure with committed types → no throw, warning emitted", async () => {
+    // Phase 3: DELETED is environmental. Since the query path writes analytics.d.ts
+    // (even with empty registry), committed types exist, so emit warning + return 0.
     writeMetricConfig();
     mocks.getWarehouseState.mockResolvedValue("DELETED");
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-    const error = await generateFromEntryPoint({
-      outFile,
-      queryFolder,
-      warehouseId: "wh-1",
-      mode: "blocking",
-    }).then(
-      () => {
-        throw new Error("expected generateFromEntryPoint to reject");
-      },
-      (err: unknown) => err,
-    );
+    try {
+      await generateFromEntryPoint({
+        outFile,
+        queryFolder,
+        warehouseId: "wh-1",
+        mode: "blocking",
+      });
 
-    // Identical surfacing to a query-path fatal preflight: same error class,
-    // same per-name fatal entries, same message template.
-    expect(error).toBeInstanceOf(TypegenFatalError);
-    expect((error as InstanceType<typeof TypegenFatalError>).queries).toEqual([
-      { name: "revenue", message: "warehouse wh-1 is DELETED" },
-    ]);
+      // Phase 3: environmental failure with committed types → no throw.
+      // The generator returns normally (exit 0).
+    } finally {
+      warnSpy.mockRestore();
+    }
 
     // A deleted warehouse is never started, waited on, or described.
     expect(mocks.startWarehouse).not.toHaveBeenCalled();
     expect(mocks.waitUntilRunning).not.toHaveBeenCalled();
     expect(mocks.executeStatement).not.toHaveBeenCalled();
 
-    // Phase 1: degraded artifacts are NOT written in blocking mode (committed types preserved).
+    // Phase 1: degraded metric artifacts are NOT written in blocking mode (committed types preserved).
     expect(fs.existsSync(metricFile)).toBe(false);
 
     // The degraded outcome is NEVER cached (mirrors the query path): the key is
@@ -736,10 +740,9 @@ describe("generateFromEntryPoint — metric-view emission", () => {
     expect(metrics.revenue).toBeUndefined();
   });
 
-  test("blocking + preflight wait rejects with a timeout: fatal, committed types untouched (no silent stall)", async () => {
-    // A timed-out wait is deterministic, not a connectivity blip: surface it as
-    // fatal rather than falling through to DESCRIBE a not-ready warehouse — the
-    // ~5-min stall that still "succeeds". (Hybrid: warehouse-level → fatal.)
+  test("blocking + preflight wait rejects with a timeout: environmental failure with committed types → no throw, warning emitted", async () => {
+    // Phase 3: timeout is environmental. Since the query path writes analytics.d.ts,
+    // committed types exist, so emit warning + return 0.
     writeMetricConfig();
     mocks.getWarehouseState.mockResolvedValue("STARTING");
     mocks.waitUntilRunning.mockRejectedValue(
@@ -751,21 +754,14 @@ describe("generateFromEntryPoint — metric-view emission", () => {
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
     try {
-      const error = await generateFromEntryPoint({
+      await generateFromEntryPoint({
         outFile,
         queryFolder,
         warehouseId: "wh-1",
         mode: "blocking",
-      }).then(
-        () => {
-          throw new Error("expected generateFromEntryPoint to reject");
-        },
-        (err: unknown) => err,
-      );
-      expect(error).toBeInstanceOf(TypegenFatalError);
-      expect((error as InstanceType<typeof TypegenFatalError>).queries).toEqual(
-        [expect.objectContaining({ name: "revenue" })],
-      );
+      });
+
+      // Phase 3: environmental failure with committed types → no throw.
     } finally {
       warnSpy.mockRestore();
       logSpy.mockRestore();
@@ -780,7 +776,7 @@ describe("generateFromEntryPoint — metric-view emission", () => {
       expect.objectContaining({ maxMs: 300_000 }),
     );
     expect(mocks.executeStatement).not.toHaveBeenCalled();
-    // Phase 1: degraded artifacts are NOT written in blocking mode (committed types preserved).
+    // Phase 1: degraded metric artifacts are NOT written in blocking mode (committed types preserved).
     expect(fs.existsSync(metricFile)).toBe(false);
 
     // The degraded outcome is not cached — the key stays uncached for the next
@@ -854,8 +850,10 @@ describe("generateFromEntryPoint — metric-view emission", () => {
     // STARTING probe → wait-only; a DELETED resolve is fatal there too.
     ["STARTING", false],
   ])(
-    "blocking + warehouse deleted mid-wait (probe read %s): fatal, committed types untouched, degraded outcome not cached",
+    "blocking + warehouse deleted mid-wait (probe read %s): environmental failure with committed types → no throw, warning emitted",
     async (probedState, startsWarehouse) => {
+      // Phase 3: DELETED mid-wait is environmental. Since the query path writes
+      // analytics.d.ts, committed types exist, so emit warning + return 0.
       writeMetricConfig();
       mocks.getWarehouseState.mockResolvedValue(probedState);
       mocks.startWarehouse.mockResolvedValue(undefined);
@@ -863,24 +861,14 @@ describe("generateFromEntryPoint — metric-view emission", () => {
       // RESOLVES (does not throw) with the terminal state.
       mocks.waitUntilRunning.mockResolvedValue("DELETED");
 
-      const error = await generateFromEntryPoint({
+      await generateFromEntryPoint({
         outFile,
         queryFolder,
         warehouseId: "wh-1",
         mode: "blocking",
-      }).then(
-        () => {
-          throw new Error("expected generateFromEntryPoint to reject");
-        },
-        (err: unknown) => err,
-      );
+      });
 
-      // Same fatal pathway as the decision-time DELETED: per-key entries
-      // with the query path's message template, thrown after the writes.
-      expect(error).toBeInstanceOf(TypegenFatalError);
-      expect((error as InstanceType<typeof TypegenFatalError>).queries).toEqual(
-        [{ name: "revenue", message: "warehouse wh-1 is DELETED" }],
-      );
+      // Phase 3: environmental failure with committed types → no throw.
 
       expect(mocks.startWarehouse).toHaveBeenCalledTimes(
         startsWarehouse ? 1 : 0,
@@ -888,7 +876,7 @@ describe("generateFromEntryPoint — metric-view emission", () => {
       // The DESCRIBE batch is skipped — nothing can answer it.
       expect(mocks.executeStatement).not.toHaveBeenCalled();
 
-      // Phase 1: degraded artifacts are NOT written in blocking mode (committed types preserved).
+      // Phase 1: degraded metric artifacts are NOT written in blocking mode (committed types preserved).
       expect(fs.existsSync(metricFile)).toBe(false);
 
       // The degraded outcome is not cached — no sticky entry to serve later.
@@ -1797,7 +1785,11 @@ describe("generateFromEntryPoint — Phase 1: anti-clobber for blocking mode", (
   const queryFolder = path.join(antiClobberDir, "queries");
   const metricViewsFolder = path.join(antiClobberDir, "metric-views");
   const outFile = path.join(antiClobberDir, "generated", "analytics.d.ts");
-  const metricFile = path.join(antiClobberDir, "generated", "metric-views.d.ts");
+  const metricFile = path.join(
+    antiClobberDir,
+    "generated",
+    "metric-views.d.ts",
+  );
 
   const degradedQuerySchema = (name: string) => ({
     name,
@@ -2068,7 +2060,9 @@ describe("generateFromEntryPoint — Phase 1: anti-clobber for blocking mode", (
         },
       ],
       syntaxErrors: [],
-      fatalErrors: [{ name: "bad_query", message: "warehouse wh-1: auth failed" }],
+      fatalErrors: [
+        { name: "bad_query", message: "warehouse wh-1: auth failed" },
+      ],
     });
 
     fs.mkdirSync(path.dirname(outFile), { recursive: true });
@@ -2087,6 +2081,398 @@ describe("generateFromEntryPoint — Phase 1: anti-clobber for blocking mode", (
 
     expect(error).toBeInstanceOf(TypegenFatalError);
     // Phase 1: degraded artifacts are NOT written in blocking mode (committed types preserved).
+    expect(fs.existsSync(outFile)).toBe(false);
+  });
+});
+
+describe("generateFromEntryPoint — Phase 3: warning message with cause labels", () => {
+  const warningTestDir = path.join(__dirname, "__output_warning__");
+  const queryFolder = path.join(warningTestDir, "queries");
+  const metricViewsFolder = path.join(warningTestDir, "metric-views");
+  const outFile = path.join(warningTestDir, "generated", "analytics.d.ts");
+  const metricFile = path.join(
+    warningTestDir,
+    "generated",
+    "metric-views.d.ts",
+  );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.cacheFile.contents = undefined;
+    fs.rmSync(warningTestDir, { recursive: true, force: true });
+    fs.mkdirSync(queryFolder, { recursive: true });
+    fs.mkdirSync(metricViewsFolder, { recursive: true });
+    // Pre-create committed types files so the gate triggers
+    fs.mkdirSync(path.dirname(outFile), { recursive: true });
+    fs.writeFileSync(outFile, "// committed types\n", "utf-8");
+    mocks.generateQueriesFromDescribe.mockResolvedValue({
+      schemas: [],
+      syntaxErrors: [],
+      fatalErrors: [],
+    });
+  });
+
+  afterAll(() => {
+    fs.rmSync(warningTestDir, { recursive: true, force: true });
+  });
+
+  test("warning: environmental failure with committed types → warning contains warehouse id and cause label (unavailable)", async () => {
+    // DELETED warehouse is classified as "unavailable"
+    mocks.getWarehouseState.mockResolvedValue("DELETED");
+    // Mock the query path to return degraded queries so it triggers environmental failure
+    mocks.generateQueriesFromDescribe.mockResolvedValue({
+      schemas: [
+        {
+          name: "q",
+          type: '{ name: "q"; parameters: Record<string, never>; result: unknown; }',
+        },
+      ],
+      syntaxErrors: [],
+      fatalErrors: [],
+      hadEnvironmentalFailure: true,
+      environmentalCause: "unavailable",
+    });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      await generateFromEntryPoint({
+        outFile,
+        queryFolder,
+        warehouseId: "wh-abc123",
+        mode: "blocking",
+      });
+
+      // Find the typegen warning call (skip other loggers)
+      const warnCalls = warnSpy.mock.calls
+        .flat()
+        .map(String)
+        .filter((s) => s.includes("AppKit typegen"));
+
+      expect(warnCalls.length).toBeGreaterThan(0);
+      const warnings = warnCalls.join("\n");
+      // Strip ANSI codes for clean assertion
+      const cleanWarnings = stripAnsi(warnings);
+
+      // Must contain stable prefix, warehouse ID, and the unavailable label
+      expect(cleanWarnings).toContain("AppKit typegen: using committed types");
+      expect(cleanWarnings).toContain("wh-abc123");
+      expect(cleanWarnings).toContain("warehouse unavailable");
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test("warning: environmental failure (auth) with committed types → warning contains 'auth blocked' label", async () => {
+    // Query path returns auth failure
+    mocks.generateQueriesFromDescribe.mockResolvedValue({
+      schemas: [],
+      syntaxErrors: [],
+      fatalErrors: [],
+      hadEnvironmentalFailure: true,
+      environmentalCause: "auth",
+    });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      await generateFromEntryPoint({
+        outFile,
+        queryFolder,
+        warehouseId: "wh-auth",
+        mode: "blocking",
+      });
+
+      const warnCalls = warnSpy.mock.calls
+        .flat()
+        .map(String)
+        .filter((s) => s.includes("AppKit typegen"));
+
+      expect(warnCalls.length).toBeGreaterThan(0);
+      const warnings = warnCalls.join("\n");
+      const cleanWarnings = stripAnsi(warnings);
+
+      expect(cleanWarnings).toContain("AppKit typegen: using committed types");
+      expect(cleanWarnings).toContain("wh-auth");
+      expect(cleanWarnings).toContain("auth blocked");
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test("warning: environmental failure (connectivity) with committed types → warning contains 'warehouse unreachable' label", async () => {
+    // Query path returns connectivity failure
+    mocks.generateQueriesFromDescribe.mockResolvedValue({
+      schemas: [],
+      syntaxErrors: [],
+      fatalErrors: [],
+      hadEnvironmentalFailure: true,
+      environmentalCause: "unreachable",
+    });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      await generateFromEntryPoint({
+        outFile,
+        queryFolder,
+        warehouseId: "wh-net",
+        mode: "blocking",
+      });
+
+      const warnCalls = warnSpy.mock.calls
+        .flat()
+        .map(String)
+        .filter((s) => s.includes("AppKit typegen"));
+
+      expect(warnCalls.length).toBeGreaterThan(0);
+      const warnings = warnCalls.join("\n");
+      const cleanWarnings = stripAnsi(warnings);
+
+      expect(cleanWarnings).toContain("AppKit typegen: using committed types");
+      expect(cleanWarnings).toContain("wh-net");
+      expect(cleanWarnings).toContain("warehouse unreachable");
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test("crash: deterministic error (404 bad warehouse id) STILL crashes even with committed types present", async () => {
+    // A 404 is deterministic, not environmental — committed types cannot save a deterministic error
+    mocks.generateQueriesFromDescribe.mockResolvedValue({
+      schemas: [],
+      syntaxErrors: [],
+      fatalErrors: [{ name: "test", message: "warehouse not found (404)" }],
+      hadEnvironmentalFailure: false,
+    });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      const error = await generateFromEntryPoint({
+        outFile,
+        queryFolder,
+        warehouseId: "wh-missing",
+        mode: "blocking",
+      }).then(
+        () => {
+          throw new Error("expected generateFromEntryPoint to reject");
+        },
+        (err: unknown) => err,
+      );
+
+      // Deterministic errors throw TypegenFatalError even with committed types
+      expect(error).toBeInstanceOf(TypegenFatalError);
+      // No warning — this is a deterministic failure
+      const typegenWarns = warnSpy.mock.calls
+        .flat()
+        .map(String)
+        .filter((s) => s.includes("AppKit typegen"));
+      expect(typegenWarns.length).toBe(0);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test("partial presence: only analytics.d.ts exists (metric absent) + environmental → warning emitted (partial presence counts)", async () => {
+    // Keep analytics.d.ts but remove metric file
+    expect(fs.existsSync(outFile)).toBe(true);
+    fs.rmSync(metricFile, { force: true });
+
+    // Query path returns environmental failure
+    mocks.generateQueriesFromDescribe.mockResolvedValue({
+      schemas: [],
+      syntaxErrors: [],
+      fatalErrors: [],
+      hadEnvironmentalFailure: true,
+      environmentalCause: "unavailable",
+    });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      await generateFromEntryPoint({
+        outFile,
+        queryFolder,
+        warehouseId: "wh-partial",
+        mode: "blocking",
+      });
+
+      // Warning emitted because at least one committed type exists (analytics.d.ts)
+      const warnCalls = warnSpy.mock.calls
+        .flat()
+        .map(String)
+        .filter((s) => s.includes("AppKit typegen"));
+
+      expect(warnCalls.length).toBeGreaterThan(0);
+      const warnings = warnCalls.join("\n");
+      const cleanWarnings = stripAnsi(warnings);
+      expect(cleanWarnings).toContain("AppKit typegen: using committed types");
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test("CI=true: warning output is ANSI-free (plain text for log parsing)", async () => {
+    process.env.CI = "true";
+    // Query path returns environmental failure
+    mocks.generateQueriesFromDescribe.mockResolvedValue({
+      schemas: [],
+      syntaxErrors: [],
+      fatalErrors: [],
+      hadEnvironmentalFailure: true,
+      environmentalCause: "unavailable",
+    });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      await generateFromEntryPoint({
+        outFile,
+        queryFolder,
+        warehouseId: "wh-ci",
+        mode: "blocking",
+      });
+
+      const warnCalls = warnSpy.mock.calls
+        .flat()
+        .map(String)
+        .filter((s) => s.includes("AppKit typegen"));
+
+      expect(warnCalls.length).toBeGreaterThan(0);
+      const warnings = warnCalls.join("\n");
+      // Verify no ANSI escape codes: stripping SGR sequences leaves it unchanged.
+      expect(stripAnsi(warnings)).toBe(warnings);
+      expect(warnings).toContain("AppKit typegen: using committed types");
+      expect(warnings).toContain("wh-ci");
+      expect(warnings).toContain("warehouse unavailable");
+    } finally {
+      delete process.env.CI;
+      warnSpy.mockRestore();
+    }
+  });
+
+  test("metric path: environmental failure + committed analytics exists → metric warning uses correct cause label", async () => {
+    fs.writeFileSync(
+      path.join(metricViewsFolder, "definitions.json"),
+      JSON.stringify({
+        metricViews: { revenue: { source: "demo.sales.revenue" } },
+      }),
+    );
+
+    // Pre-create metric committed types
+    fs.writeFileSync(metricFile, "// committed metric types\n", "utf-8");
+
+    // Metric preflight reports auth failure (environmental, not deterministic 404/400)
+    mocks.getWarehouseState.mockRejectedValue(
+      Object.assign(
+        new Error("PERMISSION_DENIED: cannot read warehouse wh-1"),
+        { status: 403 },
+      ),
+    );
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      await generateFromEntryPoint({
+        outFile,
+        queryFolder,
+        warehouseId: "wh-metric-auth",
+        mode: "blocking",
+      });
+
+      const warnCalls = warnSpy.mock.calls
+        .flat()
+        .map(String)
+        .filter((s) => s.includes("AppKit typegen"));
+
+      expect(warnCalls.length).toBeGreaterThan(0);
+      const warnings = warnCalls.join("\n");
+      const cleanWarnings = stripAnsi(warnings);
+
+      // The metric path's auth error should bubble up and generate the warning
+      expect(cleanWarnings).toContain("AppKit typegen: using committed types");
+      expect(cleanWarnings).toContain("wh-metric-auth");
+      expect(cleanWarnings).toContain("auth blocked");
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});
+
+describe("generateFromEntryPoint — Phase 3: has-types gate crash (no committed types)", () => {
+  const gateDir = path.join(__dirname, "__output_gate_crash__");
+  const queryFolder = path.join(gateDir, "queries");
+  const outFile = path.join(gateDir, "generated", "analytics.d.ts");
+
+  const degradedSchema = (name: string) => ({
+    name,
+    type: `{ name: "${name}"; parameters: Record<string, never>; result: unknown; }`,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.cacheFile.contents = undefined;
+    // Clean slate: no generated/ dir, so no committed analytics.d.ts / metric-views.d.ts.
+    fs.rmSync(gateDir, { recursive: true, force: true });
+    fs.mkdirSync(queryFolder, { recursive: true });
+    // A degraded query in blocking mode → write suppressed (Phase 1) → nothing on disk.
+    mocks.generateQueriesFromDescribe.mockResolvedValue({
+      schemas: [degradedSchema("offline_query")],
+      syntaxErrors: [],
+      fatalErrors: [],
+      hadEnvironmentalFailure: true,
+      environmentalCause: "unavailable",
+    });
+  });
+
+  afterAll(() => {
+    fs.rmSync(gateDir, { recursive: true, force: true });
+  });
+
+  test("blocking + environmental failure + NO committed types → crash with run-locally remedy", async () => {
+    const err = await generateFromEntryPoint({
+      outFile,
+      queryFolder,
+      warehouseId: "wh-nogate",
+      mode: "blocking",
+    }).then(
+      () => undefined,
+      (e: unknown) => e,
+    );
+
+    // Core safety path: no committed .d.ts to fall back on → build must fail.
+    expect(err).toBeInstanceOf(TypegenFatalError);
+    const message = stripAnsi((err as Error).message);
+    expect(message).toContain("generate-types --wait");
+    expect(message).toContain("wh-nogate");
+    // Phase 1 suppressed the degraded write, so nothing was written this run either.
+    expect(fs.existsSync(outFile)).toBe(false);
+  });
+
+  test("blocking + environmental failure + only serving.d.ts present → still crashes (serving excluded from gate)", async () => {
+    // Pre-create ONLY a serving.d.ts sibling. analytics.d.ts / metric-views.d.ts stay absent.
+    fs.mkdirSync(path.dirname(outFile), { recursive: true });
+    fs.writeFileSync(
+      path.join(path.dirname(outFile), "serving.d.ts"),
+      "// committed serving types\n",
+      "utf-8",
+    );
+
+    const err = await generateFromEntryPoint({
+      outFile,
+      queryFolder,
+      warehouseId: "wh-serving",
+      mode: "blocking",
+    }).then(
+      () => undefined,
+      (e: unknown) => e,
+    );
+
+    // serving.d.ts presence must NOT satisfy the has-types gate.
+    expect(err).toBeInstanceOf(TypegenFatalError);
+    const message = stripAnsi((err as Error).message);
+    expect(message).toContain("generate-types --wait");
     expect(fs.existsSync(outFile)).toBe(false);
   });
 });

--- a/packages/appkit/src/type-generator/tests/index.test.ts
+++ b/packages/appkit/src/type-generator/tests/index.test.ts
@@ -168,6 +168,7 @@ describe("generateFromEntryPoint — query failure handling", () => {
   const unknownSchema = (name: string) => ({
     name,
     type: `{ name: "${name}"; parameters: Record<string, never>; result: unknown; }`,
+    degraded: true,
   });
 
   beforeAll(() => {
@@ -1832,6 +1833,7 @@ describe("generateFromEntryPoint — anti-clobber for blocking mode", () => {
   const degradedQuerySchema = (name: string) => ({
     name,
     type: `{ name: "${name}"; parameters: Record<string, never>; result: unknown; }`,
+    degraded: true,
   });
 
   beforeEach(() => {
@@ -2063,10 +2065,10 @@ describe("generateFromEntryPoint — anti-clobber for blocking mode", () => {
     expect(content).toContain("measureKeys: string"); // Permissive degraded type
   });
 
-  test("blocking mode + degraded query (no syntax/fatal errors): resolves without write", async () => {
-    // When a query is degraded but there are no syntax or fatal errors,
-    // the function resolves normally. In blocking mode, the degraded write
-    // is suppressed, so outFile is not written.
+  test("blocking mode + degraded query (no syntax/fatal errors): crashes when no committed types exist", async () => {
+    // The explicit degraded marker must drive both write suppression and the
+    // committed-types gate, even if the producer omitted the legacy
+    // hadEnvironmentalFailure summary bit.
     mocks.generateQueriesFromDescribe.mockResolvedValue({
       schemas: [degradedQuerySchema("offline_query")],
       syntaxErrors: [],
@@ -2080,7 +2082,7 @@ describe("generateFromEntryPoint — anti-clobber for blocking mode", () => {
         warehouseId: "wh-1",
         mode: "blocking",
       }),
-    ).resolves.toBeUndefined();
+    ).rejects.toThrow(TypegenFatalError);
 
     // The file was not written because the query was degraded in blocking mode
     expect(fs.existsSync(outFile)).toBe(false);
@@ -2095,6 +2097,7 @@ describe("generateFromEntryPoint — anti-clobber for blocking mode", () => {
         {
           name: "bad_query",
           type: `{ name: "bad_query"; parameters: Record<string, never>; result: unknown; }`,
+          degraded: true,
         },
       ],
       syntaxErrors: [],
@@ -2444,6 +2447,7 @@ describe("generateFromEntryPoint — has-types gate crash (no committed types)",
   const degradedSchema = (name: string) => ({
     name,
     type: `{ name: "${name}"; parameters: Record<string, never>; result: unknown; }`,
+    degraded: true,
   });
 
   beforeEach(() => {

--- a/packages/appkit/src/type-generator/tests/index.test.ts
+++ b/packages/appkit/src/type-generator/tests/index.test.ts
@@ -587,11 +587,11 @@ describe("generateFromEntryPoint — metric-view emission", () => {
     expect((error as Error).message).toContain("revenue");
     expect((error as Error).message).toContain("DESCRIBE exploded");
 
-    // Write-first semantics: the degraded artifacts still ship before the throw.
-    expect(fs.existsSync(metricFile)).toBe(true);
+    // Phase 1: the degraded metric write is suppressed in blocking mode (committed types preserved).
+    expect(fs.existsSync(metricFile)).toBe(false);
   });
 
-  test("blocking + a non-terminal DESCRIBE (warehouse not ready): degrades, does NOT escalate", async () => {
+  test("blocking + a non-terminal DESCRIBE (warehouse not ready): degrades, does NOT escalate, Phase 1 suppresses write", async () => {
     writeMetricConfig();
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
@@ -601,6 +601,8 @@ describe("generateFromEntryPoint — metric-view emission", () => {
       // a per-key failure. Unlike a bad source (which `--wait` fails), a not-ready
       // warehouse stays a soft degrade even under `--wait`, so infra flakiness
       // can't break the build (mirrors the STOPPED-resolve preflight case).
+      // Per Phase 1 anti-clobber: degraded artifacts are NOT written in blocking
+      // mode when there are no failures (to preserve committed good types).
       await expect(
         generateFromEntryPoint({
           outFile,
@@ -616,10 +618,8 @@ describe("generateFromEntryPoint — metric-view emission", () => {
 
       const warned = warnSpy.mock.calls.flat().map(String).join("\n");
       expect(warned).not.toContain("metric sync failed");
-      // Permissive artifacts still ship.
-      const declarations = fs.readFileSync(metricFile, "utf-8");
-      expect(declarations).toContain('"revenue"');
-      expect(declarations).toContain("measureKeys: string");
+      // Phase 1: degraded artifacts are suppressed, not written (to preserve committed types).
+      expect(fs.existsSync(metricFile)).toBe(false);
     } finally {
       warnSpy.mockRestore();
       logSpy.mockRestore();
@@ -698,7 +698,7 @@ describe("generateFromEntryPoint — metric-view emission", () => {
     );
   });
 
-  test("blocking + DELETED: fails through the query path's fatal pathway (TypegenFatalError after artifacts are written)", async () => {
+  test("blocking + DELETED: fails through the query path's fatal pathway (TypegenFatalError, committed types untouched)", async () => {
     writeMetricConfig();
     mocks.getWarehouseState.mockResolvedValue("DELETED");
 
@@ -726,10 +726,8 @@ describe("generateFromEntryPoint — metric-view emission", () => {
     expect(mocks.waitUntilRunning).not.toHaveBeenCalled();
     expect(mocks.executeStatement).not.toHaveBeenCalled();
 
-    // Write-first semantics match query fatals: degraded artifacts exist.
-    const declarations = fs.readFileSync(metricFile, "utf-8");
-    expect(declarations).toContain('"revenue"');
-    expect(declarations).toContain("measureKeys: string");
+    // Phase 1: degraded artifacts are NOT written in blocking mode (committed types preserved).
+    expect(fs.existsSync(metricFile)).toBe(false);
 
     // The degraded outcome is NEVER cached (mirrors the query path): the key is
     // left uncached so a later pass re-probes, and no stale/sticky entry can be
@@ -738,7 +736,7 @@ describe("generateFromEntryPoint — metric-view emission", () => {
     expect(metrics.revenue).toBeUndefined();
   });
 
-  test("blocking + preflight wait rejects with a timeout: fatal after artifacts (no silent stall)", async () => {
+  test("blocking + preflight wait rejects with a timeout: fatal, committed types untouched (no silent stall)", async () => {
     // A timed-out wait is deterministic, not a connectivity blip: surface it as
     // fatal rather than falling through to DESCRIBE a not-ready warehouse — the
     // ~5-min stall that still "succeeds". (Hybrid: warehouse-level → fatal.)
@@ -782,10 +780,8 @@ describe("generateFromEntryPoint — metric-view emission", () => {
       expect.objectContaining({ maxMs: 300_000 }),
     );
     expect(mocks.executeStatement).not.toHaveBeenCalled();
-    // ... but degraded artifacts are still written before the throw.
-    expect(fs.readFileSync(metricFile, "utf-8")).toContain(
-      "measureKeys: string",
-    );
+    // Phase 1: degraded artifacts are NOT written in blocking mode (committed types preserved).
+    expect(fs.existsSync(metricFile)).toBe(false);
 
     // The degraded outcome is not cached — the key stays uncached for the next
     // pass to re-probe.
@@ -793,10 +789,12 @@ describe("generateFromEntryPoint — metric-view emission", () => {
     expect(metrics.revenue).toBeUndefined();
   });
 
-  test("blocking + preflight wait resolves non-RUNNING (STOPPED): degrades, does not throw", async () => {
+  test("blocking + preflight wait resolves non-RUNNING (STOPPED): degrades, does not throw, Phase 1 suppresses write", async () => {
     // A non-RUNNING *resolve* (not a throw) for a startable state is soft: fall
     // through to DESCRIBE, which degrades on the still-cold warehouse. Only a
     // DELETED/DELETING resolve (or a thrown deterministic error) is fatal.
+    // Per Phase 1 anti-clobber: degraded artifacts are NOT written in blocking
+    // mode when there are no failures (to preserve committed good types).
     writeMetricConfig();
     mocks.getWarehouseState.mockResolvedValue("STARTING");
     mocks.waitUntilRunning.mockResolvedValue("STOPPED");
@@ -839,9 +837,8 @@ describe("generateFromEntryPoint — metric-view emission", () => {
     // The DESCRIBE batch still ran (fall-through), and its non-terminal answer
     // degraded the key per Phase 1 semantics.
     expect(mocks.executeStatement).toHaveBeenCalledTimes(1);
-    expect(fs.readFileSync(metricFile, "utf-8")).toContain(
-      "measureKeys: string",
-    );
+    // Phase 1: degraded artifacts are suppressed, not written (to preserve committed types).
+    expect(fs.existsSync(metricFile)).toBe(false);
 
     // The degraded outcome is not cached; the key stays uncached and the next
     // describe-capable pass re-probes it (convergence via re-describe, not via a
@@ -857,7 +854,7 @@ describe("generateFromEntryPoint — metric-view emission", () => {
     // STARTING probe → wait-only; a DELETED resolve is fatal there too.
     ["STARTING", false],
   ])(
-    "blocking + warehouse deleted mid-wait (probe read %s): fatal after artifacts, degraded outcome not cached",
+    "blocking + warehouse deleted mid-wait (probe read %s): fatal, committed types untouched, degraded outcome not cached",
     async (probedState, startsWarehouse) => {
       writeMetricConfig();
       mocks.getWarehouseState.mockResolvedValue(probedState);
@@ -891,10 +888,8 @@ describe("generateFromEntryPoint — metric-view emission", () => {
       // The DESCRIBE batch is skipped — nothing can answer it.
       expect(mocks.executeStatement).not.toHaveBeenCalled();
 
-      // Degraded artifacts are still written before the throw.
-      const declarations = fs.readFileSync(metricFile, "utf-8");
-      expect(declarations).toContain('"revenue"');
-      expect(declarations).toContain("measureKeys: string");
+      // Phase 1: degraded artifacts are NOT written in blocking mode (committed types preserved).
+      expect(fs.existsSync(metricFile)).toBe(false);
 
       // The degraded outcome is not cached — no sticky entry to serve later.
       const metrics =
@@ -1794,4 +1789,304 @@ describe("generateFromEntryPoint — metric cache section", () => {
       );
     },
   );
+});
+
+// ── Phase 1: Write suppression for blocking mode with degraded types ──
+describe("generateFromEntryPoint — Phase 1: anti-clobber for blocking mode", () => {
+  const antiClobberDir = path.join(__dirname, "__output_anti_clobber__");
+  const queryFolder = path.join(antiClobberDir, "queries");
+  const metricViewsFolder = path.join(antiClobberDir, "metric-views");
+  const outFile = path.join(antiClobberDir, "generated", "analytics.d.ts");
+  const metricFile = path.join(antiClobberDir, "generated", "metric-views.d.ts");
+
+  const degradedQuerySchema = (name: string) => ({
+    name,
+    type: `{ name: "${name}"; parameters: Record<string, never>; result: unknown; }`,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.cacheFile.contents = undefined;
+    fs.rmSync(antiClobberDir, { recursive: true, force: true });
+    fs.mkdirSync(queryFolder, { recursive: true });
+    fs.mkdirSync(metricViewsFolder, { recursive: true });
+    mocks.generateQueriesFromDescribe.mockResolvedValue({
+      schemas: [],
+      syntaxErrors: [],
+      fatalErrors: [],
+    });
+  });
+
+  afterAll(() => {
+    fs.rmSync(antiClobberDir, { recursive: true, force: true });
+  });
+
+  test("blocking mode + degraded query (no errors): no write to outFile (queries .d.ts)", async () => {
+    mocks.generateQueriesFromDescribe.mockResolvedValue({
+      schemas: [degradedQuerySchema("offline_query")],
+      syntaxErrors: [],
+      fatalErrors: [],
+    });
+
+    // Pre-write a "good" committed file so we can verify it's NOT overwritten
+    fs.mkdirSync(path.dirname(outFile), { recursive: true });
+    const committedContent =
+      "// Committed good types\nexport const GOOD_VERSION = true;";
+    fs.writeFileSync(outFile, committedContent, "utf-8");
+
+    // Run in blocking mode with degraded query and NO errors
+    await expect(
+      generateFromEntryPoint({
+        outFile,
+        queryFolder,
+        warehouseId: "wh-1",
+        mode: "blocking",
+      }),
+    ).resolves.toBeUndefined();
+
+    // The committed file must NOT be overwritten with degraded types
+    const finalContent = fs.readFileSync(outFile, "utf-8");
+    expect(finalContent).toBe(committedContent);
+    expect(finalContent).not.toContain("offline_query");
+  });
+
+  test("blocking mode + non-degraded query: writes to outFile normally", async () => {
+    mocks.generateQueriesFromDescribe.mockResolvedValue({
+      schemas: [
+        {
+          name: "good_query",
+          type: `{ name: "good_query"; parameters: Record<string, never>; result: Array<{ id: number; }> }`,
+        },
+      ],
+      syntaxErrors: [],
+      fatalErrors: [],
+    });
+
+    await expect(
+      generateFromEntryPoint({
+        outFile,
+        queryFolder,
+        warehouseId: "wh-1",
+        mode: "blocking",
+      }),
+    ).resolves.toBeUndefined();
+
+    // File should be written with good types
+    const content = fs.readFileSync(outFile, "utf-8");
+    expect(content).toContain("interface QueryRegistry");
+    expect(content).toContain("good_query");
+  });
+
+  test("non-blocking mode + degraded query: writes to outFile anyway", async () => {
+    mocks.generateQueriesFromDescribe.mockResolvedValue({
+      schemas: [degradedQuerySchema("offline_query")],
+      syntaxErrors: [],
+      fatalErrors: [],
+    });
+
+    await expect(
+      generateFromEntryPoint({
+        outFile,
+        queryFolder,
+        warehouseId: "wh-1",
+        mode: "non-blocking",
+      }),
+    ).resolves.toBeUndefined();
+
+    // In non-blocking mode, the file is written even with degraded types
+    const content = fs.readFileSync(outFile, "utf-8");
+    expect(content).toContain("interface QueryRegistry");
+    expect(content).toContain("offline_query");
+  });
+
+  test("blocking mode + degraded metric (no failures): no write to metric-views.d.ts", async () => {
+    fs.writeFileSync(
+      path.join(metricViewsFolder, "definitions.json"),
+      JSON.stringify({
+        metricViews: { revenue: { source: "demo.sales.revenue" } },
+      }),
+    );
+
+    // Pre-write a "good" committed metric file
+    fs.mkdirSync(path.dirname(metricFile), { recursive: true });
+    const committedMetricContent =
+      "// Committed good metric types\nexport const GOOD_METRIC = true;";
+    fs.writeFileSync(metricFile, committedMetricContent, "utf-8");
+
+    // Inject a fetcher that returns PENDING (non-terminal, triggers degradation with NO failures)
+    await expect(
+      generateFromEntryPoint({
+        outFile,
+        queryFolder,
+        warehouseId: "wh-1",
+        mode: "blocking",
+        metricFetcher: async () => ({
+          statement_id: "stmt-mock",
+          status: { state: "PENDING" },
+        }),
+      }),
+    ).resolves.toBeUndefined();
+
+    // The committed metric file must NOT be overwritten with degraded types
+    const finalMetricContent = fs.readFileSync(metricFile, "utf-8");
+    expect(finalMetricContent).toBe(committedMetricContent);
+    expect(finalMetricContent).not.toContain("revenue");
+  });
+
+  test("blocking mode + degraded query WITH syntax errors: no write to outFile, still throws", async () => {
+    mocks.generateQueriesFromDescribe.mockResolvedValue({
+      schemas: [degradedQuerySchema("bad_query")],
+      syntaxErrors: [{ name: "bad_query", message: "Table not found" }],
+      fatalErrors: [],
+    });
+
+    fs.mkdirSync(path.dirname(outFile), { recursive: true });
+
+    const error = await generateFromEntryPoint({
+      outFile,
+      queryFolder,
+      warehouseId: "wh-1",
+      mode: "blocking",
+    }).then(
+      () => {
+        throw new Error("expected generateFromEntryPoint to reject");
+      },
+      (err: unknown) => err,
+    );
+
+    expect(error).toBeInstanceOf(TypegenSyntaxError);
+    // Phase 1: degraded artifacts are NOT written in blocking mode (committed types preserved).
+    expect(fs.existsSync(outFile)).toBe(false);
+  });
+
+  test("blocking mode + non-degraded metric: writes to metric-views.d.ts normally", async () => {
+    fs.writeFileSync(
+      path.join(metricViewsFolder, "definitions.json"),
+      JSON.stringify({
+        metricViews: { revenue: { source: "demo.sales.revenue" } },
+      }),
+    );
+
+    const describeResponse: DatabricksStatementExecutionResponse = {
+      statement_id: "stmt-mock",
+      status: { state: "SUCCEEDED" },
+      result: {
+        data_array: [
+          [
+            JSON.stringify({
+              columns: [
+                {
+                  name: "total_revenue",
+                  type: "DECIMAL(38,2)",
+                  is_measure: true,
+                },
+                { name: "region", type: "STRING", is_measure: false },
+              ],
+            }),
+          ],
+        ],
+      },
+    };
+
+    mocks.getWarehouseState.mockResolvedValue("RUNNING");
+    mocks.executeStatement.mockResolvedValue(describeResponse);
+
+    await expect(
+      generateFromEntryPoint({
+        outFile,
+        queryFolder,
+        warehouseId: "wh-1",
+        mode: "blocking",
+      }),
+    ).resolves.toBeUndefined();
+
+    // File should be written with good types
+    const content = fs.readFileSync(metricFile, "utf-8");
+    expect(content).toContain("interface MetricRegistry");
+    expect(content).toContain("revenue");
+    expect(content).toContain('"total_revenue": number');
+  });
+
+  test("non-blocking mode + degraded metric: writes to metric-views.d.ts anyway", async () => {
+    fs.writeFileSync(
+      path.join(metricViewsFolder, "definitions.json"),
+      JSON.stringify({
+        metricViews: { revenue: { source: "demo.sales.revenue" } },
+      }),
+    );
+
+    mocks.getWarehouseState.mockResolvedValue("STOPPED");
+
+    await expect(
+      generateFromEntryPoint({
+        outFile,
+        queryFolder,
+        warehouseId: "wh-1",
+        mode: "non-blocking",
+      }),
+    ).resolves.toBeUndefined();
+
+    // In non-blocking mode, the file is written even with degraded types
+    const content = fs.readFileSync(metricFile, "utf-8");
+    expect(content).toContain("interface MetricRegistry");
+    expect(content).toContain("revenue");
+    expect(content).toContain("measureKeys: string"); // Permissive degraded type
+  });
+
+  test("blocking mode + degraded query (no syntax/fatal errors): resolves without write", async () => {
+    // When a query is degraded but there are no syntax or fatal errors,
+    // the function resolves normally. In blocking mode, the degraded write
+    // is suppressed, so outFile is not written.
+    mocks.generateQueriesFromDescribe.mockResolvedValue({
+      schemas: [degradedQuerySchema("offline_query")],
+      syntaxErrors: [],
+      fatalErrors: [],
+    });
+
+    await expect(
+      generateFromEntryPoint({
+        outFile,
+        queryFolder,
+        warehouseId: "wh-1",
+        mode: "blocking",
+      }),
+    ).resolves.toBeUndefined();
+
+    // The file was not written because the query was degraded in blocking mode
+    expect(fs.existsSync(outFile)).toBe(false);
+  });
+
+  test("blocking mode + degraded query WITH fatal errors (auth/bad-id): no write to outFile, still throws TypegenFatalError", async () => {
+    // This test covers the fresh-CI-checkout fatal-degrade clobber-prevention case:
+    // a degraded schema result with fatal errors (not syntax errors) should NOT write
+    // artifacts in blocking mode, yet should still throw TypegenFatalError.
+    mocks.generateQueriesFromDescribe.mockResolvedValue({
+      schemas: [
+        {
+          name: "bad_query",
+          type: `{ name: "bad_query"; parameters: Record<string, never>; result: unknown; }`,
+        },
+      ],
+      syntaxErrors: [],
+      fatalErrors: [{ name: "bad_query", message: "warehouse wh-1: auth failed" }],
+    });
+
+    fs.mkdirSync(path.dirname(outFile), { recursive: true });
+
+    const error = await generateFromEntryPoint({
+      outFile,
+      queryFolder,
+      warehouseId: "wh-1",
+      mode: "blocking",
+    }).then(
+      () => {
+        throw new Error("expected generateFromEntryPoint to reject");
+      },
+      (err: unknown) => err,
+    );
+
+    expect(error).toBeInstanceOf(TypegenFatalError);
+    // Phase 1: degraded artifacts are NOT written in blocking mode (committed types preserved).
+    expect(fs.existsSync(outFile)).toBe(false);
+  });
 });

--- a/packages/appkit/src/type-generator/tests/index.test.ts
+++ b/packages/appkit/src/type-generator/tests/index.test.ts
@@ -2313,8 +2313,7 @@ describe("generateFromEntryPoint — warning message with cause labels", () => {
     }
   });
 
-  test("CI=true: warning output is ANSI-free (plain text for log parsing)", async () => {
-    process.env.CI = "true";
+  test("warning output is ANSI-free (plain text for CI log parsing)", async () => {
     // Query path returns environmental failure
     mocks.generateQueriesFromDescribe.mockResolvedValue({
       schemas: [],
@@ -2347,7 +2346,6 @@ describe("generateFromEntryPoint — warning message with cause labels", () => {
       expect(warnings).toContain("wh-ci");
       expect(warnings).toContain("warehouse unavailable");
     } finally {
-      delete process.env.CI;
       warnSpy.mockRestore();
     }
   });

--- a/packages/appkit/src/type-generator/tests/unreachable-warehouse-gate.test.ts
+++ b/packages/appkit/src/type-generator/tests/unreachable-warehouse-gate.test.ts
@@ -1,0 +1,152 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+
+/**
+ * End-to-end coverage for the `--wait` has-types gate when the warehouse is
+ * unreachable.
+ *
+ * The sibling `index.test.ts` mocks `generateQueriesFromDescribe`, so its gate
+ * tests hand the entry point a `hadEnvironmentalFailure: true` they wrote
+ * themselves — they would still pass if the query path never set that flag.
+ * That is exactly how the original bug survived: the query path reported
+ * `false` for a connectivity failure and no test joined the two halves.
+ *
+ * Here only the SDK boundary is mocked. The real query path classifies the
+ * failure and the real gate decides, so a regression in either half fails a
+ * test.
+ */
+
+const mocks = vi.hoisted(() => ({
+  getWarehouse: vi.fn(),
+  executeStatement: vi.fn(),
+}));
+
+vi.mock("@databricks/sdk-experimental", () => ({
+  WorkspaceClient: vi.fn(() => ({
+    statementExecution: { executeStatement: mocks.executeStatement },
+    warehouses: { get: mocks.getWarehouse, start: vi.fn() },
+  })),
+}));
+
+// Keep the on-disk typegen cache out of play: a reused cached type would mask
+// the degrade this test depends on.
+vi.mock("../cache", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../cache")>();
+  return {
+    ...actual,
+    loadCache: vi.fn(async () => ({
+      version: actual.CACHE_VERSION,
+      queries: {},
+    })),
+    saveCache: vi.fn(),
+  };
+});
+
+const { generateFromEntryPoint, TypegenFatalError } = await import("../index");
+
+const testDir = path.join(__dirname, "__output_unreachable_gate__");
+const queryFolder = path.join(testDir, "queries");
+const outFile = path.join(testDir, "generated", "analytics.d.ts");
+
+/** DNS-style transport failure: what a CI runner without warehouse egress sees. */
+function unreachableError() {
+  return Object.assign(new Error("getaddrinfo ENOTFOUND x.databricks.com"), {
+    code: "ENOTFOUND",
+  });
+}
+
+describe("--wait gate: unreachable warehouse (real query path)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fs.rmSync(testDir, { recursive: true, force: true });
+    fs.mkdirSync(queryFolder, { recursive: true });
+    fs.writeFileSync(
+      path.join(queryFolder, "users.sql"),
+      "SELECT id FROM users",
+      "utf-8",
+    );
+    mocks.getWarehouse.mockRejectedValue(unreachableError());
+  });
+
+  afterAll(() => {
+    fs.rmSync(testDir, { recursive: true, force: true });
+  });
+
+  test("no committed types → crashes with the run-locally remedy instead of exiting 0", async () => {
+    const err = await generateFromEntryPoint({
+      outFile,
+      queryFolder,
+      warehouseId: "wh-unreachable",
+      mode: "blocking",
+    }).then(
+      () => undefined,
+      (e: unknown) => e,
+    );
+
+    // The regression this guards: the run used to resolve, write nothing, and
+    // exit 0 — leaving the build to fail later with no usable diagnostic.
+    expect(err).toBeInstanceOf(TypegenFatalError);
+    expect((err as Error).message).toContain("generate-types --wait");
+    expect(fs.existsSync(outFile)).toBe(false);
+    // Preflight failed, so no DESCRIBE was attempted.
+    expect(mocks.executeStatement).not.toHaveBeenCalled();
+  });
+
+  test("committed types present → warns 'warehouse unreachable' and keeps them", async () => {
+    fs.mkdirSync(path.dirname(outFile), { recursive: true });
+    const committed = "// committed types\n";
+    fs.writeFileSync(outFile, committed, "utf-8");
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await generateFromEntryPoint({
+        outFile,
+        queryFolder,
+        warehouseId: "wh-unreachable",
+        mode: "blocking",
+      });
+
+      const warnings = warnSpy.mock.calls
+        .flat()
+        .map(String)
+        .filter((s) => s.includes("AppKit typegen"))
+        .join("\n");
+
+      expect(warnings).toContain("AppKit typegen: using committed types");
+      expect(warnings).toContain("wh-unreachable");
+      // The label the query path now supplies; it was unreachable in practice
+      // while connectivity failures reported no cause at all.
+      expect(warnings).toContain("warehouse unreachable");
+      // Anti-clobber: the degraded result must not overwrite what was committed.
+      expect(fs.readFileSync(outFile, "utf-8")).toBe(committed);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test("non-blocking mode stays silent and writes degraded types", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      // Must not throw: the non-blocking default never fails on warehouse state.
+      await generateFromEntryPoint({
+        outFile,
+        queryFolder,
+        warehouseId: "wh-unreachable",
+        mode: "non-blocking",
+      });
+
+      const gateWarnings = warnSpy.mock.calls
+        .flat()
+        .map(String)
+        .filter((s) => s.includes("using committed types"));
+
+      expect(gateWarnings).toEqual([]);
+      // Degraded types are written here — the gate is blocking-only.
+      expect(fs.existsSync(outFile)).toBe(true);
+      expect(fs.readFileSync(outFile, "utf-8")).toContain("result: unknown");
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});

--- a/packages/appkit/src/type-generator/tests/unreachable-warehouse-gate.test.ts
+++ b/packages/appkit/src/type-generator/tests/unreachable-warehouse-gate.test.ts
@@ -12,7 +12,7 @@ import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
  * That is exactly how the original bug survived: the query path reported
  * `false` for a connectivity failure and no test joined the two halves.
  *
- * Here only the SDK boundary is mocked. The real query path classifies the
+ * Here only the client boundary is mocked. The real query path classifies the
  * failure and the real gate decides, so a regression in either half fails a
  * test.
  */
@@ -22,12 +22,21 @@ const mocks = vi.hoisted(() => ({
   executeStatement: vi.fn(),
 }));
 
-vi.mock("@databricks/sdk-experimental", () => ({
-  WorkspaceClient: vi.fn(() => ({
-    statementExecution: { executeStatement: mocks.executeStatement },
-    warehouses: { get: mocks.getWarehouse, start: vi.fn() },
-  })),
-}));
+// Stub the wrapper, not `@databricks/sdk-experimental` underneath it: the
+// wrapper re-exports SDK values (`ConfigError`, `Context`, `Time`, `TimeUnits`)
+// that a bare SDK factory mock would drop, breaking module init. Spreading
+// `importOriginal` keeps those intact while swapping only the factory.
+vi.mock("../../workspace-client", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../workspace-client")>();
+  return {
+    ...actual,
+    createWorkspaceClient: () => ({
+      statementExecution: { executeStatement: mocks.executeStatement },
+      warehouses: { get: mocks.getWarehouse, start: vi.fn() },
+    }),
+  };
+});
 
 // Keep the on-disk typegen cache out of play: a reused cached type would mask
 // the degrade this test depends on.

--- a/packages/appkit/src/type-generator/tests/unreachable-warehouse-gate.test.ts
+++ b/packages/appkit/src/type-generator/tests/unreachable-warehouse-gate.test.ts
@@ -3,8 +3,8 @@ import path from "node:path";
 import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
 
 /**
- * End-to-end coverage for the `--wait` has-types gate when the warehouse is
- * unreachable.
+ * End-to-end coverage for the `--wait` has-types gate when query DESCRIBE
+ * cannot produce a schema for environmental reasons.
  *
  * The sibling `index.test.ts` mocks `generateQueriesFromDescribe`, so its gate
  * tests hand the entry point a `hadEnvironmentalFailure: true` they wrote
@@ -65,7 +65,7 @@ function unreachableError() {
   });
 }
 
-describe("--wait gate: unreachable warehouse (real query path)", () => {
+describe("--wait gate: environmental query failures (real query path)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     fs.rmSync(testDir, { recursive: true, force: true });
@@ -128,6 +128,58 @@ describe("--wait gate: unreachable warehouse (real query path)", () => {
       // while connectivity failures reported no cause at all.
       expect(warnings).toContain("warehouse unreachable");
       // Anti-clobber: the degraded result must not overwrite what was committed.
+      expect(fs.readFileSync(outFile, "utf-8")).toBe(committed);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test("non-terminal DESCRIBE + no committed types → crashes instead of silently exiting 0", async () => {
+    mocks.getWarehouse.mockResolvedValue({ state: "RUNNING" });
+    mocks.executeStatement.mockResolvedValue({
+      statement_id: "stmt-pending",
+      status: { state: "PENDING" },
+    });
+
+    const err = await generateFromEntryPoint({
+      outFile,
+      queryFolder,
+      warehouseId: "wh-scaling",
+      mode: "blocking",
+    }).then(
+      () => undefined,
+      (e: unknown) => e,
+    );
+
+    expect(err).toBeInstanceOf(TypegenFatalError);
+    expect((err as Error).message).toContain("generate-types --wait");
+    expect(fs.existsSync(outFile)).toBe(false);
+  });
+
+  test("non-terminal DESCRIBE + committed types → warns unavailable and keeps them", async () => {
+    mocks.getWarehouse.mockResolvedValue({ state: "RUNNING" });
+    mocks.executeStatement.mockResolvedValue({
+      statement_id: "stmt-pending",
+      status: { state: "RUNNING" },
+    });
+    fs.mkdirSync(path.dirname(outFile), { recursive: true });
+    const committed = "// committed types\n";
+    fs.writeFileSync(outFile, committed, "utf-8");
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await expect(
+        generateFromEntryPoint({
+          outFile,
+          queryFolder,
+          warehouseId: "wh-scaling",
+          mode: "blocking",
+        }),
+      ).resolves.toBeUndefined();
+
+      const warnings = warnSpy.mock.calls.flat().map(String).join("\n");
+      expect(warnings).toContain("AppKit typegen: using committed types");
+      expect(warnings).toContain("warehouse unavailable");
       expect(fs.readFileSync(outFile, "utf-8")).toBe(committed);
     } finally {
       warnSpy.mockRestore();

--- a/packages/appkit/src/type-generator/types.ts
+++ b/packages/appkit/src/type-generator/types.ts
@@ -99,10 +99,14 @@ export const sqlTypeToHelper: Record<string, string> = {
  * Query schema interface
  * @property name - the name of the query
  * @property type - the type of the query (string, number, boolean, object, array, etc.)
+ * @property degraded - true when the schema could not be resolved and `type`
+ *   is an unknown fallback. Absent when `type` came from DESCRIBE or a matching
+ *   last-known-good cache entry.
  */
 export interface QuerySchema {
   name: string;
   type: string;
+  degraded?: boolean;
 }
 
 /**

--- a/packages/appkit/src/type-generator/types.ts
+++ b/packages/appkit/src/type-generator/types.ts
@@ -138,12 +138,21 @@ export interface QueryFatalError {
  *   warehouse (genuine SQL errors). Connectivity failures are deliberately NOT
  *   included: they degrade silently (reuse last-known-good type or emit
  *   `unknown`) so a transient outage never fails a build.
- * @property fatalErrors - non-SQL fatal describe request failures. These still
- *   produce `result: unknown` schemas so callers can write declarations before
- *   surfacing the error.
+ * @property fatalErrors - deterministic non-SQL fatal describe request failures
+ *   (404/400). These still produce `result: unknown` schemas so callers can write
+ *   declarations before surfacing the error.
+ * @property hadEnvironmentalFailure - `true` when an environmental failure occurred
+ *   in blocking mode (auth, connectivity, timeouts, or other unrecognized failures).
+ *   Used by {@link generateFromEntryPoint} to decide whether to apply the has-types
+ *   gate. Always false in non-blocking mode.
+ * @property environmentalCause - coarse cause label for the environmental failure,
+ *   one of "auth" (401/403), "unreachable" (connectivity), or "unavailable" (other).
+ *   Only set when hadEnvironmentalFailure is true; used by the warning message.
  */
 export interface QueryGenerationResult {
   schemas: QuerySchema[];
   syntaxErrors: QuerySyntaxError[];
   fatalErrors: QueryFatalError[];
+  hadEnvironmentalFailure?: boolean;
+  environmentalCause?: "auth" | "unreachable" | "unavailable";
 }


### PR DESCRIPTION
## What & why

Makes the blocking (`--wait`) type-generation path resilient for CI/CD. On a fresh CI checkout, the committed `.d.ts` files become the **fallback of record**: `--wait` never overwrites good committed types with degraded (`result: unknown`) ones, and a two-bucket failure taxonomy decides crash-vs-fall-back. The non-blocking dev/install path is untouched.

## Behavior

**Blocking (`--wait`) mode:**
- **Deterministic failures always crash**, regardless of committed types: SQL syntax errors, HTTP 404 (bad warehouse id), HTTP 400 (malformed request).
- **Environmental failures gate on committed types**: auth (401/403), connectivity, DELETED/DELETING, wait-for-RUNNING timeout, and any unrecognized failure.
  - Committed types present → skip the write, emit one loud greppable stderr warning naming the coarse cause (auth blocked / warehouse unreachable / warehouse unavailable) + warehouse id, and exit 0.
  - No committed types → crash with a generic "run `generate-types --wait` locally and commit the `.d.ts`" remedy.
- Serving types (`serving.d.ts`) are excluded from the gate (gitignored, degrade independently).

**Non-blocking mode:** unchanged — still writes best-effort/degraded types immediately and refreshes via the detached worker.

## Commits (one per phase)

1. `fix(appkit)` — anti-clobber: `--wait` never overwrites committed types on any degrade
2. `feat(appkit)` — `classifyBlockingFailure` two-bucket taxonomy (pure, in `errors.ts`)
3. `feat(appkit)` — has-types gate + loud warning + CLI terminal wiring (the join)
4. `docs` — document the CI-resilient `--wait` behavior
5. `chore` — remove implementation-phase narration and slop

## Testing

- `pnpm test` — 3763 passed / 1 skipped / 0 failed (type-generator suite: 537 across 19 files, incl. new `errors.test.ts` + gate-matrix coverage: environmental+present→warn, environmental+absent→crash, deterministic→crash, serving-exclusion, partial-presence, CI-safe warning).
- `pnpm -r typecheck`, `pnpm check` (0 errors), `pnpm build`, `pnpm docs:build` — all green.
- Runtime acceptance bar: dev-playground boots under `--conditions=development` with no `ERR_PACKAGE_PATH_NOT_EXPORTED`; no surviving `shared/<subpath>` bare imports.

## Notes

- Known v1 simplification: a metric-views-only app (no `config/queries/`) writes an empty `analytics.d.ts` on a fresh run, which satisfies the has-types gate — so an environmental failure falls back + warns rather than crashing even on a true first build. Documented in the type-generation docs.
- Built on top of the #509 revert (no committed cache; committed `.d.ts` output is the fallback).

This pull request and its description were written by Isaac.

<img width="3181" height="643" alt="typegen" src="https://github.com/user-attachments/assets/38f8715a-13a8-46b7-89f5-32c28270d207" />
