### PR TITLE
feat(stream): make SSE maxEventSize configurable end-to-end

### DIFF
--- a/packages/appkit/src/plugin/plugin.ts
+++ b/packages/appkit/src/plugin/plugin.ts
@@ -251,7 +251,7 @@ export abstract class Plugin<
       config.name ??
       (this.constructor as { manifest?: { name: string } }).manifest?.name ??
       "plugin";
-    this.streamManager = new StreamManager();
+    this.streamManager = new StreamManager(config.streamConfig);
     this.app = new AppManager();
     this.devFileReader = DevFileReader.getInstance();
     this.context = (config as Record<string, unknown>).context as

--- a/packages/appkit/src/plugin/tests/plugin.test.ts
+++ b/packages/appkit/src/plugin/tests/plugin.test.ts
@@ -261,6 +261,19 @@ describe("Plugin", () => {
       expect(AppManager).toHaveBeenCalledTimes(1);
       expect(StreamManager).toHaveBeenCalledTimes(1);
     });
+
+    test("should forward streamConfig to the StreamManager", () => {
+      const streamConfig = { maxEventSize: 20 * 1024 * 1024 };
+      new TestPlugin({ ...config, streamConfig });
+
+      expect(StreamManager).toHaveBeenCalledWith(streamConfig);
+    });
+
+    test("should construct the StreamManager with defaults when no streamConfig", () => {
+      new TestPlugin(config);
+
+      expect(StreamManager).toHaveBeenCalledWith(undefined);
+    });
   });
 
   describe("setup", () => {

--- a/packages/shared/src/plugin.ts
+++ b/packages/shared/src/plugin.ts
@@ -1,6 +1,7 @@
 import type express from "express";
 import type { JSONSchema7 } from "json-schema";
 
+import type { StreamConfig } from "./execute";
 import type {
   DiscoveryDescriptor,
   PluginManifest as GeneratedPluginManifest,
@@ -72,6 +73,14 @@ export interface BasePluginConfig {
    * @default true for all telemetry types
    */
   telemetry?: TelemetryOptions;
+
+  /**
+   * SSE stream configuration for this plugin's `executeStream()` calls (buffer
+   * sizes, `maxEventSize`, TTL, heartbeat). Sets the plugin's StreamManager
+   * defaults; a per-call `stream` config still overrides these. Use it to raise
+   * `maxEventSize` above the 5 MiB default when a stream emits larger events.
+   */
+  streamConfig?: StreamConfig;
 }
 
 export type TelemetryOptions =


### PR DESCRIPTION
## Summary

Makes the SSE `maxEventSize` limit actually overridable by application code. Two commits:

1. **`fix(stream)` (existing)** — raise the default event limit to 5 MiB, honour a per-call `maxEventSize` (it was read off the `StreamManager` instance, so per-call values passed via `executeStream({ stream })` type-checked and were then silently ignored), and measure UTF-8 bytes instead of `String.length`.

2. **`feat(stream)` (new)** — expose `streamConfig` on `BasePluginConfig`.

### Why the second commit

Even after the per-call fix, no shipped path could reach the knob:

- `Plugin` always constructed `new StreamManager()` with no options, so the constructor-level defaults (including `maxEventSize`) were unreachable through plugin config.
- The built-in `analytics` plugin — the one that emits `Event exceeds max size` — builds its `StreamExecutionSettings` with no `stream` field, so the per-call override never reached it.

Result: an app hitting the limit had no way to raise it without patching AppKit.

### Change

Add `streamConfig?: StreamConfig` to `BasePluginConfig` and forward it to the plugin's `StreamManager`. A per-call `executeStream({ stream })` override still layers on top of these instance defaults.

```ts
createApp({
  plugins: [
    analytics({
      streamConfig: { maxEventSize: 20 * 1024 * 1024 }, // 20 MiB, overrides the 5 MiB default
    }),
  ],
});
```

## Notes

- Per-plugin: each plugin instance can carry its own stream limits.
- Client side must be raised in tandem — a browser using `connectSSE`'s default `maxBufferSize` (5 MiB) will reject a larger event; pass `connectSSE({ maxBufferSize })` to match.

## Testing

- New plugin tests assert `streamConfig` is forwarded to the `StreamManager` constructor (and `undefined` when unset).
- `plugin.test.ts` (54) and `stream/tests/` (112) pass.

This pull request and its description were written by Isaac.