### PR TITLE
fix(cli): classify doctor field origin via shared computeOriginFromField

### DIFF
--- a/packages/shared/src/cli/commands/doctor/resolve-targets.test.ts
+++ b/packages/shared/src/cli/commands/doctor/resolve-targets.test.ts
@@ -160,7 +160,9 @@ describe("targetsFromManifestFile", () => {
     expect(targets).toEqual([]);
   });
 
-  it("excludes value-default and platform-injected fields from envVars", () => {
+  it("keeps only user-supplied fields, excluding cli/platform/static ones", () => {
+    // A synced manifest stamps `origin`. Only the user-supplied field should
+    // reach envVars; the cli-, platform-, and static-origin fields are excluded.
     const targets = targetsFromManifestFile(
       writeManifest({
         version: "2.0",
@@ -175,6 +177,10 @@ describe("targetsFromManifestFile", () => {
                   alias: "Postgres",
                   permission: "CAN_CONNECT_AND_CREATE",
                   fields: {
+                    instanceName: {
+                      env: "LAKEBASE_INSTANCE_NAME",
+                      origin: "user",
+                    },
                     endpointPath: { env: "LAKEBASE_ENDPOINT", origin: "cli" },
                     host: {
                       env: "PGHOST",
@@ -203,7 +209,47 @@ describe("targetsFromManifestFile", () => {
       }),
     );
     const pg = targets.find((t) => t.type === "postgres");
-    expect(pg?.envVars).toEqual(["LAKEBASE_ENDPOINT"]);
+    expect(pg?.envVars).toEqual(["LAKEBASE_INSTANCE_NAME"]);
+  });
+
+  it("excludes cli-origin fields, whether stamped or derived from `resolve`", () => {
+    // A stamped `origin: "cli"` (synced manifest) and an unstamped field with
+    // `resolve` (authored manifest) must both be treated as non-user, so
+    // doctor never reports them as MISSING user env vars.
+    const targets = targetsFromManifestFile(
+      writeManifest({
+        version: "2.0",
+        plugins: {
+          lakebase: {
+            requiredByTemplate: true,
+            resources: {
+              required: [
+                {
+                  type: "postgres",
+                  resourceKey: "pg",
+                  alias: "Postgres",
+                  permission: "CAN_CONNECT_AND_CREATE",
+                  fields: {
+                    // synced manifest: origin stamped by `plugin sync`
+                    stampedCli: { env: "LAKEBASE_ENDPOINT", origin: "cli" },
+                    // authored manifest: no stamped origin, resolve → cli
+                    derivedCli: {
+                      env: "LAKEBASE_HOST",
+                      resolve: "postgres:host",
+                    },
+                    // genuine user-supplied field survives
+                    user: { env: "LAKEBASE_INSTANCE_NAME" },
+                  },
+                },
+              ],
+              optional: [],
+            },
+          },
+        },
+      }),
+    );
+    const pg = targets.find((t) => t.type === "postgres");
+    expect(pg?.envVars).toEqual(["LAKEBASE_INSTANCE_NAME"]);
   });
 
   it("resolves fieldValues from a static `value` when the env var is unset", () => {

--- a/packages/shared/src/cli/commands/doctor/resolve-targets.ts
+++ b/packages/shared/src/cli/commands/doctor/resolve-targets.ts
@@ -7,6 +7,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { computeOriginFromField } from "../../../schemas/manifest";
 import type { ResourceTarget } from "./types";
 import { errorMessage } from "./utils";
 
@@ -17,6 +18,8 @@ interface ManifestField {
   /** Static default value baked into the manifest. */
   value?: string;
   origin?: "user" | "platform" | "static" | "cli";
+  /** Resolver key (cli origin), e.g. "postgres:host". */
+  resolve?: string;
   /** Only generated into the local .env; the platform injects it at deploy. */
   localOnly?: boolean;
 }
@@ -47,13 +50,11 @@ interface TemplateManifest {
   plugins?: Record<string, ManifestPlugin>;
 }
 
-/** A field's env var is the developer's to supply only when it has no static
- * default and isn't platform-injected at deploy time. */
+/** A field's env var is the developer's to supply only when its effective
+ * origin is `"user"` — a stamped `origin`, else derived from the field shape. */
 function isUserSuppliedEnv(field: ManifestField): boolean {
-  if (field.value !== undefined) return false;
-  if (field.origin === "platform" || field.origin === "static") return false;
-  if (field.localOnly) return false;
-  return true;
+  const origin = field.origin ?? computeOriginFromField(field);
+  return origin === "user";
 }
 
 /** Env vars the config layer should presence-check (i.e. user-supplied ones). */


### PR DESCRIPTION
Stacked on #462 (`feat/registry-cli`) — please review/merge that first; this PR targets `feat/registry-cli`, not `main`.

## Problem

`doctor`'s `resolve-targets.isUserSuppliedEnv` hand-rolled the field-origin cascade and never handled the `cli` origin. In a synced `appkit.plugins.json` (where `plugin sync` stamps `origin`), a `cli`-origin field — one resolved by the CLI via `resolve` — was classified as user-supplied, so `appkit doctor` wrongly reported it as a MISSING user env var.

## Fix

Reuse the canonical classifier instead of re-implementing the cascade:

- Import `computeOriginFromField` from `schemas/manifest` (the single source `plugin sync` uses).
- Add `resolve?: string` to the local `ManifestField` so cli-origin fields in **authored** manifests (no stamped `origin`) classify correctly.
- A field is user-supplied iff its **effective** origin is `"user"` — trust a stamped `field.origin` first, else derive it from the field shape:

  ```ts
  const origin = field.origin ?? computeOriginFromField(field);
  return origin === "user";
  ```

This mirrors the `fieldOrigin` helper in `registry/requirements.ts`, importing the shared classifier directly.

## Tests

- New case proves a `cli`-origin field is excluded from `envVars`, covering both a stamped `origin: "cli"` field and an unstamped field with `resolve` set.
- Corrected the existing `"excludes value-default and platform-injected fields"` case: it previously asserted the cli-origin `LAKEBASE_ENDPOINT` was *included* (that assertion encoded the bug). It now includes a genuine user field and asserts only that survives, so it discriminates cli/platform/static (excluded) from user (kept).

## Verify

- `pnpm --filter=shared typecheck` — clean
- `npx vitest run packages/shared/src/cli/commands/doctor` — 129 passed
- `npx biome check` on both changed files — clean
