### PR TITLE
fix(appkit): surface swallowed tool-execution errors in agents plugin

### DIFF
--- a/packages/appkit/src/core/agent/plugins-map.ts
+++ b/packages/appkit/src/core/agent/plugins-map.ts
@@ -18,10 +18,14 @@ import type { Plugins, PluginToolkitProvider } from "./types";
  * @param contextLabel - prefix included in the error message; differentiates
  *   the runtime context (e.g. `"runAgent: tools(plugins)"` vs
  *   `"AgentsPlugin: tools(plugins)"`) so users know which path to debug.
+ * @param nonProviderNames - names of plugins that ARE registered but expose no
+ *   agent tools (no `.toolkit()`), so a miss on one of these reports "registered
+ *   but not a ToolProvider" instead of the misleading "not registered".
  */
 export function createPluginsProxy(
   entries: Record<string, PluginToolkitProvider>,
   contextLabel: string,
+  nonProviderNames?: ReadonlySet<string>,
 ): Plugins {
   return new Proxy(entries, {
     get(target, prop, receiver) {
@@ -49,6 +53,13 @@ export function createPluginsProxy(
         return undefined;
       }
       const available = Object.keys(target).join(", ") || "(none)";
+      if (nonProviderNames?.has(prop)) {
+        throw new Error(
+          `${contextLabel} referenced plugin '${prop}', which is registered but ` +
+            `exposes no agent tools (no .toolkit() — not a ToolProvider), so it ` +
+            `can't be used from tools(plugins). Tool-providing plugins: ${available}.`,
+        );
+      }
       throw new Error(
         `${contextLabel} referenced plugin '${prop}', but it is not registered. ` +
           `Available: ${available}.`,

--- a/packages/appkit/src/core/agent/tests/plugins-map.test.ts
+++ b/packages/appkit/src/core/agent/tests/plugins-map.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "vitest";
+
+import { createPluginsProxy } from "../plugins-map";
+import type { PluginToolkitProvider } from "../types";
+
+describe("createPluginsProxy — miss messages", () => {
+  const entries: Record<string, PluginToolkitProvider> = {
+    analytics: { toolkit: () => ({}) },
+  };
+
+  test("a registered non-provider plugin reports it is not a ToolProvider", () => {
+    const proxy = createPluginsProxy(entries, "test", new Set(["aiSearch"]));
+    expect(() => (proxy as Record<string, unknown>).aiSearch).toThrow(
+      /registered but exposes no agent tools/,
+    );
+  });
+
+  test("an unknown plugin still reports 'not registered'", () => {
+    const proxy = createPluginsProxy(entries, "test", new Set(["aiSearch"]));
+    expect(() => (proxy as Record<string, unknown>).ghost).toThrow(
+      /not registered/,
+    );
+  });
+
+  test("a known tool-providing plugin resolves to its entry", () => {
+    const proxy = createPluginsProxy(entries, "test");
+    expect((proxy as Record<string, unknown>).analytics).toBe(
+      entries.analytics,
+    );
+  });
+});

--- a/packages/appkit/src/plugins/agents/agents.ts
+++ b/packages/appkit/src/plugins/agents/agents.ts
@@ -737,8 +737,9 @@ export class AgentsPlugin extends Plugin implements ToolProvider {
    */
   private buildPluginsMap(): Plugins {
     const out: Record<string, PluginToolkitProvider> = {};
+    const label = `Agent '${this.name}': tools(plugins)`;
     if (!this.context) {
-      return createPluginsProxy(out, `Agent '${this.name}': tools(plugins)`);
+      return createPluginsProxy(out, label);
     }
     for (const { name, provider } of this.context.getToolProviders()) {
       const direct = (provider as { toolkit?: unknown }).toolkit;
@@ -750,7 +751,13 @@ export class AgentsPlugin extends Plugin implements ToolProvider {
         };
       }
     }
-    return createPluginsProxy(out, `Agent '${this.name}': tools(plugins)`);
+    // Plugins that are registered but expose no agent tools (e.g. aiSearch):
+    // a reference to one gets "registered but not a ToolProvider" rather than
+    // the misleading "not registered".
+    const nonProviders = new Set(
+      this.context.getPluginNames().filter((n) => !(n in out)),
+    );
+    return createPluginsProxy(out, label, nonProviders);
   }
 
   private async applyAutoInherit(
@@ -1214,6 +1221,7 @@ export class AgentsPlugin extends Plugin implements ToolProvider {
       translator,
       outboundEvents,
       toolCallsUsed: { count: 0 },
+      toolErrors: [],
     };
 
     const deps = this.toolDispatchDeps();
@@ -1436,6 +1444,7 @@ export class AgentsPlugin extends Plugin implements ToolProvider {
       translator: new AgentEventTranslator(),
       outboundEvents: new EventChannel<ResponseStreamEvent>(),
       toolCallsUsed: { count: 0 },
+      toolErrors: [],
     };
 
     const deps = this.toolDispatchDeps();
@@ -1558,6 +1567,11 @@ export class AgentsPlugin extends Plugin implements ToolProvider {
       // Lets an eval runner attach assessments to this turn's trace; absent
       // when tracing is disabled.
       ...(mlflowTraceId ? { mlflow_trace_id: mlflowTraceId } : {}),
+      // Tool failures the model recovered from — the non-streaming equivalent
+      // of the streaming path's `tool_result` error events.
+      ...(runState.toolErrors.length > 0
+        ? { tool_errors: runState.toolErrors }
+        : {}),
       output: [message],
     });
   }

--- a/packages/appkit/src/plugins/agents/agents.ts
+++ b/packages/appkit/src/plugins/agents/agents.ts
@@ -751,9 +751,8 @@ export class AgentsPlugin extends Plugin implements ToolProvider {
         };
       }
     }
-    // Plugins that are registered but expose no agent tools (e.g. aiSearch):
-    // a reference to one gets "registered but not a ToolProvider" rather than
-    // the misleading "not registered".
+    // Registered plugins that expose no agent tools (e.g. aiSearch) — so a
+    // reference reports "not a ToolProvider", not the misleading "not registered".
     const nonProviders = new Set(
       this.context.getPluginNames().filter((n) => !(n in out)),
     );

--- a/packages/appkit/src/plugins/agents/tests/dispatch-tool-call.test.ts
+++ b/packages/appkit/src/plugins/agents/tests/dispatch-tool-call.test.ts
@@ -86,6 +86,7 @@ function makeRunState(plugin: AgentsPlugin) {
       push: (event: unknown) => pushed.push(event),
     },
     toolCallsUsed: { count: 0 },
+    toolErrors: [] as Array<{ tool: string; error: string }>,
   };
   return { runState, pushed, plugin };
 }
