### PR TITLE
fix: template mobile-nav set-state-in-effect + lint-staged unmatched-pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,11 +51,11 @@
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [
-      "oxlint --fix",
-      "oxfmt --write"
+      "oxlint --fix --no-error-on-unmatched-pattern",
+      "oxfmt --write --no-error-on-unmatched-pattern"
     ],
     "*.json": [
-      "oxfmt --write"
+      "oxfmt --write --no-error-on-unmatched-pattern"
     ]
   },
   "devDependencies": {

--- a/template/client/src/App.tsx
+++ b/template/client/src/App.tsx
@@ -1,5 +1,5 @@
 import { createBrowserRouter, RouterProvider, NavLink, Outlet } from 'react-router';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import {
   Button,
   Card,
@@ -108,11 +108,6 @@ function Layout() {
   const isMobile = useIsMobile();
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
 
-  // Close mobile nav when viewport crosses to desktop
-  useEffect(() => {
-    if (!isMobile) setMobileNavOpen(false);
-  }, [isMobile]);
-
   return (
     <div className="min-h-screen bg-background flex flex-col">
       <header className="border-b px-4 md:px-6 py-3 flex items-center gap-4">
@@ -121,7 +116,9 @@ function Layout() {
         <NavLinks className="hidden md:flex gap-1" linkClass={navLinkClass} />
         {/* Mobile nav — visible below md breakpoint */}
         <div className="ml-auto md:hidden">
-          <Sheet open={mobileNavOpen} onOpenChange={setMobileNavOpen}>
+          {/* Gate on isMobile so the portaled sheet can't linger on desktop
+              (replaces a set-state-in-effect reset). */}
+          <Sheet open={mobileNavOpen && isMobile} onOpenChange={setMobileNavOpen}>
             <Button variant="ghost" size="icon" onClick={() => setMobileNavOpen(true)}>
               <Menu className="h-5 w-5" />
               <span className="sr-only">Open navigation</span>


### PR DESCRIPTION
## What

Two small lint-correctness fixes, both surfaced while regression-testing the Biome→oxc migration (#538) by scaffolding and linting a fresh app:

1. **`template/client/src/App.tsx`** — the mobile-nav `Sheet` reset its open state inside a `useEffect` keyed on `isMobile`, which `eslint-plugin-react-hooks` v7 flags as `react-hooks/set-state-in-effect`. Fixed by deriving the open prop (`open={mobileNavOpen && isMobile}`) and dropping the effect.
2. **`package.json` lint-staged** — restore `--no-errors-on-unmatched` behavior (lost in the oxc migration) so commits touching only oxc-ignored files don't fail pre-commit.

## Why

- **App.tsx**: This eslint error has been latent since the responsive-nav change (#391) — `eslint-plugin-react-hooks` has been v7 (which added `set-state-in-effect`) since the template was created. It went unnoticed because **CI never lints the template or a scaffolded app**. The fix follows React's recommended pattern (compute during render instead of resetting state in an effect):
  ```diff
  -import { useState, useEffect } from 'react';
  +import { useState } from 'react';
  ...
  -  // Close mobile nav when viewport crosses to desktop
  -  useEffect(() => {
  -    if (!isMobile) setMobileNavOpen(false);
  -  }, [isMobile]);
  ...
  -  <Sheet open={mobileNavOpen} onOpenChange={setMobileNavOpen}>
  +  <Sheet open={mobileNavOpen && isMobile} onOpenChange={setMobileNavOpen}>
  ```
  Behavior is preserved: on desktop the portaled Radix sheet is forced closed; on mobile the toggle works; a mobile→desktop resize closes it and Radix fires `onOpenChange(false)`, keeping state in sync — no effect needed.

- **lint-staged**: `oxlint`/`oxfmt` exit non-zero on an all-ignored fileset ("No files found to lint"). The pre-oxc Biome command used `--no-errors-on-unmatched`; this restores that via `--no-error-on-unmatched-pattern` on both tools.

## Verification

On a freshly scaffolded app (`databricks apps init` from the template):
- `eslint .` → **0 problems** (was 1 error)
- `tsc -b` (server + client) → passes
- `vite build` → succeeds

## Not fixed here (follow-up)

The root gap is that **CI doesn't lint the template or a scaffolded app**, so this class of error stays invisible. A CI step that scaffolds an app and runs `npm run lint` would catch it going forward — happy to do that separately.
