### PR TITLE
template: git-backed deployment in scaffolded databricks.yml (proposal)

### DIFF
--- a/template/databricks.yml.tmpl
+++ b/template/databricks.yml.tmpl
@@ -11,18 +11,23 @@ resources:
     app:
       name: "{{.projectName}}"
       description: "{{.appDescription}}"
+{{- if .git.url}}
+      # Git-backed deployment: the app is deployed from the Git repository below
+      # (auto-detected from this directory's Git remote) instead of uploading
+      # local files. Commit and push the branch before deploying so the ref
+      # exists on the remote.
+      git_repository:
+        url: {{.git.url}}
+        provider: {{.git.provider}}
+      git_source:
+        branch: {{.git.branch}}
+        source_code_path: {{.git.sourceCodePath}}
+{{- else}}
+      # Local source: files in this directory are uploaded on deploy. To deploy
+      # from Git instead, run `databricks apps init` inside a Git repository that
+      # has a remote — the git_repository/git_source block is filled in for you.
       source_code_path: ./
-
-      # Git-backed deployment (recommended): deploy from a Git repository/ref
-      # instead of uploading local files — reproducible, reviewable, and
-      # roll-back-able. Once the app is in a repo, replace `source_code_path`
-      # above with the block below (see the databricks-apps skill's git gate).
-      # git_repository:
-      #   url: https://github.com/my-org/my-repo
-      #   provider: gitHub            # gitHub, gitHubEnterprise, gitLab, bitbucketCloud, ...
-      # git_source:
-      #   branch: main                # or tag: / commit:
-      #   source_code_path: ./        # repo-relative path; omit for repo root
+{{- end}}
 
       # Start the app automatically on deploy.
       lifecycle:

--- a/template/databricks.yml.tmpl
+++ b/template/databricks.yml.tmpl
@@ -13,6 +13,17 @@ resources:
       description: "{{.appDescription}}"
       source_code_path: ./
 
+      # Git-backed deployment (recommended): deploy from a Git repository/ref
+      # instead of uploading local files — reproducible, reviewable, and
+      # roll-back-able. Once the app is in a repo, replace `source_code_path`
+      # above with the block below (see the databricks-apps skill's git gate).
+      # git_repository:
+      #   url: https://github.com/my-org/my-repo
+      #   provider: gitHub            # gitHub, gitHubEnterprise, gitLab, bitbucketCloud, ...
+      # git_source:
+      #   branch: main                # or tag: / commit:
+      #   source_code_path: ./        # repo-relative path; omit for repo root
+
       # Start the app automatically on deploy.
       lifecycle:
         started: true

--- a/template/databricks.yml.tmpl
+++ b/template/databricks.yml.tmpl
@@ -11,23 +11,19 @@ resources:
     app:
       name: "{{.projectName}}"
       description: "{{.appDescription}}"
-{{- if .git.url}}
-      # Git-backed deployment: the app is deployed from the Git repository below
-      # (auto-detected from this directory's Git remote) instead of uploading
-      # local files. Commit and push the branch before deploying so the ref
-      # exists on the remote.
-      git_repository:
-        url: {{.git.url}}
-        provider: {{.git.provider}}
-      git_source:
-        branch: {{.git.branch}}
-        source_code_path: {{.git.sourceCodePath}}
-{{- else}}
-      # Local source: files in this directory are uploaded on deploy. To deploy
-      # from Git instead, run `databricks apps init` inside a Git repository that
-      # has a remote — the git_repository/git_source block is filled in for you.
       source_code_path: ./
-{{- end}}
+
+      # Git-backed deployment: deploy from a Git repository/ref instead of
+      # uploading local files (reproducible, reviewable, rollback-able). To
+      # migrate this app to Git, replace `source_code_path` above with the block
+      # below and redeploy — the databricks-apps skill's git-migration path can
+      # do this for you.
+      # git_repository:
+      #   url: https://github.com/my-org/my-repo
+      #   provider: gitHub            # gitHub, gitLab, bitbucketCloud, azureDevOpsServices, ...
+      # git_source:
+      #   branch: main                # or tag: / commit:
+      #   source_code_path: ./        # repo-relative path
 
       # Start the app automatically on deploy.
       lifecycle:


### PR DESCRIPTION
## Proposal: git-backed deployment by default for scaffolded apps

This makes a newly scaffolded AppKit app **deploy from its Git repository** instead of uploading local files — automatically, whenever `databricks apps init` runs inside a Git repo with a remote. It's a proposal for discussion; happy to adjust shape/scope.

### What changes here (AppKit)

`template/databricks.yml.tmpl` replaces the commented `git_repository`/`git_source` example with a conditional block:

```yaml
{{- if .git.url}}
      git_repository:
        url: {{.git.url}}
        provider: {{.git.provider}}
      git_source:
        branch: {{.git.branch}}
        source_code_path: {{.git.sourceCodePath}}
{{- else}}
      source_code_path: ./
{{- end}}
```

### What makes it active (paired CLI change)

The template fields are populated by a paired change in the Databricks CLI — **databricks/cli#6406** — which detects the Git repo containing the app at `apps init` time and derives the origin URL, provider (`gitHub`/`gitLab`/`bitbucketCloud`/`azureDevOpsServices`), current branch, and repo-relative source path. Detection is conservative: it falls back to `source_code_path` when there's no repo, no origin, an unknown provider host, a detached HEAD, or an out-of-repo destination.

Net effect: `git clone <repo> && cd <repo> && databricks apps init` produces a git-backed `databricks.yml` with zero extra steps. Outside a repo, behavior is unchanged.

### Safe / backward-compatible

- Bundle validation requires exactly one of `source_code_path` or `git_source`; the conditional emits exactly one, never both.
- Older CLIs render `.git.url` empty (`missingkey=zero`) → the `else` branch keeps `source_code_path`. So this template works with any CLI version.
- Verified: the template renders valid YAML in both branches.

### Questions for the reviewer

1. Is the scaffold template the right home for this, given the detection logic necessarily lives in the CLI's `apps init`?
2. Are you comfortable making git-backed the **default** whenever scaffolding inside a repo with a remote (vs. opt-in)? A deploy still requires the code to be committed and pushed first — the rendered comment says so.
3. Any concerns with the provider-host mapping or the conservative fallbacks?

This pull request and its description were written by Isaac.