### PR TITLE
feat(appkit): cache ai-search queries with OBO-safe keys

### DIFF
--- a/docs/docs/plugins/ai-search.md
+++ b/docs/docs/plugins/ai-search.md
@@ -261,6 +261,16 @@ console.log(result.results);
 
 Pass optional overrides as a second argument to `query` to adjust `numResults` or other per-call settings.
 
+## Caching
+
+Query results are cached with a short TTL (60s) so repeated identical queries — including a component that re-renders or mounts twice — reuse a single Vector Search call instead of hitting the index each time. The next-page route is not cached: a page token is a single-use cursor and already identifies the exact page.
+
+The cache key covers everything that changes results: the resolved index, `queryText`, `queryVector` (hashed), `queryType`, `numResults`, the resolved `columns`, `filters`, and whether reranking is on. Two queries that differ in any of these are cached separately.
+
+### Per-user isolation
+
+For `auth: "on-behalf-of-user"` indexes the caller's identity is part of the cache key, so one user never sees another user's cached results — and an on-behalf-of-user query never reads a service-principal-populated entry. Service-principal indexes share a single cache entry across callers.
+
 ## React hook
 
 `useAiSearchQuery` reads the configured indexes from the plugin's client config and posts to the right `/:alias/query` route, so the UI never hardcodes an alias. With one index configured it needs no arguments; pass `{ alias }` to target a specific one.

--- a/packages/appkit/src/plugins/ai-search/ai-search.ts
+++ b/packages/appkit/src/plugins/ai-search/ai-search.ts
@@ -1,11 +1,12 @@
+import { createHash } from "node:crypto";
 import type express from "express";
-import type { IAppRouter, PluginExecutionSettings } from "shared";
+import type { CacheConfig, IAppRouter, PluginExecutionSettings } from "shared";
 import { AiSearchConnector } from "../../connectors/ai-search/client";
 import type {
   VsQueryParams,
   VsRawResponse,
 } from "../../connectors/ai-search/types";
-import { getWorkspaceClient } from "../../context";
+import { getCurrentUserId, getWorkspaceClient } from "../../context";
 import { createLogger } from "../../logging/logger";
 import { Plugin, toPlugin } from "../../plugin";
 import type { PluginManifest } from "../../registry";
