### PR TITLE
fix(appkit): exclude lakebase postgres.project from the bundle

### DIFF
--- a/packages/appkit/src/plugins/lakebase/manifest.json
+++ b/packages/appkit/src/plugins/lakebase/manifest.json
@@ -16,6 +16,7 @@
           "project": {
             "description": "Full Lakebase Postgres project resource name. Obtain by running `databricks postgres list-projects`, select the desired item from the output array and use its .name value.",
             "examples": ["projects/{project-id}"],
+            "bundleIgnore": true,
             "discovery": {
               "type": "kind",
               "resourceKind": "postgres_project",

--- a/template/appkit.plugins.json
+++ b/template/appkit.plugins.json
@@ -234,6 +234,7 @@
             "fields": {
               "project": {
                 "description": "Full Lakebase Postgres project resource name. Obtain by running `databricks postgres list-projects`, select the desired item from the output array and use its .name value.",
+                "bundleIgnore": true,
                 "examples": [
                   "projects/{project-id}"
                 ],


### PR DESCRIPTION
`project` on the lakebase `postgres` resource is a discovery-only field. AppKit's
discovery walks project → branch → database (listing branches needs a project),
but the `branch`/`database` values it picks are already fully-qualified names that
embed the project — so `project` never needs to go into the app bundle.

`databricks apps init` ignores the manifest's `discovery` blocks, so it treated
`project` as a normal bundle field: it declared an unused `postgres_project`
variable, and non-interactive generation (`--set`) failed with

```
incomplete resource "postgres": missing fields [postgres.project]
```

Marking `project` as `bundleIgnore` (like `endpointPath`) keeps it available for
discovery but drops it from the bundle. Regenerating the `appkit-*` app templates
now works with just `branch`/`database` and no stray variable.

This pull request and its description were written by Isaac.