@@ -231,6 +232,37 @@ describe("dispatchToolCall — approval gate honours `effect`", () => {
       "Tool execution denied by user approval gate (tool: delete_user).",
     );
     expect(execute).not.toHaveBeenCalled();
+  });
+});
+
+describe("dispatchToolCall — tool failures are captured", () => {
+  test("rethrows the tool error and records it in runState.toolErrors", async () => {
+    const plugin = new AgentsPlugin({});
+    const { runState } = makeRunState(plugin);
+
+    const toolIndex = new Map<string, unknown>([
+      [
+        "boom",
+        {
+          source: "function",
+          def: {
+            name: "boom",
+            description: "throws",
+            parameters: { type: "object" },
+          },
+          functionTool: {
+            execute: vi.fn().mockRejectedValue(new Error("kaboom")),
+          },
+        },
+      ],
+    ]);
+
+    await expect(
+      callDispatch(plugin, { runState, toolIndex, name: "boom", args: {} }),
+    ).rejects.toThrow(/kaboom/);
+
+    // The caught error is recorded so the non-streaming response can surface it.
+    expect(runState.toolErrors).toEqual([{ tool: "boom", error: "kaboom" }]);
   });
 });
 

--- a/packages/appkit/src/plugins/agents/tests/route-handler-errors.test.ts
+++ b/packages/appkit/src/plugins/agents/tests/route-handler-errors.test.ts
@@ -376,6 +376,71 @@ describe("POST /invocations & /responses — successful invoke", () => {
   });
 });
 