@@ -166,22 +167,28 @@ export class AiSearchPlugin extends Plugin<IAiSearchConfig> {
         // projection past what the app configured. (query() callers are
         // trusted and keep the override.)
         const { columns: _clientColumns, ...safeBody } = body;
-        const plugin =
-          indexConfig.auth === "on-behalf-of-user" ? this.asUser(req) : this;
+        const isAsUser = indexConfig.auth === "on-behalf-of-user";
+        const plugin = isAsUser ? this.asUser(req) : this;
         const queryType =
           safeBody.queryType ?? indexConfig.queryType ?? "hybrid";
+
+        // Key per user for OBO so results never leak across users; SP shares "global".
+        const executorKey = isAsUser ? this.resolveUserId(req) : "global";
 
         try {
           // Prepare inside execute so a self-managed embeddingFn runs in the
           // same OBO context as the query, not as the service principal.
-          const result = await plugin.execute(async (signal) => {
-            const prepared = await this._prepareQuery(safeBody, indexConfig);
-            return this.connector.query(
-              getWorkspaceClient(),
-              { indexName: indexConfig.indexName, ...prepared },
-              signal,
-            );
-          }, querySettings);
+          const result = await plugin.execute(
+            async (signal) => {
+              const prepared = await this._prepareQuery(safeBody, indexConfig);
+              return this.connector.query(
+                getWorkspaceClient(),
+                { indexName: indexConfig.indexName, ...prepared },
+                signal,
+              );
+            },
+            this._executeSettings(safeBody, indexConfig, executorKey),
+          );
 
           this._sendResult(res, result, queryType);
         } catch (error) {
@@ -230,6 +237,8 @@ export class AiSearchPlugin extends Plugin<IAiSearchConfig> {
           const plugin =
             indexConfig.auth === "on-behalf-of-user" ? this.asUser(req) : this;
 
+          // Uncached: a page token is a single-use cursor. `querySettings` has
+          // no `cacheKey`, so caching stays off.
           const result = await plugin.execute(
             async (signal) =>
               this.connector.queryNextPage(
@@ -301,16 +310,22 @@ export class AiSearchPlugin extends Plugin<IAiSearchConfig> {
       throw new Error(`No index configured with alias "${alias}"`);
     }
 
-    const prepared = await this._prepareQuery(request, indexConfig);
+    // Resolve queryType for the response here; _prepareQuery runs inside
+    // execute so a cache hit skips the embedding and the VS call.
+    const { queryType } = this._resolveQueryParams(request, indexConfig);
 
+    // getCurrentUserId() is the user's id under asUser(), the service id
+    // otherwise — keying per caller like the route's executorKey.
     const result = await this.execute(
-      async (signal) =>
-        this.connector.query(
+      async (signal) => {
+        const prepared = await this._prepareQuery(request, indexConfig);
+        return this.connector.query(
           getWorkspaceClient(),
           { indexName: indexConfig.indexName, ...prepared },
           signal,
-        ),
-      querySettings,
+        );
+      },
+      this._executeSettings(request, indexConfig, getCurrentUserId()),
     );
 
     if (!result.ok) {
@@ -319,7 +334,7 @@ export class AiSearchPlugin extends Plugin<IAiSearchConfig> {
       );
     }
 
-    return this._parseResponse(result.data, prepared.queryType);
+    return this._parseResponse(result.data, queryType);
   }
 
   async shutdown(): Promise<void> {
@@ -373,11 +388,31 @@ export class AiSearchPlugin extends Plugin<IAiSearchConfig> {
     res.json(this._parseResponse(result.data, queryType));
   }
 
+  /**
+   * Resolve request-vs-index defaults for the result-determining fields.
+   * Shared by `_prepareQuery` (the payload) and `_cacheKeyFor` (the key) so
+   * the two can't drift.
+   */
+  private _resolveQueryParams(
+    request: SearchRequest,
+    indexConfig: IndexConfig,
+  ): Pick<VsQueryParams, "queryType" | "columns" | "numResults" | "reranker"> {
+    const queryType = request.queryType ?? indexConfig.queryType ?? "hybrid";
+    const columns = request.columns ?? indexConfig.columns ?? [];
+    return {
+      queryType,
+      columns,
+      numResults: request.numResults ?? indexConfig.numResults ?? 20,
+      reranker: this._resolveReranker(request.reranker, indexConfig, columns),
+    };
+  }
+
   private async _prepareQuery(
     request: SearchRequest,
     indexConfig: IndexConfig,
   ): Promise<Omit<VsQueryParams, "indexName">> {
-    const queryType = request.queryType ?? indexConfig.queryType ?? "hybrid";
+    const { queryType, columns, numResults, reranker } =
+      this._resolveQueryParams(request, indexConfig);
     let queryText = request.queryText;
     let queryVector = request.queryVector;
 
@@ -398,16 +433,78 @@ export class AiSearchPlugin extends Plugin<IAiSearchConfig> {
       }
     }
 
-    const columns = request.columns ?? indexConfig.columns ?? [];
     return {
       queryText,
       queryVector,
       queryType,
       columns,
-      numResults: request.numResults ?? indexConfig.numResults ?? 20,
+      numResults,
       filters: request.filters,
-      reranker: this._resolveReranker(request.reranker, indexConfig, columns),
+      reranker,
     };
+  }
+
+  /**
+   * Cache key for a query: every input that changes the VS result, resolved
+   * via `_resolveQueryParams` so the key matches the payload (post-allowlist
+   * `columns`, not the raw request). `queryVector` is hashed (vectors are
+   * large); the key uses `queryText`, not the derived embedding, since the
+   * embedding is a function of `queryText` and hasn't run at key-build time.
+   * `columns`/`filters` are order-normalized so equivalent requests share an
+   * entry.
+   */
+  private _cacheKeyFor(
+    request: SearchRequest,
+    indexConfig: IndexConfig & { indexName: string },
+    executorKey: string,
+  ): CacheConfig["cacheKey"] {
+    const { queryType, columns, numResults, reranker } =
+      this._resolveQueryParams(request, indexConfig);
+    return [
+      "ai-search:query",
+      indexConfig.indexName,
+      request.queryText ?? "",
+      request.queryVector ? this._hashVector(request.queryVector) : "",
+      queryType,
+      numResults,
+      // columns is a projection; order doesn't affect results, so sort a copy.
+      JSON.stringify([...columns].sort()),
+      this._stableStringify(request.filters ?? null),
+      String(!!reranker),
+      executorKey,
+    ];
+  }
+
+  private _hashVector(vector: number[]): string {
+    return createHash("sha256").update(JSON.stringify(vector)).digest("hex");
+  }
+
+  /** Execute settings with the per-call cache key folded in. */
+  private _executeSettings(
+    request: SearchRequest,
+    indexConfig: IndexConfig & { indexName: string },
+    executorKey: string,
+  ): PluginExecutionSettings {
+    return {
+      default: {
+        ...aiSearchDefaults,
+        cache: {
+          ...aiSearchDefaults.cache,
+          cacheKey: this._cacheKeyFor(request, indexConfig, executorKey),
+        },
+      },
+    };
+  }
+
+  /** `JSON.stringify` with object keys sorted recursively; array order kept. */
+  private _stableStringify(value: unknown): string {
+    return JSON.stringify(value, (_key, val) =>
+      val && typeof val === "object" && !Array.isArray(val)
+        ? Object.fromEntries(
+            Object.entries(val).sort(([a], [b]) => a.localeCompare(b)),
+          )
+        : val,
+    );
   }
 
   private _resolveReranker(

--- a/packages/appkit/src/plugins/ai-search/defaults.ts
+++ b/packages/appkit/src/plugins/ai-search/defaults.ts
@@ -1,7 +1,9 @@
 import type { PluginExecuteConfig } from "shared";
 
 export const aiSearchDefaults: PluginExecuteConfig = {
-  cache: { enabled: false },
+  // Short TTL: VS results shift as the index resyncs, so cache only long
+  // enough to absorb bursts without serving stale results.
+  cache: { enabled: true, ttl: 60 },
   retry: { enabled: true, initialDelay: 1000, attempts: 3 },
   timeout: 30_000,
 };

--- a/packages/appkit/src/plugins/ai-search/tests/ai-search.test.ts
+++ b/packages/appkit/src/plugins/ai-search/tests/ai-search.test.ts
@@ -9,6 +9,15 @@ import { Context } from "../../../workspace-client";
 vi.mock("../../../context", () => ({
   getWorkspaceClient: vi.fn(() => mockWorkspaceClient),
   getCurrentUserId: vi.fn(() => "test-user"),
+  // OBO plumbing so asUser() runs its non-dev path. getCurrentUserId stays
+  // constant, so per-user scoping is driven by executorKey in the cacheKey.
+  runInUserContext: <T>(_ctx: unknown, fn: () => T): T => fn(),
+  ServiceContext: {
+    createUserContext: (_token: string, userId: string) => ({
+      userId,
+      isUserContext: true,
+    }),
+  },
 }));
 
 vi.mock("../../../logging/logger", () => ({
@@ -53,16 +62,37 @@ vi.mock("../../../telemetry", () => ({
   normalizeTelemetryOptions: () => ({ traces: false, metrics: false }),
 }));
 
-vi.mock("../../../cache", () => ({
-  CacheManager: {
-    getInstanceSync: () => ({
-      get: vi.fn(),
-      set: vi.fn(),
-      delete: vi.fn(),
-      generateKey: vi.fn(() => "test-key"),
-    }),
-  },
+// In-memory cache keyed like the real CacheManager.generateKey, so tests
+// exercise real key composition. Never stores rejections.
+const { mockCacheStore } = vi.hoisted(() => ({
+  mockCacheStore: new Map<string, unknown>(),
 }));
+
+vi.mock("../../../cache", () => {
+  const keyOf = (parts: unknown[], userKey: string) =>
+    JSON.stringify([userKey, ...parts]);
+  return {
+    CacheManager: {
+      getInstanceSync: () => ({
+        get: vi.fn(),
+        set: vi.fn(),
+        delete: vi.fn(),
+        generateKey: keyOf,
+        getOrExecute: async (
+          key: unknown[],
+          fn: (signal?: AbortSignal) => Promise<unknown>,
+          userKey: string,
+        ) => {
+          const k = keyOf(key, userKey);
+          if (mockCacheStore.has(k)) return mockCacheStore.get(k);
+          const result = await fn();
+          mockCacheStore.set(k, result);
+          return result;
+        },
+      }),
+    },
+  };
+});
 
 vi.mock("../../../app", () => ({
   AppManager: vi.fn().mockImplementation(() => ({})),
@@ -108,6 +138,7 @@ describe("AiSearchPlugin", () => {
   beforeEach(() => {
     mockRequest.mockClear();
     mockRequest.mockResolvedValue(validVsResponse);
+    mockCacheStore.clear();
   });
 
   describe("setup()", () => {
@@ -664,6 +695,236 @@ describe("AiSearchPlugin", () => {
       await expect(
         plugin.query("products", { queryText: "q" }),
       ).rejects.toThrow(/Vector search query failed for index "products"/);
+    });
+  });
+
+  describe("caching", () => {
+    const makePlugin = () =>
+      new AiSearchPlugin({
+        indexes: {
+          products: {
+            indexName: "cat.sch.products",
+            columns: ["id", "title"],
+            queryType: "hybrid",
+            numResults: 10,
+          },
+        },
+      });
+
+    it("serves an identical query from cache (connector called once)", async () => {
+      const plugin = makePlugin();
+      await plugin.setup();
+
+      await plugin.query("products", { queryText: "machine learning" });
+      await plugin.query("products", { queryText: "machine learning" });
+
+      expect(mockRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([
+      ["queryText", { queryText: "different" }],
+      ["numResults", { queryText: "q", numResults: 5 }],
+      ["queryType", { queryText: "q", queryType: "ann" as const }],
+      ["columns", { queryText: "q", columns: ["id"] }],
+      ["filters", { queryText: "q", filters: { category: ["books"] } }],
+      ["reranker", { queryText: "q", reranker: true }],
+    ])(
+      "does not share cache entries when %s differs (2 connector calls)",
+      async (_field, second) => {
+        const plugin = makePlugin();
+        await plugin.setup();
+
+        await plugin.query("products", { queryText: "q" });
+        await plugin.query("products", second);
+
+        expect(mockRequest).toHaveBeenCalledTimes(2);
+      },
+    );
+
+    it("shares a cache entry for filters that differ only in key order", async () => {
+      const plugin = makePlugin();
+      await plugin.setup();
+
+      // Same filter semantics, different key insertion order — must hit the
+      // same entry (the key stable-stringifies object keys).
+      await plugin.query("products", {
+        queryText: "q",
+        filters: { category: ["books"], inStock: true },
+      });
+      await plugin.query("products", {
+        queryText: "q",
+        filters: { inStock: true, category: ["books"] },
+      });
+
+      expect(mockRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it("still splits entries when filter values differ", async () => {
+      const plugin = makePlugin();
+      await plugin.setup();
+
+      // Guard against over-merging: only key ORDER is normalized, not values.
+      await plugin.query("products", {
+        queryText: "q",
+        filters: { category: ["books"] },
+      });
+      await plugin.query("products", {
+        queryText: "q",
+        filters: { category: ["films"] },
+      });
+
+      expect(mockRequest).toHaveBeenCalledTimes(2);
+    });
+
+    it("shares a cache entry for the same columns in a different order", async () => {
+      const plugin = makePlugin();
+      await plugin.setup();
+
+      // columns is a projection list — order doesn't change results, so a
+      // reordered projection must reuse the entry (key sorts a copy).
+      await plugin.query("products", {
+        queryText: "q",
+        columns: ["id", "title"],
+      });
+      await plugin.query("products", {
+        queryText: "q",
+        columns: ["title", "id"],
+      });
+
+      expect(mockRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it("keys managed-embedding queries by queryText, skipping embedding on a route cache hit", async () => {
+      // Keyed by queryText, not the derived vector; the hit skips embeddingFn.
+      const embeddingFn = vi.fn().mockResolvedValue([0.1, 0.2, 0.3]);
+      const plugin = new AiSearchPlugin({
+        indexes: {
+          docs: {
+            indexName: "cat.sch.docs",
+            columns: ["id", "title"],
+            queryType: "ann",
+            embeddingFn,
+          },
+        },
+      });
+      await plugin.setup();
+
+      const { router, getHandler } = createMockRouter();
+      plugin.injectRoutes(router);
+      const handler = getHandler("POST", "/:alias/query");
+      const run = () =>
+        handler(
+          createMockRequest({
+            params: { alias: "docs" },
+            body: { queryText: "same" },
+          }),
+          createMockResponse(),
+        );
+
+      await run();
+      await run();
+
+      expect(mockRequest).toHaveBeenCalledTimes(1);
+      expect(embeddingFn).toHaveBeenCalledTimes(1);
+    });
+
+    it("skips embedding on a programmatic query() cache hit too", async () => {
+      const embeddingFn = vi.fn().mockResolvedValue([0.1, 0.2, 0.3]);
+      const plugin = new AiSearchPlugin({
+        indexes: {
+          docs: {
+            indexName: "cat.sch.docs",
+            columns: ["id", "title"],
+            queryType: "ann",
+            embeddingFn,
+          },
+        },
+      });
+      await plugin.setup();
+
+      await plugin.query("docs", { queryText: "same" });
+      await plugin.query("docs", { queryText: "same" });
+
+      expect(mockRequest).toHaveBeenCalledTimes(1);
+      expect(embeddingFn).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not share cache across OBO users (per-user cache key)", async () => {
+      const plugin = new AiSearchPlugin({
+        indexes: {
+          docs: {
+            indexName: "cat.sch.docs",
+            columns: ["id", "title"],
+            auth: "on-behalf-of-user",
+          },
+        },
+      });
+      await plugin.setup();
+
+      const { router, getHandler } = createMockRouter();
+      plugin.injectRoutes(router);
+      const handler = getHandler("POST", "/:alias/query");
+
+      const runAs = async (user: string) => {
+        const res = createMockResponse();
+        await handler(
+          createMockRequest({
+            params: { alias: "docs" },
+            body: { queryText: "shared question" },
+            headers: {
+              "x-forwarded-user": user,
+              "x-forwarded-access-token": "tok",
+            },
+          }),
+          res,
+        );
+        return res;
+      };
+
+      const resA = await runAs("alice");
+      const resB = await runAs("bob");
+
+      // Same query text, different users → distinct keys → both hit the
+      // connector. A shared entry would collapse this to one call and leak
+      // alice's results to bob.
+      expect(mockRequest).toHaveBeenCalledTimes(2);
+      expect(resA.json).toHaveBeenCalled();
+      expect(resB.json).toHaveBeenCalled();
+    });
+
+    it("re-serves the same OBO user from cache (connector called once)", async () => {
+      const plugin = new AiSearchPlugin({
+        indexes: {
+          docs: {
+            indexName: "cat.sch.docs",
+            columns: ["id", "title"],
+            auth: "on-behalf-of-user",
+          },
+        },
+      });
+      await plugin.setup();
+
+      const { router, getHandler } = createMockRouter();
+      plugin.injectRoutes(router);
+      const handler = getHandler("POST", "/:alias/query");
+
+      const runAsAlice = () =>
+        handler(
+          createMockRequest({
+            params: { alias: "docs" },
+            body: { queryText: "shared question" },
+            headers: {
+              "x-forwarded-user": "alice",
+              "x-forwarded-access-token": "tok",
+            },
+          }),
+          createMockResponse(),
+        );
+
+      await runAsAlice();
+      await runAsAlice();
+
+      expect(mockRequest).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
## Problem

`aiSearch` did no caching. Two gaps compounded: `aiSearchDefaults` had `cache: { enabled: false }`, and — more importantly — none of the `execute()` calls passed a `cacheKey`. The `CacheInterceptor` only engages when `cache.enabled && cache.cacheKey?.length` (see `plugin.ts` `_buildInterceptors`), so caching never engaged even if `enabled` were flipped.

## What this does

Wires up query caching, mirroring the analytics plugin's per-call config pattern.

- **Enable cache** in `aiSearchDefaults` with a short **60s TTL**. Vector Search results shift as the index resyncs, so the cache only lives long enough to absorb bursts (repeated queries, React StrictMode double-mounts) without serving stale results for long.
- **Per-call `cacheKey`** covering everything that changes a result: resolved index, `queryText`, hashed `queryVector` (vectors are large), `queryType`, `numResults`, post-allowlist `columns`, `filters`, and whether reranking is on.
- **Single source of default resolution** (`_resolveQueryParams`) shared by `_prepareQuery` (the payload) and `_cacheKeyFor` (the key), so the key can't silently drift from what's actually sent to VS.
- **Programmatic `query()` runs `_prepareQuery` inside `execute`** now (the HTTP route already did), so a cache hit skips both `embeddingFn` and the VS call on both paths.
- **next-page is deliberately uncached**: a page token is a single-use cursor that already identifies the exact page.
- **Docs**: added a Caching section (TTL, key composition, per-user isolation) to the ai-search plugin page.

## Security invariant

OBO queries must never read a service-principal-populated cache entry or another user's entry. The caller identity is folded into the key (`"global"` for SP, the resolved user id for `auth: "on-behalf-of-user"`), **and** the interceptor independently namespaces by `context.userKey`. On the OBO path `execute` runs inside `runInUserContext`, so both cover it. SP indexes intentionally share one entry.

## Tests

Added a `caching` suite to `ai-search.test.ts` (replaced the stub cache mock with a faithful in-memory `getOrExecute` keyed like the real `CacheManager`):

- identical query twice → connector called once (hit)
- distinct keys per differing field (queryText / numResults / queryType / columns / filters / reranker) → 2 calls (parametrized)
- managed-embedding: keyed by `queryText`, embedding + connector skipped on a hit — asserted on **both** the route and programmatic paths
- OBO two users → distinct keys → both hit the connector (no cross-user leak); same user re-served from cache

## Verification

- `pnpm --filter=@databricks/appkit build:package` ✓
- `pnpm exec vitest run ai-search` — 61/61 ✓
- `pnpm -r typecheck` ✓
- `pnpm check` (biome) — exit 0 ✓