### PR TITLE
feat(appkit): thread the app cache through PluginContext

### DIFF
--- a/packages/appkit/src/core/appkit.ts
+++ b/packages/appkit/src/core/appkit.ts
@@ -32,10 +32,16 @@ export class AppKit<TPlugins extends InputPluginMap> {
   #setupPromises: Promise<void>[] = [];
   #context: PluginContext;
 
-  private constructor(config: { plugins: TPlugins }) {
+  /**
+   * @param context - The app's plugin context, carrying this app's cache. Built
+   *   in `_createApp` after the cache so it can be injected here, rather than
+   *   constructed inside AppKit — this is what lets a later change give each
+   *   app its own manager.
+   */
+  private constructor(config: { plugins: TPlugins }, context: PluginContext) {
     const { plugins, ...globalConfig } = config;
 
-    this.#context = new PluginContext();
+    this.#context = context;
 
     const pluginEntries = Object.entries(plugins);
 
@@ -194,7 +200,7 @@ export class AppKit<TPlugins extends InputPluginMap> {
   ): Promise<PluginMap<T>> {
     // Initialize core services
     TelemetryManager.initialize(config?.telemetry);
-    await CacheManager.getInstance(config?.cache);
+    const cache = await CacheManager.getInstance(config?.cache);
 
     const withDefaults = AppKit.withDefaultPlugins(config.plugins as T);
     const rawPlugins = AppKit.filterDevOnlyPlugins(withDefaults);
@@ -220,7 +226,8 @@ export class AppKit<TPlugins extends InputPluginMap> {
       plugins: preparedPlugins,
     };
 
-    const instance = new AppKit(mergedConfig);
+    const context = new PluginContext({ cache });
+    const instance = new AppKit(mergedConfig, context);
 
     await Promise.all(instance.#setupPromises);
     await instance.#context.emitLifecycle("setup:complete");

--- a/packages/appkit/src/core/plugin-context.ts
+++ b/packages/appkit/src/core/plugin-context.ts
@@ -1,6 +1,7 @@
 import type express from "express";
 import type { BasePlugin, IAppRequest, ToolProvider } from "shared";
 
+import type { CacheManager } from "../cache";
 import { createLogger } from "../logging/logger";
 import {
   type ITelemetry,
@@ -70,16 +71,24 @@ export class PluginContext {
   private telemetry: ITelemetry;
 
   /**
+   * This app's cache. `createApp` injects the manager it builds here so every
+   * plugin reads it as `this.cache`. Optional: a context can be built without
+   * one (a bare test context, or the app-less `runAgent` path), in which case
+   * plugins fall back to the process-wide `CacheManager`.
+   */
+  readonly cache?: CacheManager;
+
+  /**
    * @param deps.telemetry - Telemetry provider used for `executeTool` spans.
    *   Defaults to the shared `"plugin-context"` provider — the production
    *   path. Injectable so the testing kit can pass a mock provider and run
-   *   `executeTool` without a live OpenTelemetry pipeline. This is the only
-   *   seam the mock context needs; route buffering and the tool registry are
-   *   exercised through the existing public API.
+   *   `executeTool` without a live OpenTelemetry pipeline.
+   * @param deps.cache - The manager `createApp` built for this app.
    */
-  constructor(deps: { telemetry?: ITelemetry } = {}) {
+  constructor(deps: { telemetry?: ITelemetry; cache?: CacheManager } = {}) {
     this.telemetry =
       deps.telemetry ?? TelemetryManager.getProvider("plugin-context");
+    this.cache = deps.cache;
   }
 
   /**

--- a/packages/appkit/src/plugin/plugin.ts
+++ b/packages/appkit/src/plugin/plugin.ts
@@ -268,7 +268,7 @@ export abstract class Plugin<
 
   private tryAttachContext(): void {
     try {
-      this.cache = CacheManager.getInstanceSync();
+      this.cache = this.context?.cache ?? CacheManager.getInstanceSync();
     } catch {
       return;
     }
@@ -293,16 +293,16 @@ export abstract class Plugin<
       telemetryConfig?: BasePluginConfig["telemetry"];
     } = {},
   ): void {
+    if (deps.context !== undefined) {
+      this.context = deps.context as PluginContext;
+    }
     if (!this.cache) {
-      this.cache = CacheManager.getInstanceSync();
+      this.cache = this.context?.cache ?? CacheManager.getInstanceSync();
     }
     this.telemetry = TelemetryManager.getProvider(
       this.name,
       deps.telemetryConfig ?? this.config.telemetry,
     );
-    if (deps.context !== undefined) {
-      this.context = deps.context as PluginContext;
-    }
     this.isReady = true;
   }
 


### PR DESCRIPTION
## Stack

- [**#572** — thread the cache through PluginContext](https://github.com/databricks/appkit/pull/572) ← **you are here**
  - [**#573** — give each app its own CacheManager](https://github.com/databricks/appkit/pull/573)

#573 stacks on top of this one and holds the behavioural change — review this first.

## Summary

Threads the app's `CacheManager` through `PluginContext`. `createApp` injects the manager it builds, and a plugin reads it from its context as `this.cache`, falling back to the process-wide manager when a context carries none.

Behaviour is unchanged — the injected cache is still the singleton, so this is a no-op for existing apps. It's the groundwork for #573, which gives each app its own manager and removes the singleton; kept separate so that change is a focused review rather than a 60-file one.

## What changes

- `PluginContext` gains an optional, `readonly` `cache`; `createApp` passes the manager into it.
- `Plugin` binds `this.cache` from its context first, then the singleton.
- `CacheManager.getInstance` / `getInstanceSync` are untouched; no consumer or test changes.

## Verification

- `pnpm test` — 4659 passing, 1 skipped
- `pnpm -r typecheck`, `pnpm check` — clean
