### PR TITLE
fix(appkit): extract text from gpt-oss array-shaped delta.content

### DIFF
--- a/packages/appkit/src/agents/databricks.ts
+++ b/packages/appkit/src/agents/databricks.ts
@@ -106,6 +106,18 @@ function throwIfExceedsStreamLimit(
   }
 }
 
+/** Text of a harmony `reasoning` part: `summary[].text` plus an optional `text`. */
+function reasoningPartText(part: Record<string, unknown>): string {
+  let text = "";
+  if (Array.isArray(part.summary)) {
+    for (const s of part.summary) {
+      if (isRecord(s) && typeof s.text === "string") text += s.text;
+    }
+  }
+  if (typeof part.text === "string") text += part.text;
+  return text;
+}
+
 /**
  * Escape-hatch options: provide an `endpointUrl` + `authenticate()` and the
  * adapter uses a bare `fetch()` to call it. Useful for tests and for pointing
@@ -636,16 +648,32 @@ export class DatabricksAdapter implements AgentAdapter {
           const deltaUnknown = openAiChoicesDelta(parsed);
           if (!isRecord(deltaUnknown)) continue;
 
-          if (typeof deltaUnknown.content === "string") {
-            const content = deltaUnknown.content;
-            throwIfExceedsStreamLimit(
-              "streamed assistant text",
-              fullText.length,
-              content,
-              this.maxStreamTextChars,
-            );
-            fullText += content;
-            yield { type: "message_delta" as const, content };
+          // gpt-oss (harmony) sends delta.content as an array of parts
+          // (text = answer, reasoning = chain-of-thought), not a string.
+          const contentUnknown = deltaUnknown.content;
+          const parts =
+            typeof contentUnknown === "string"
+              ? [{ type: "text", text: contentUnknown }]
+              : Array.isArray(contentUnknown)
+                ? contentUnknown
+                : [];
+
+          for (const part of parts) {
+            if (!isRecord(part)) continue;
+            if (part.type === "text" && typeof part.text === "string") {
+              const content = part.text;
+              throwIfExceedsStreamLimit(
+                "streamed assistant text",
+                fullText.length,
+                content,
+                this.maxStreamTextChars,
+              );
+              fullText += content;
+              yield { type: "message_delta" as const, content };
+            } else if (part.type === "reasoning") {
+              const content = reasoningPartText(part);
+              if (content) yield { type: "thinking" as const, content };
+            }
           }
 
           const toolCallsRaw = deltaUnknown.tool_calls;

--- a/packages/appkit/src/agents/tests/databricks.test.ts
+++ b/packages/appkit/src/agents/tests/databricks.test.ts
@@ -330,6 +330,93 @@ describe("DatabricksAdapter", () => {
     expect(mockAuthenticate).toHaveBeenCalledTimes(2);
   });
 
+  // Regression for #558: a custom tool's result must ground a gpt-oss answer
+  // that streams back as an array-shaped delta.content. The result reaching
+  // the model and the array answer being captured are the two failure points.
+  test("grounds a gpt-oss array-shaped answer in a tool result", async () => {
+    const toolResult = [
+      {
+        n: 1,
+        source: "test",
+        text: "The HTTPS ingest API default port is 8443.",
+      },
+    ];
+    const executeTool = vi.fn().mockResolvedValue(toolResult);
+    const searchTools: AgentToolDefinition[] = [
+      {
+        name: "search_docs",
+        description: "Search product docs.",
+        parameters: {
+          type: "object",
+          properties: { query: { type: "string" } },
+          required: ["query"],
+        },
+      },
+    ];
+
+    let callCount = 0;
+    globalThis.fetch = vi.fn().mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return Promise.resolve({
+          ok: true,
+          body: createReadableStream([
+            harmonyDelta([
+              {
+                type: "reasoning",
+                summary: [{ type: "summary_text", text: "Search the docs." }],
+              },
+            ]),
+            toolCallDelta(0, "call_1", "search_docs", ""),
+            toolCallDelta(0, undefined, undefined, '{"query":"gateway port"}'),
+            sseChunk("[DONE]"),
+          ]),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        body: createReadableStream([
+          harmonyDelta([
+            {
+              type: "reasoning",
+              summary: [{ type: "summary_text", text: "The tool says 8443." }],
+            },
+            { type: "text", text: "The default port is 8443." },
+          ]),
+          sseChunk("[DONE]"),
+        ]),
+      });
+    });
+
+    const adapter = createAdapter();
+    const events: AgentEvent[] = [];
+
+    for await (const event of adapter.run(
+      { messages: createTestMessages(), tools: searchTools, threadId: "t1" },
+      { executeTool },
+    )) {
+      events.push(event);
+    }
+
+    expect(executeTool).toHaveBeenCalledWith("search_docs", {
+      query: "gateway port",
+    });
+
+    // The tool result must be present in the follow-up request the model sees.
+    const [, secondInit] = (globalThis.fetch as any).mock.calls[1];
+    const secondBody = JSON.parse(secondInit.body);
+    const toolMessage = secondBody.messages.find(
+      (m: { role: string }) => m.role === "tool",
+    );
+    expect(toolMessage.content).toContain("8443");
+
+    // The array-shaped final answer is captured (not silently dropped).
+    expect(events).toContainEqual({
+      type: "message_delta",
+      content: "The default port is 8443.",
+    });
+  });
+
   describe("Vertex/Gemini thoughtSignature pass-through", () => {
     // Vertex AI's OpenAI-compatible surface attaches `thoughtSignature`
     // on every function call emitted by Gemini 2.x/3.x models. The next

--- a/packages/appkit/src/agents/tests/databricks.test.ts
+++ b/packages/appkit/src/agents/tests/databricks.test.ts
@@ -52,6 +52,14 @@ function toolCallDelta(
   );
 }
 
+function harmonyDelta(parts: unknown[]): string {
+  return sseChunk(
+    JSON.stringify({
+      choices: [{ delta: { content: parts } }],
+    }),
+  );
+}
+
 function createReadableStream(chunks: string[]): ReadableStream<Uint8Array> {
   const encoder = new TextEncoder();
   let i = 0;
@@ -139,6 +147,70 @@ describe("DatabricksAdapter", () => {
     expect(events[0]).toEqual({ type: "status", status: "running" });
     expect(events[1]).toEqual({ type: "message_delta", content: "Hello" });
     expect(events[2]).toEqual({ type: "message_delta", content: " world" });
+  });
+
+  test("extracts answer text from harmony array-shaped delta.content", async () => {
+    globalThis.fetch = mockFetch([
+      harmonyDelta([
+        {
+          type: "reasoning",
+          summary: [{ type: "summary_text", text: "...answer the user." }],
+        },
+        { type: "text", text: "The default port is 8443." },
+      ]),
+      sseChunk("[DONE]"),
+    ]);
+
+    const adapter = createAdapter();
+    const events: AgentEvent[] = [];
+
+    for await (const event of adapter.run(
+      { messages: createTestMessages(), tools: [], threadId: "t1" },
+      { executeTool: vi.fn() },
+    )) {
+      events.push(event);
+    }
+
+    expect(events).toContainEqual({
+      type: "message_delta",
+      content: "The default port is 8443.",
+    });
+    expect(events).toContainEqual({
+      type: "thinking",
+      content: "...answer the user.",
+    });
+    // Reasoning must not leak into the answer: exactly one message_delta.
+    expect(events.filter((e) => e.type === "message_delta")).toHaveLength(1);
+  });
+
+  test("reasoning-only harmony delta yields thinking but no answer text", async () => {
+    globalThis.fetch = mockFetch([
+      harmonyDelta([
+        {
+          type: "reasoning",
+          summary: [
+            { type: "summary_text", text: "We have the search result..." },
+          ],
+        },
+      ]),
+      sseChunk("[DONE]"),
+    ]);
+
+    const adapter = createAdapter();
+    const events: AgentEvent[] = [];
+
+    for await (const event of adapter.run(
+      { messages: createTestMessages(), tools: [], threadId: "t1" },
+      { executeTool: vi.fn() },
+    )) {
+      events.push(event);
+    }
+
+    expect(events.filter((e) => e.type === "message_delta")).toHaveLength(0);
+    expect(events).toContainEqual({
+      type: "thinking",
+      content: "We have the search result...",
+    });
   });
 
   test("calls authenticate() per request for fresh headers", async () => {


### PR DESCRIPTION
## Problem

`DatabricksAdapter`'s chat-completions stream (`streamCompletion`) only extracted assistant text when `delta.content` was a **string**. The `databricks-gpt-oss-120b` endpoint streams OpenAI-chat-completions style but delivers `delta.content` as an **array of content parts** (harmony format). The array — including the actual answer — was silently dropped, so the agent's final text came back empty and the UI rendered a blank assistant bubble. Plain string-content endpoints were unaffected.

## Fix

Normalize `delta.content` into content parts and handle each shape through one path:

| `delta.content` | Behavior |
|---|---|
| `string` | → `message_delta` (answer) — unchanged |
| array `{type:"text", text}` | → `message_delta` (answer) |
| array `{type:"reasoning", summary/text}` | → `thinking` event, kept out of the answer |
| unknown part / `null` / non-array | ignored safely (no throw) |
| `tool_calls` | unchanged, still processed alongside content |

`text` parts append to the answer (and respect the existing `maxStreamTextChars` cap); `reasoning` parts emit a `thinking` event (mapped downstream to `appkit.thinking`) without polluting the answer text. A single array delta may carry both a reasoning part and a text part.

## Scope / caveats

- Only the **chat-completions** adapter path is affected. The OpenAI **Responses API** path (`fromSupervisorApi` / `supervisor-api.ts`) already handles its own `output_text` shape and is untouched.
- The non-streaming path doesn't exist (adapter always streams), and message-history reconstruction (`buildMessages`) reads AppKit's own string-typed `AgentInput`, not model deltas — both verified unaffected.
- Unrecognized shapes degrade safely: a new endpoint won't crash or blank the answer as long as the answer arrives as a string or `text` part; worst case is unrendered reasoning (e.g. the `delta.reasoning_content` convention is not extracted).

## Testing

- Added two regression tests in `databricks.test.ts` (array delta with a `text` part yields `message_delta` + `thinking`; reasoning-only delta yields `thinking` and no answer text). The existing string-path test still passes.
- `vitest --project appkit` → 36 passed
- `tsc --noEmit` (appkit) → clean
- `oxlint` + `oxfmt --check` → clean


fixes https://github.com/databricks/appkit/issues/558