+describe("POST /invocations — tool failures surfaced", () => {
+  test("returns tool_errors alongside a completed response", async () => {
+    const plugin = new AgentsPlugin({});
+    (plugin as any).agents.set("default", {
+      name: "default",
+      instructions: "hi",
+      // Mimics a real adapter: invokes the tool, swallows its failure, and
+      // finishes the turn (the model recovers with an ungrounded answer).
+      adapter: {
+        async *run(
+          _input: unknown,
+          ctx: { executeTool: (n: string, a: unknown) => Promise<unknown> },
+        ) {
+          try {
+            await ctx.executeTool("boom", {});
+          } catch {
+            // adapter continues after a tool failure
+          }
+          yield { type: "message_delta", content: "done" };
+        },
+      },
+      toolIndex: new Map([
+        [
+          "boom",
+          {
+            source: "function",
+            def: {
+              name: "boom",
+              description: "throws",
+              parameters: { type: "object" },
+            },
+            functionTool: {
+              execute: vi.fn().mockRejectedValue(new Error("kaboom")),
+            },
+          },
+        ],
+      ]),
+    });
+    (plugin as any).defaultAgentName = "default";
+    (plugin as any).threadStore = {
+      create: vi.fn().mockResolvedValue({ id: "t-new", messages: [] }),
+      addMessage: vi.fn(),
+      delete: vi.fn(),
+    };
+
+    const { res, json } = mockRes();
+    await (
+      plugin as unknown as {
+        _handleInvoke: (
+          r: express.Request,
+          w: express.Response,
+        ) => Promise<void>;
+      }
+    )._handleInvoke(mockReq({ input: "hi" }), res);
+
+    expect(res.status).not.toHaveBeenCalledWith(500);
+    const payload = json.mock.calls[0]?.[0] as {
+      status: string;
+      tool_errors?: Array<{ tool: string; error: string }>;
+    };
+    expect(payload.status).toBe("completed");
+    expect(payload.tool_errors).toEqual([{ tool: "boom", error: "kaboom" }]);
+  });
+});
+
 describe("/invocations and /responses are aliases", () => {
   test("both routes are registered and bound to the same handler", () => {
     const plugin = new AgentsPlugin({});

--- a/packages/appkit/src/plugins/agents/tool-dispatch.ts
+++ b/packages/appkit/src/plugins/agents/tool-dispatch.ts
@@ -139,71 +139,9 @@ export async function dispatchToolCall(
   // wait above (which is human latency).
   let toolResult: unknown;
   try {
-    toolResult = await traceTool(name, args, async () => {
-      switch (entry.source) {
-        case "toolkit":
-          if (!deps.context) {
-            throw new Error(
-              "Plugin tool execution requires PluginContext; this should never happen through createApp",
-            );
-          }
-          return deps.context.executeTool(
-            runState.req,
-            entry.pluginName,
-            entry.localName,
-            args,
-            runState.signal,
-            runState.limits.toolCallTimeoutMs,
-          );
-        case "function": {
-          // Function tools declare their parameters as a JSON-object schema,
-          // so adapters always serialize `args` as an object. A non-object
-          // value here means the upstream model emitted malformed tool-call
-          // JSON; surface a clear error rather than silently passing through
-          // a wrong-shape value the tool will then choke on.
-          if (
-            typeof args !== "object" ||
-            args === null ||
-            Array.isArray(args)
-          ) {
-            throw new Error(
-              `Function tool '${name}' received non-object arguments (got ${args === null ? "null" : Array.isArray(args) ? "array" : typeof args}); expected a JSON object.`,
-            );
-          }
-          return entry.functionTool.execute(args as Record<string, unknown>);
-        }
-        case "mcp": {
-          const mcpClient = deps.getMcpClient();
-          if (!mcpClient) throw new Error("MCP client not connected");
-          const oboToken = runState.req.headers["x-forwarded-access-token"];
-          const mcpAuth =
-            typeof oboToken === "string"
-              ? { Authorization: `Bearer ${oboToken}` }
-              : undefined;
-          return mcpClient.callTool(entry.mcpToolName, args, mcpAuth);
-        }
-        case "subagent": {
-          const childAgent = deps.agents.get(entry.agentName);
-          if (!childAgent)
-            throw new Error(`Sub-agent not found: ${entry.agentName}`);
-          return runSubAgent(deps, runState, childAgent, args, depth + 1);
-        }
-        case "hosted-supervisor":
-          // Defense-in-depth: should never fire. Hosted-supervisor entries are
-          // routed via `AgentInput.extensions` and the SA endpoint executes
-          // them server-side; their `def` is filtered out of the adapter's
-          // `tools` array, so the model never sees a callable schema for them.
-          // If we reach here, the agent is paired with a non-SA adapter that
-          // somehow surfaced the placeholder def to the model — surface a
-          // clear error rather than crash later in `normalizeToolResult`.
-          throw new Error(
-            `Tool '${name}' is a hosted-supervisor tool and cannot be invoked from the Node process. ` +
-              "It is executed server-side by the Databricks AI Gateway and is only reachable when the agent's model is a Supervisor API adapter.",
-          );
-        case "skill":
-          return deps.dispatchSkillTool(entry, args);
-      }
-    });
+    toolResult = await traceTool(name, args, () =>
+      runToolEntry(deps, runState, entry, name, args, depth),
+    );
   } catch (err) {
     const error = err instanceof Error ? err.message : String(err);
     logger.error(
@@ -217,6 +155,76 @@ export async function dispatchToolCall(
   }
 
   return normalizeToolResult(toolResult);
+}
+
+/**
+ * Executes a resolved tool entry by source. Unknown sources fall through to
+ * `undefined` (the tool index only holds these six).
+ */
+async function runToolEntry(
+  deps: ToolDispatchDeps,
+  runState: RunState,
+  entry: ResolvedToolEntry,
+  name: string,
+  args: unknown,
+  depth: number,
+): Promise<unknown> {
+  switch (entry.source) {
+    case "toolkit":
+      if (!deps.context) {
+        throw new Error(
+          "Plugin tool execution requires PluginContext; this should never happen through createApp",
+        );
+      }
+      return deps.context.executeTool(
+        runState.req,
+        entry.pluginName,
+        entry.localName,
+        args,
+        runState.signal,
+        runState.limits.toolCallTimeoutMs,
+      );
+    case "function": {
+      // Function tools declare their parameters as a JSON-object schema, so
+      // adapters always serialize `args` as an object. A non-object value here
+      // means the model emitted malformed tool-call JSON; surface a clear error
+      // rather than passing a wrong-shape value the tool will choke on.
+      if (typeof args !== "object" || args === null || Array.isArray(args)) {
+        throw new Error(
+          `Function tool '${name}' received non-object arguments (got ${args === null ? "null" : Array.isArray(args) ? "array" : typeof args}); expected a JSON object.`,
+        );
+      }
+      return entry.functionTool.execute(args as Record<string, unknown>);
+    }
+    case "mcp": {
+      const mcpClient = deps.getMcpClient();
+      if (!mcpClient) throw new Error("MCP client not connected");
+      const oboToken = runState.req.headers["x-forwarded-access-token"];
+      const mcpAuth =
+        typeof oboToken === "string"
+          ? { Authorization: `Bearer ${oboToken}` }
+          : undefined;
+      return mcpClient.callTool(entry.mcpToolName, args, mcpAuth);
+    }
+    case "subagent": {
+      const childAgent = deps.agents.get(entry.agentName);
+      if (!childAgent)
+        throw new Error(`Sub-agent not found: ${entry.agentName}`);
+      return runSubAgent(deps, runState, childAgent, args, depth + 1);
+    }
+    case "hosted-supervisor":
+      // Defense-in-depth: should never fire. Hosted-supervisor entries are
+      // routed via `AgentInput.extensions` and executed server-side; their
+      // `def` is filtered out of the adapter's `tools`, so the model never
+      // sees a callable schema. Reaching here means a non-SA adapter surfaced
+      // the placeholder def — fail clearly rather than crash in normalize.
+      throw new Error(
+        `Tool '${name}' is a hosted-supervisor tool and cannot be invoked from the Node process. ` +
+          "It is executed server-side by the Databricks AI Gateway and is only reachable when the agent's model is a Supervisor API adapter.",
+      );
+    case "skill":
+      return deps.dispatchSkillTool(entry, args);
+  }
 }
 
 /**

--- a/packages/appkit/src/plugins/agents/tool-dispatch.ts
+++ b/packages/appkit/src/plugins/agents/tool-dispatch.ts
@@ -12,6 +12,7 @@ import type {
   ResolvedToolEntry,
 } from "../../core/agent/types";
 import type { PluginContext } from "../../core/plugin-context";
+import { createLogger } from "../../logging/logger";
 import { buildAdapterExtensions } from "./adapter-extensions";
 import { requiresApproval } from "./approval";
 import type { EventChannel } from "./event-channel";
@@ -19,6 +20,8 @@ import type { AgentEventTranslator } from "./event-translator";
 import { traceTool } from "./mlflow";
 import { composePromptForAgent } from "./prompt";
 import type { ToolApprovalGate } from "./tool-approval-gate";
+
+const logger = createLogger("agents:tools");
 
 /**
  * Per-stream state shared between the top-level `executeTool` and any
@@ -46,6 +49,11 @@ export interface RunState {
   outboundEvents: EventChannel<ResponseStreamEvent>;
   /** Boxed mutable counter shared across parent + all sub-agent dispatches. */
   toolCallsUsed: { count: number };
+  /**
+   * Tool failures captured for the non-streaming `/invocations` response;
+   * the streaming path already emits `tool_result` error events.
+   */
+  toolErrors: Array<{ tool: string; error: string }>;
 }
 
 /**
@@ -129,68 +137,81 @@ export async function dispatchToolCall(
 
   // Traced from here so the span covers execution only, not the approval
   // wait above (which is human latency).
-  const toolResult = await traceTool(name, args, async () => {
-    let result: unknown;
-    if (entry.source === "toolkit") {
-      if (!deps.context) {
-        throw new Error(
-          "Plugin tool execution requires PluginContext; this should never happen through createApp",
+  let toolResult: unknown;
+  try {
+    toolResult = await traceTool(name, args, async () => {
+      let result: unknown;
+      if (entry.source === "toolkit") {
+        if (!deps.context) {
+          throw new Error(
+            "Plugin tool execution requires PluginContext; this should never happen through createApp",
+          );
+        }
+        result = await deps.context.executeTool(
+          runState.req,
+          entry.pluginName,
+          entry.localName,
+          args,
+          runState.signal,
+          runState.limits.toolCallTimeoutMs,
         );
-      }
-      result = await deps.context.executeTool(
-        runState.req,
-        entry.pluginName,
-        entry.localName,
-        args,
-        runState.signal,
-        runState.limits.toolCallTimeoutMs,
-      );
-    } else if (entry.source === "function") {
-      // Function tools declare their parameters as a JSON-object schema,
-      // so adapters always serialize `args` as an object. A non-object
-      // value here means the upstream model emitted malformed tool-call
-      // JSON; surface a clear error rather than silently passing through
-      // a wrong-shape value the tool will then choke on.
-      if (typeof args !== "object" || args === null || Array.isArray(args)) {
-        throw new Error(
-          `Function tool '${name}' received non-object arguments (got ${args === null ? "null" : Array.isArray(args) ? "array" : typeof args}); expected a JSON object.`,
+      } else if (entry.source === "function") {
+        // Function tools declare their parameters as a JSON-object schema,
+        // so adapters always serialize `args` as an object. A non-object
+        // value here means the upstream model emitted malformed tool-call
+        // JSON; surface a clear error rather than silently passing through
+        // a wrong-shape value the tool will then choke on.
+        if (typeof args !== "object" || args === null || Array.isArray(args)) {
+          throw new Error(
+            `Function tool '${name}' received non-object arguments (got ${args === null ? "null" : Array.isArray(args) ? "array" : typeof args}); expected a JSON object.`,
+          );
+        }
+        result = await entry.functionTool.execute(
+          args as Record<string, unknown>,
         );
+      } else if (entry.source === "mcp") {
+        const mcpClient = deps.getMcpClient();
+        if (!mcpClient) throw new Error("MCP client not connected");
+        const oboToken = runState.req.headers["x-forwarded-access-token"];
+        const mcpAuth =
+          typeof oboToken === "string"
+            ? { Authorization: `Bearer ${oboToken}` }
+            : undefined;
+        result = await mcpClient.callTool(entry.mcpToolName, args, mcpAuth);
+      } else if (entry.source === "subagent") {
+        const childAgent = deps.agents.get(entry.agentName);
+        if (!childAgent)
+          throw new Error(`Sub-agent not found: ${entry.agentName}`);
+        result = await runSubAgent(deps, runState, childAgent, args, depth + 1);
+      } else if (entry.source === "hosted-supervisor") {
+        // Defense-in-depth: should never fire. Hosted-supervisor entries are
+        // routed via `AgentInput.extensions` and the SA endpoint executes
+        // them server-side; their `def` is filtered out of the adapter's
+        // `tools` array, so the model never sees a callable schema for them.
+        // If we reach here, the agent is paired with a non-SA adapter that
+        // somehow surfaced the placeholder def to the model — surface a
+        // clear error rather than crash later in `normalizeToolResult`.
+        throw new Error(
+          `Tool '${name}' is a hosted-supervisor tool and cannot be invoked from the Node process. ` +
+            "It is executed server-side by the Databricks AI Gateway and is only reachable when the agent's model is a Supervisor API adapter.",
+        );
+      } else if (entry.source === "skill") {
+        result = await deps.dispatchSkillTool(entry, args);
       }
-      result = await entry.functionTool.execute(
-        args as Record<string, unknown>,
-      );
-    } else if (entry.source === "mcp") {
-      const mcpClient = deps.getMcpClient();
-      if (!mcpClient) throw new Error("MCP client not connected");
-      const oboToken = runState.req.headers["x-forwarded-access-token"];
-      const mcpAuth =
-        typeof oboToken === "string"
-          ? { Authorization: `Bearer ${oboToken}` }
-          : undefined;
-      result = await mcpClient.callTool(entry.mcpToolName, args, mcpAuth);
-    } else if (entry.source === "subagent") {
-      const childAgent = deps.agents.get(entry.agentName);
-      if (!childAgent)
-        throw new Error(`Sub-agent not found: ${entry.agentName}`);
-      result = await runSubAgent(deps, runState, childAgent, args, depth + 1);
-    } else if (entry.source === "hosted-supervisor") {
-      // Defense-in-depth: should never fire. Hosted-supervisor entries are
-      // routed via `AgentInput.extensions` and the SA endpoint executes
-      // them server-side; their `def` is filtered out of the adapter's
-      // `tools` array, so the model never sees a callable schema for them.
-      // If we reach here, the agent is paired with a non-SA adapter that
-      // somehow surfaced the placeholder def to the model — surface a
-      // clear error rather than crash later in `normalizeToolResult`.
-      throw new Error(
-        `Tool '${name}' is a hosted-supervisor tool and cannot be invoked from the Node process. ` +
-          "It is executed server-side by the Databricks AI Gateway and is only reachable when the agent's model is a Supervisor API adapter.",
-      );
-    } else if (entry.source === "skill") {
-      result = await deps.dispatchSkillTool(entry, args);
-    }
 
-    return result;
-  });
+      return result;
+    });
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    logger.error(
+      "Tool '%s' failed (request %s): %O",
+      name,
+      runState.requestId,
+      err,
+    );
+    runState.toolErrors.push({ tool: name, error });
+    throw err;
+  }
 
   return normalizeToolResult(toolResult);
 }

--- a/packages/appkit/src/plugins/agents/tool-dispatch.ts
+++ b/packages/appkit/src/plugins/agents/tool-dispatch.ts
@@ -140,66 +140,69 @@ export async function dispatchToolCall(
   let toolResult: unknown;
   try {
     toolResult = await traceTool(name, args, async () => {
-      let result: unknown;
-      if (entry.source === "toolkit") {
-        if (!deps.context) {
-          throw new Error(
-            "Plugin tool execution requires PluginContext; this should never happen through createApp",
+      switch (entry.source) {
+        case "toolkit":
+          if (!deps.context) {
+            throw new Error(
+              "Plugin tool execution requires PluginContext; this should never happen through createApp",
+            );
+          }
+          return deps.context.executeTool(
+            runState.req,
+            entry.pluginName,
+            entry.localName,
+            args,
+            runState.signal,
+            runState.limits.toolCallTimeoutMs,
           );
+        case "function": {
+          // Function tools declare their parameters as a JSON-object schema,
+          // so adapters always serialize `args` as an object. A non-object
+          // value here means the upstream model emitted malformed tool-call
+          // JSON; surface a clear error rather than silently passing through
+          // a wrong-shape value the tool will then choke on.
+          if (
+            typeof args !== "object" ||
+            args === null ||
+            Array.isArray(args)
+          ) {
+            throw new Error(
+              `Function tool '${name}' received non-object arguments (got ${args === null ? "null" : Array.isArray(args) ? "array" : typeof args}); expected a JSON object.`,
+            );
+          }
+          return entry.functionTool.execute(args as Record<string, unknown>);
         }
-        result = await deps.context.executeTool(
-          runState.req,
-          entry.pluginName,
-          entry.localName,
-          args,
-          runState.signal,
-          runState.limits.toolCallTimeoutMs,
-        );
-      } else if (entry.source === "function") {
-        // Function tools declare their parameters as a JSON-object schema,
-        // so adapters always serialize `args` as an object. A non-object
-        // value here means the upstream model emitted malformed tool-call
-        // JSON; surface a clear error rather than silently passing through
-        // a wrong-shape value the tool will then choke on.
-        if (typeof args !== "object" || args === null || Array.isArray(args)) {
+        case "mcp": {
+          const mcpClient = deps.getMcpClient();
+          if (!mcpClient) throw new Error("MCP client not connected");
+          const oboToken = runState.req.headers["x-forwarded-access-token"];
+          const mcpAuth =
+            typeof oboToken === "string"
+              ? { Authorization: `Bearer ${oboToken}` }
+              : undefined;
+          return mcpClient.callTool(entry.mcpToolName, args, mcpAuth);
+        }
+        case "subagent": {
+          const childAgent = deps.agents.get(entry.agentName);
+          if (!childAgent)
+            throw new Error(`Sub-agent not found: ${entry.agentName}`);
+          return runSubAgent(deps, runState, childAgent, args, depth + 1);
+        }
+        case "hosted-supervisor":
+          // Defense-in-depth: should never fire. Hosted-supervisor entries are
+          // routed via `AgentInput.extensions` and the SA endpoint executes
+          // them server-side; their `def` is filtered out of the adapter's
+          // `tools` array, so the model never sees a callable schema for them.
+          // If we reach here, the agent is paired with a non-SA adapter that
+          // somehow surfaced the placeholder def to the model — surface a
+          // clear error rather than crash later in `normalizeToolResult`.
           throw new Error(
-            `Function tool '${name}' received non-object arguments (got ${args === null ? "null" : Array.isArray(args) ? "array" : typeof args}); expected a JSON object.`,
+            `Tool '${name}' is a hosted-supervisor tool and cannot be invoked from the Node process. ` +
+              "It is executed server-side by the Databricks AI Gateway and is only reachable when the agent's model is a Supervisor API adapter.",
           );
-        }
-        result = await entry.functionTool.execute(
-          args as Record<string, unknown>,
-        );
-      } else if (entry.source === "mcp") {
-        const mcpClient = deps.getMcpClient();
-        if (!mcpClient) throw new Error("MCP client not connected");
-        const oboToken = runState.req.headers["x-forwarded-access-token"];
-        const mcpAuth =
-          typeof oboToken === "string"
-            ? { Authorization: `Bearer ${oboToken}` }
-            : undefined;
-        result = await mcpClient.callTool(entry.mcpToolName, args, mcpAuth);
-      } else if (entry.source === "subagent") {
-        const childAgent = deps.agents.get(entry.agentName);
-        if (!childAgent)
-          throw new Error(`Sub-agent not found: ${entry.agentName}`);
-        result = await runSubAgent(deps, runState, childAgent, args, depth + 1);
-      } else if (entry.source === "hosted-supervisor") {
-        // Defense-in-depth: should never fire. Hosted-supervisor entries are
-        // routed via `AgentInput.extensions` and the SA endpoint executes
-        // them server-side; their `def` is filtered out of the adapter's
-        // `tools` array, so the model never sees a callable schema for them.
-        // If we reach here, the agent is paired with a non-SA adapter that
-        // somehow surfaced the placeholder def to the model — surface a
-        // clear error rather than crash later in `normalizeToolResult`.
-        throw new Error(
-          `Tool '${name}' is a hosted-supervisor tool and cannot be invoked from the Node process. ` +
-            "It is executed server-side by the Databricks AI Gateway and is only reachable when the agent's model is a Supervisor API adapter.",
-        );
-      } else if (entry.source === "skill") {
-        result = await deps.dispatchSkillTool(entry, args);
+        case "skill":
+          return deps.dispatchSkillTool(entry, args);
       }
-
-      return result;
     });
   } catch (err) {
     const error = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Problem

Follow-up to the "Additional note" in #558. When a tool throws inside the `agents` plugin, the adapter catches it, emits a `tool_result` error event + an `{"error": "..."}` tool message, and the model recovers with an ungrounded answer. On the **non-streaming `/invocations`** surface the failure then disappears entirely:

- **No server log** — the adapter catch writes nothing (only `console.debug` exists for SSE parsing). The reporter's "not even a clear log at error level".
- **Dropped from the response** — `_runAgentNonStreaming` consumes the stream with no `onEvent`, so the `tool_result` error is discarded and the envelope returns `status: "completed"` with only the ungrounded text.

The streaming path already forwards tool errors to clients (`event-translator.ts` `handleToolResult`), so this is a non-streaming + logging gap.

## Changes

1. **Log tool failures at error level** in `dispatchToolCall` (`tool-dispatch.ts`) — the single chokepoint every tool (toolkit / function / mcp / sub-agent / skill), adapter, and HTTP path routes through. Previously nothing was logged.
2. **Surface in the `/invocations` response** — capture failures in `RunState.toolErrors` and add an **additive** `tool_errors: [{ tool, error }]` field to the non-streaming JSON envelope (only when non-empty). Streaming is unchanged (already emits `tool_result` errors).
3. **Clearer `tools(plugins)` proxy error** — `createPluginsProxy` now distinguishes a plugin that is **registered but exposes no agent tools** (not a `ToolProvider`, e.g. `aiSearch`) from one that is genuinely **not registered**. Because the proxy is closure-captured, this improves both the eager (setup-time) and lazy (runtime, inside `execute`) reference cases.

### Note on "fail-fast"

An **eager** `tools(plugins)` reference to a missing/non-toolkit plugin *already* fails fast at agent setup (registration rethrows). The reporter's case was a **lazy** reference (`plugins.aiSearch.query()` inside a tool's `execute`), which setup can't see — that path is covered by the logging + response surfacing above, plus the clearer proxy message.

## Testing

- `dispatch-tool-call.test.ts`: a throwing tool → `dispatchToolCall` rethrows and records `{tool, error}` in `runState.toolErrors`.
- `route-handler-errors.test.ts`: a `/invocations` run with a failing tool → response is still `completed` **and** includes `tool_errors`.
- `plugins-map.test.ts` (new): proxy miss for a registered-non-provider name yields the new message; unknown name yields the old one.
- Full agents + core-agent suites: 399 passing. `tsc --noEmit`, `oxlint`, `oxfmt --check`: clean.

Relates to #558 (the "Additional note"). Does not close it — #559 covers the primary array-content bug; this covers error visibility.