### PR TITLE
fix(template): drop root postinstall typegen to avoid deploy cache-bust

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -17,7 +17,6 @@
     "format:fix": "prettier --write .",
     "test": "vitest run",
     "clean": "rm -rf client/dist dist build node_modules",
-    "postinstall": "npm run typegen",
     "prebuild": "npm run sync && npm run typegen -- --wait",
     "predev": "npm run sync && npm run typegen",
     "sync": "appkit plugin sync --write --silent",


### PR DESCRIPTION
## What

Removes the redundant root `postinstall: npm run typegen` from the generated app template.

## Why

A root `postinstall` runs on every `npm install`. In container-based deploys, a root install-lifecycle script forces the build to copy the full application source **before** installing dependencies — so any source-only change invalidates the cached dependency layer and reinstalls from scratch on redeploy.

Type generation is already wired where it is actually needed:

- `prebuild`: `npm run sync && npm run typegen -- --wait`
- `predev`: `npm run sync && npm run typegen`

so the `postinstall` invocation is redundant for both local dev and deploy (deploy runs `npm install` → `npm run build`, which triggers `prebuild`). Dropping it lets source-only redeploys reuse the cached dependency layer, which primarily benefits the developer inner loop (edit code → redeploy).

## Safety

- No functional change — `typegen` still runs via `prebuild`/`predev`.
- The template imports no generated types directly (`shared/appkit-types` is only a `tsconfig` `include`, which tolerates an empty dir, plus a gitignored serving stub), so a fresh `npm install && npm run typecheck` without a build is unaffected.

## Verification

- [x] `template/package.json` remains valid JSON; `typegen`/`sync`/`prebuild`/`predev` intact
- [ ] Scaffold from the template; clean install / build / test / start
- [ ] Redeploy after a source-only change; confirm the dependency layer is reused
