### PR TITLE
fix: bump js-yaml to 4.3.1

### DIFF
--- a/packages/appkit/package.json
+++ b/packages/appkit/package.json
@@ -92,7 +92,7 @@
     "drizzle-orm": "0.45.2",
     "express": "4.22.2",
     "get-port": "7.2.0",
-    "js-yaml": "4.2.0",
+    "js-yaml": "4.3.1",
     "magic-string": "0.30.21",
     "mlflow-tracing": "0.1.3",
     "obug": "2.1.1",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -51,7 +51,7 @@
     "@standard-schema/spec": "1.1.0",
     "commander": "12.1.0",
     "dotenv": "16.6.1",
-    "js-yaml": "4.2.0",
+    "js-yaml": "4.3.1",
     "picocolors": "1.1.1",
     "yaml": "2.8.2",
     "zod": "4.3.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,8 +322,8 @@ importers:
         specifier: 7.2.0
         version: 7.2.0
       js-yaml:
-        specifier: 4.2.0
-        version: 4.2.0
+        specifier: 4.3.1
+        version: 4.3.1
       magic-string:
         specifier: 0.30.21
         version: 0.30.21
@@ -577,8 +577,8 @@ importers:
         specifier: 16.6.1
         version: 16.6.1
       js-yaml:
-        specifier: 4.2.0
-        version: 4.2.0
+        specifier: 4.3.1
+        version: 4.3.1
       picocolors:
         specifier: 1.1.1
         version: 1.1.1
@@ -8512,8 +8512,8 @@ packages:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
     hasBin: true
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@27.0.0:
@@ -14255,7 +14255,7 @@ snapshots:
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.3.2
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
       lodash: 4.17.21
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
@@ -14741,7 +14741,7 @@ snapshots:
       '@docusaurus/utils-common': 3.9.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       fs-extra: 11.3.2
       joi: 17.13.3
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
       lodash: 4.17.21
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -14766,7 +14766,7 @@ snapshots:
       globby: 11.1.0
       gray-matter: 4.0.3
       jiti: 1.21.7
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
       lodash: 4.17.21
       micromatch: 4.0.8
       p-queue: 6.6.2
@@ -14910,7 +14910,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
       minimatch: 3.1.2
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -19368,7 +19368,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@5.6.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -19378,7 +19378,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -21575,7 +21575,7 @@ snapshots:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
## Summary

Minimal, focused carve-out of the js-yaml portion of #551 (the OSV batch update). Bumps the direct `js-yaml` declaration in `@databricks/appkit` and `@databricks/shared` from `4.2.0` to `4.3.1` and refreshes the lockfile, removing **every** `js-yaml@4.2.0` record (both direct declarations plus the deduped transitives under docusaurus, `@eslint/eslintrc`, and `cosmiconfig`).

Diff is 3 files, +15/-15 — no other dependency is touched.

## Why 4.3.1

`4.3.1` backports two sec updates from js-yaml v5 line.

## Impact assessment — negligible

- **No API/behavior change for us.** The only breaking change across 4.3.0/4.3.1 is the loader-option rename `maxMergeSeqLength` → `maxTotalMergeKeys`. AppKit passes no merge/alias options at any call site.
- **Advisories not reachable.** Both CVEs require parsing *untrusted* YAML with pathological merge-chains or large `!!omap`. AppKit's only two `yaml.load()` call sites parse trusted, source-controlled files at CLI/init time:
  - `packages/appkit/src/core/agent/load-agents.ts:320` — markdown agent-file frontmatter
  - `packages/shared/src/cli/commands/doctor/bundle.ts:109` — `databricks.yml` / `app.yaml`
- This is a defense-in-depth / scanner-clearing bump with no runtime downside.

## Scope note

The docs-site-only transitive `js-yaml@3.14.2` (via `@docusaurus/utils` → `gray-matter`, never shipped in any published package) is intentionally **out of scope** here — it belongs with a docusaurus toolchain bump rather than a hand-pinned override.