### PR TITLE
feat(cli): add 'appkit registry info' and show resource requirements on add

### DIFF
--- a/packages/shared/src/cli/commands/registry/add.ts
+++ b/packages/shared/src/cli/commands/registry/add.ts
@@ -11,6 +11,7 @@ import {
   stripNamespace,
 } from "./client";
 import { REGISTRY_REPO, type RegistryToken, resolveToken } from "./constants";
+import { extractRequirements, renderRequirements } from "./requirements";
 import { registerPluginInServer } from "./server-register";
 
 /** Subdirectories that commonly hold the frontend / server in an AppKit app. */
@@ -271,6 +272,10 @@ async function runAdd(
           manifest = JSON.parse(file.content) as PluginManifestShape;
           pluginRel = path.dirname(target);
         }
+      }
+      const requirements = extractRequirements(item);
+      if (requirements.length > 0) {
+        console.log(`\n${renderRequirements(item, requirements)}`);
       }
       pluginSummaries.push({
         importPath: `./${pluginRel}`,

--- a/packages/shared/src/cli/commands/registry/index.ts
+++ b/packages/shared/src/cli/commands/registry/index.ts
@@ -1,4 +1,5 @@
 import { Command } from "commander";
+import { registryInfoCommand } from "./info";
 import { registryListCommand, registrySearchCommand } from "./list";
 
 /**
@@ -6,6 +7,7 @@ import { registryListCommand, registrySearchCommand } from "./list";
  * Subcommands:
  *   - list: Enumerate items available in the registry
  *   - search: Find items by name, description, type, or keyword
+ *   - info: Show an item's resource requirements and dependencies
  *
  * Note: `appkit add <item>` is exposed as a top-level command (see add.ts)
  * since it is the primary entry point for consumers.
@@ -14,11 +16,13 @@ export const registryCommand = new Command("registry")
   .description("AppKit component registry commands")
   .addCommand(registryListCommand)
   .addCommand(registrySearchCommand)
+  .addCommand(registryInfoCommand)
   .addHelpText(
     "after",
     `
 Examples:
   $ appkit registry list
   $ appkit registry search kpi dashboard
+  $ appkit registry info analytics
   $ appkit add metric-card`,
   );

--- a/packages/shared/src/cli/commands/registry/info.ts
+++ b/packages/shared/src/cli/commands/registry/info.ts
@@ -1,0 +1,58 @@
+import process from "node:process";
+import { Command } from "commander";
+import pc from "picocolors";
+import { fetchRegistryItem, stripNamespace } from "./client";
+import { resolveToken } from "./constants";
+import { extractRequirements, renderRequirements } from "./requirements";
+
+async function runInfo(ref: string, opts: { json?: boolean }): Promise<void> {
+  const token = resolveToken();
+  const item = await fetchRegistryItem(stripNamespace(ref), token);
+  const rows = extractRequirements(item);
+
+  if (opts.json) {
+    console.log(
+      JSON.stringify(
+        {
+          name: item.name,
+          type: item.type,
+          dependencies: item.dependencies ?? [],
+          registryDependencies: item.registryDependencies ?? [],
+          resources: rows,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  console.log(pc.bold(item.name));
+  const deps = item.dependencies ?? [];
+  const registryDeps = item.registryDependencies ?? [];
+  if (deps.length > 0) {
+    console.log(pc.dim(`  npm dependencies: ${deps.join(", ")}`));
+  }
+  if (registryDeps.length > 0) {
+    console.log(pc.dim(`  registry dependencies: ${registryDeps.join(", ")}`));
+  }
+  console.log(`\n${renderRequirements(item, rows)}`);
+}
+
+export const registryInfoCommand = new Command("info")
+  .description("Show an item's resource requirements and dependencies")
+  .argument("<item>", "Registry item name, e.g. analytics")
+  .option("--json", "Output as JSON")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  $ appkit registry info analytics
+  $ appkit registry info @databricks-appkit/analytics --json`,
+  )
+  .action((ref: string, opts: { json?: boolean }) =>
+    runInfo(ref, opts).catch((err) => {
+      console.error(err);
+      process.exit(1);
+    }),
+  );

--- a/packages/shared/src/cli/commands/registry/requirements.test.ts
+++ b/packages/shared/src/cli/commands/registry/requirements.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import type { RegistryItem } from "./client";
+import { extractRequirements, renderRequirements } from "./requirements";
+
+function pluginItem(manifest: unknown): RegistryItem {
+  return {
+    name: "analytics",
+    files: [
+      {
+        path: "manifest.json",
+        target: "manifest.json",
+        type: "registry:file",
+        content: JSON.stringify(manifest),
+      },
+    ],
+  };
+}
+
+const ANALYTICS_MANIFEST = {
+  name: "analytics",
+  resources: {
+    required: [
+      {
+        type: "sql_warehouse",
+        resourceKey: "sql-warehouse",
+        permission: "CAN_USE",
+        description: "SQL warehouse for queries",
+        fields: {
+          id: { env: "DATABRICKS_WAREHOUSE_ID", origin: "user" },
+        },
+      },
+    ],
+    optional: [
+      {
+        type: "volume",
+        fields: { name: { env: "VOLUME_NAME", origin: "user" } },
+      },
+    ],
+  },
+};
+
+describe("extractRequirements", () => {
+  it("returns required rows first, then optional", () => {
+    const rows = extractRequirements(pluginItem(ANALYTICS_MANIFEST));
+    expect(rows.map((r) => [r.type, r.required])).toEqual([
+      ["sql_warehouse", true],
+      ["volume", false],
+    ]);
+  });
+
+  it("captures permission, fields, env and origin", () => {
+    const [warehouse] = extractRequirements(pluginItem(ANALYTICS_MANIFEST));
+    expect(warehouse.permission).toBe("CAN_USE");
+    expect(warehouse.fields).toEqual([
+      {
+        key: "id",
+        env: "DATABRICKS_WAREHOUSE_ID",
+        origin: "user",
+        description: undefined,
+      },
+    ]);
+  });
+
+  it("returns empty for a UI item with no manifest", () => {
+    const ui: RegistryItem = {
+      name: "metric-card",
+      files: [
+        {
+          path: "metric-card.tsx",
+          target: "components/metric-card.tsx",
+          type: "registry:component",
+          content: "export const MetricCard = () => null;",
+        },
+      ],
+    };
+    expect(extractRequirements(ui)).toEqual([]);
+  });
+
+  it("returns empty for a plugin with no declared resources", () => {
+    const rows = extractRequirements(
+      pluginItem({ name: "hello", resources: { required: [], optional: [] } }),
+    );
+    expect(rows).toEqual([]);
+  });
+
+  it("tolerates malformed manifest json", () => {
+    const item: RegistryItem = {
+      name: "broken",
+      files: [
+        {
+          path: "manifest.json",
+          target: "manifest.json",
+          type: "registry:file",
+          content: "{ not json",
+        },
+      ],
+    };
+    expect(extractRequirements(item)).toEqual([]);
+  });
+});
+
+describe("renderRequirements", () => {
+  it("renders a no-requirements line for items without resources", () => {
+    const out = renderRequirements(pluginItem({ name: "hello" }));
+    expect(out).toContain("no resource requirements");
+  });
+
+  it("lists each resource with its env vars and origin", () => {
+    const out = renderRequirements(pluginItem(ANALYTICS_MANIFEST));
+    expect(out).toContain("sql_warehouse");
+    expect(out).toContain("required");
+    expect(out).toContain("CAN_USE");
+    expect(out).toContain("DATABRICKS_WAREHOUSE_ID");
+    expect(out).toContain("volume");
+    expect(out).toContain("optional");
+    expect(out).toContain("VOLUME_NAME");
+  });
+});

--- a/packages/shared/src/cli/commands/registry/requirements.ts
+++ b/packages/shared/src/cli/commands/registry/requirements.ts
@@ -1,0 +1,126 @@
+import path from "node:path";
+import pc from "picocolors";
+import type { RegistryItem } from "./client";
+
+/**
+ * A single resource field as declared in a plugin manifest. `origin` is the
+ * computed classifier written by `plugin sync` (platform/static/cli/user) that
+ * says how the value reaches the running app.
+ */
+export interface RequirementField {
+  key: string;
+  env?: string;
+  origin?: string;
+  description?: string;
+}
+
+/** A resource requirement flattened for display. */
+export interface ResourceRequirementRow {
+  type: string;
+  resourceKey?: string;
+  permission?: string;
+  required: boolean;
+  description?: string;
+  fields: RequirementField[];
+}
+
+interface ManifestFieldShape {
+  env?: string;
+  origin?: string;
+  description?: string;
+}
+interface ManifestResourceShape {
+  type?: string;
+  resourceKey?: string;
+  permission?: string;
+  description?: string;
+  fields?: Record<string, ManifestFieldShape>;
+}
+interface ManifestShape {
+  resources?: {
+    required?: ManifestResourceShape[];
+    optional?: ManifestResourceShape[];
+  };
+}
+
+function toFields(
+  fields: Record<string, ManifestFieldShape> | undefined,
+): RequirementField[] {
+  return Object.entries(fields ?? {}).map(([key, f]) => ({
+    key,
+    env: f.env,
+    origin: f.origin,
+    description: f.description,
+  }));
+}
+
+function toRows(
+  resources: ManifestResourceShape[] | undefined,
+  required: boolean,
+): ResourceRequirementRow[] {
+  return (resources ?? []).map((r) => ({
+    type: r.type ?? "unknown",
+    resourceKey: r.resourceKey,
+    permission: r.permission,
+    required,
+    description: r.description,
+    fields: toFields(r.fields),
+  }));
+}
+
+/** The manifest.json file shipped by a plugin item, or null for UI items. */
+function findManifest(item: RegistryItem): ManifestShape | null {
+  const file = (item.files ?? []).find(
+    (f) => path.basename(f.target ?? f.path) === "manifest.json",
+  );
+  if (!file) return null;
+  try {
+    return JSON.parse(file.content) as ManifestShape;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extracts a plugin item's declared resource requirements (required first,
+ * then optional). Returns an empty array for UI items or plugins that declare
+ * no resources.
+ */
+export function extractRequirements(
+  item: RegistryItem,
+): ResourceRequirementRow[] {
+  const manifest = findManifest(item);
+  if (!manifest) return [];
+  return [
+    ...toRows(manifest.resources?.required, true),
+    ...toRows(manifest.resources?.optional, false),
+  ];
+}
+
+/**
+ * Renders the resource requirements for an item as human-readable lines.
+ * Returns a single "no resources" line when there are none, so callers can
+ * print unconditionally.
+ */
+export function renderRequirements(
+  item: RegistryItem,
+  rows: ResourceRequirementRow[] = extractRequirements(item),
+): string {
+  if (rows.length === 0) {
+    return pc.dim(`${item.name}: no resource requirements.`);
+  }
+
+  const lines: string[] = [pc.bold(`Resources required by ${item.name}:`)];
+  for (const row of rows) {
+    const tag = row.required ? pc.yellow("required") : pc.dim("optional");
+    const perm = row.permission ? pc.dim(` [${row.permission}]`) : "";
+    lines.push(`  ${pc.cyan(row.type)} (${tag})${perm}`);
+    if (row.description) lines.push(`    ${pc.dim(row.description)}`);
+    for (const field of row.fields) {
+      if (!field.env) continue;
+      const origin = field.origin ? pc.dim(` (${field.origin})`) : "";
+      lines.push(`    - ${field.env}${origin}`);
+    }
+  }
+  return lines.join("\n");
+}


### PR DESCRIPTION
**Stack 2/7** — base: \`feat/registry-resource-bugfixes\` (#516)

## What
- New \`appkit registry info <item>\`: prints a plugin's declared resource requirements (type, permission, required/optional, env vars, origin) plus its npm/registry deps. \`--json\` for scripting.
- \`appkit add\` prints the same requirements table per plugin as it installs, via a shared \`requirements\` module.

## Tests
7 tests: extract/render across plugin, UI, empty, and malformed manifests.

Part of the resource-aware \`appkit add\` stack (2/7).