### PR TITLE
fix: bump drizzle-orm to 0.45.2

### DIFF
--- a/apps/dev-playground/package.json
+++ b/apps/dev-playground/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@databricks/appkit": "workspace:*",
-    "drizzle-orm": "0.45.1",
+    "drizzle-orm": "0.45.2",
     "reflect-metadata": "0.2.2",
     "sequelize": "6.37.7",
     "typeorm": "0.3.28"

--- a/packages/appkit/package.json
+++ b/packages/appkit/package.json
@@ -89,7 +89,7 @@
     "@types/semver": "7.7.1",
     "apache-arrow": "21.1.0",
     "dotenv": "16.6.1",
-    "drizzle-orm": "0.45.1",
+    "drizzle-orm": "0.45.2",
     "express": "4.22.2",
     "get-port": "7.2.0",
     "js-yaml": "4.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,8 +146,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/appkit
       drizzle-orm:
-        specifier: 0.45.1
-        version: 0.45.1(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(pg@8.18.0)
+        specifier: 0.45.2
+        version: 0.45.2(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(pg@8.18.0)
       reflect-metadata:
         specifier: 0.2.2
         version: 0.2.2
@@ -313,8 +313,8 @@ importers:
         specifier: 16.6.1
         version: 16.6.1
       drizzle-orm:
-        specifier: 0.45.1
-        version: 0.45.1(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(pg@8.18.0)
+        specifier: 0.45.2
+        version: 0.45.2(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(pg@8.18.0)
       express:
         specifier: 4.22.2
         version: 4.22.2
@@ -7042,8 +7042,8 @@ packages:
     resolution: {integrity: sha512-iGCHkfUc5kFekGiqhe8B/mdaurD+lakO9txNnTvKtA6PISrw86LgqHvRzWYPyoE2Ph5aMIrCw9/uko6XHTKCwA==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
-  drizzle-orm@0.45.1:
-    resolution: {integrity: sha512-Te0FOdKIistGNPMq2jscdqngBRfBpC8uMFVwqjf6gtTVJHIQ/dosgV/CLBU2N4ZJBsXL5savCba9b0YJskKdcA==}
+  drizzle-orm@0.45.2:
+    resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
       '@cloudflare/workers-types': '>=4'
@@ -19948,7 +19948,7 @@ snapshots:
 
   dottie@2.0.6: {}
 
-  drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(pg@8.18.0):
+  drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(pg@8.18.0):
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@types/pg': 8.16.0


### PR DESCRIPTION
- bump drizzle-orm from 0.45.1 to 0.45.2 in AppKit and the dev playground
- refresh the pnpm lockfile