### PR TITLE
fix(appkit): bind `this` on asUser exports so OBO methods keep their receiver

### DIFF
--- a/packages/appkit/src/core/tests/appkit-as-user-exports.test.ts
+++ b/packages/appkit/src/core/tests/appkit-as-user-exports.test.ts
@@ -129,12 +129,28 @@ class ContextProbePlugin extends Plugin {
     return getUserContext();
   }
 
+  /**
+   * Mirrors the analytics `query` export that PR #385 broke: a class method
+   * that dereferences `this` (there: `this.queryProcessor`). Exported UNBOUND
+   * below. If the asUser proxy hands it out without binding `this`, reading
+   * `this.marker` throws "Cannot read properties of undefined" — the exact
+   * reported symptom — before it can read the user context.
+   */
+  private readonly marker = "probe";
+  getContextViaThis() {
+    if (this.marker !== "probe") throw new Error("wrong instance");
+    return getUserContext();
+  }
+
   exports() {
     return {
       // Class method bound to this
       getContext: this.getContext.bind(this),
       // Inline arrow function — the key case this fix addresses
       getContextArrow: () => getUserContext(),
+      // Unbound class-method reference (the analytics `query: this.query`
+      // pattern). Regression guard for PR #385.
+      getContextRaw: this.getContextViaThis,
     };
   }
 }
@@ -193,6 +209,30 @@ describe("exports-level asUser(req)", () => {
     expect(ctx).toBeDefined();
     expect(ctx.isUserContext).toBe(true);
     expect(ctx.userId).toBe("bob");
+  });
+
+  test("unbound class-method export runs in user context via asUser(req)", async () => {
+    // End-to-end guard for PR #385: exercises the full
+    // createApp → appkit.plugin.asUser(req).method() path with an export
+    // shaped exactly like analytics `query: this.query` (unbound, touches
+    // `this`). Pre-fix this threw "Cannot read properties of undefined".
+    const appkit = (await createApp({ plugins: [probe()] })) as any;
+
+    const req = createMockRequest({
+      headers: {
+        "x-forwarded-access-token": "user-token-abc",
+        "x-forwarded-user": "carol",
+        "x-forwarded-email": "carol@example.com",
+      },
+    });
+
+    const userExports = appkit.probe.asUser(req);
+
+    expect(() => userExports.getContextRaw()).not.toThrow();
+    const ctx = userExports.getContextRaw() as UserContext;
+    expect(ctx).toBeDefined();
+    expect(ctx.isUserContext).toBe(true);
+    expect(ctx.userId).toBe("carol");
   });
 
   test("SP exports (without asUser) do not have user context", async () => {

--- a/packages/appkit/src/plugin/plugin.ts
+++ b/packages/appkit/src/plugin/plugin.ts
@@ -506,7 +506,9 @@ export abstract class Plugin<
             // themselves; leave them untouched.
             if (typeof raw === "function") return raw;
             if (isPlainObject(raw)) {
-              return wrapExportFunctions(raw, wrapCall);
+              return wrapExportFunctions(raw, (fn) =>
+                wrapCall(fn.bind(target)),
+              );
             }
             return raw;
           };

--- a/packages/appkit/src/plugin/tests/asUser-proxy.test.ts
+++ b/packages/appkit/src/plugin/tests/asUser-proxy.test.ts
@@ -82,6 +82,24 @@ class ProbePlugin extends Plugin<BasePluginConfig> {
     return getUserContext()?.userId;
   }
 
+  /**
+   * The exact shape of the analytics `query` export that PR #385 broke:
+   * an exported method that dereferences `this` (there: `this.queryProcessor`).
+   * If the proxy hands this out unbound, `this` is `undefined` and reading
+   * `this.instanceMarker` throws the reported
+   * "Cannot read properties of undefined" TypeError — before it ever gets to
+   * read the user context. Returns the user id so one assertion proves BOTH
+   * that `this` is bound and that the user scope is applied.
+   */
+  private readonly instanceMarker = "probe-instance";
+  observeViaThis(): string | undefined {
+    // Touch `this` first — this is the line that threw pre-fix.
+    if (this.instanceMarker !== "probe-instance") {
+      throw new Error("wrong instance");
+    }
+    return getUserContext()?.userId;
+  }
+
   // Calls observeSync via `this` — we use this to prove the inner call
   // inherits the user context from the outer wrapped call.
   outerCallsInner(): string | undefined {
@@ -100,6 +118,12 @@ class ProbePlugin extends Plugin<BasePluginConfig> {
   exports() {
     return {
       classMethod: this.observeSync.bind(this),
+      // Unbound class-method reference (the analytics `query: this.query`
+      // pattern). The proxy must bind `this` to the target, or the method
+      // runs with `this === undefined` and throws on the first `this.x`.
+      // Regression guard for PR #385. Points at a method that dereferences
+      // `this` so the test actually fails without the bind.
+      rawClassMethod: this.observeViaThis,
       arrowFn: () => getUserContext()?.userId,
       asyncArrowFn: async () => {
         // Force an await so we exercise AsyncLocalStorage propagation.
@@ -333,6 +357,21 @@ describe("Plugin.asUser proxy", () => {
       const exports = plugin.asUser(createReqWithObo()).exports();
 
       expect((exports as any).classMethod()).toBe("alice");
+    });
+
+    test("unbound class-method export binds `this` and sees user context", () => {
+      // Regression for PR #385: `exports()` returning a bare `this.method`
+      // (e.g. analytics `query: this.query`) must run with `this` bound to
+      // the plugin. Before the fix the wrapper called it with no receiver,
+      // so `this === undefined` and the method threw
+      // "Cannot read properties of undefined (reading 'queryProcessor')".
+      const plugin = new ProbePlugin(config);
+      const exports = plugin.asUser(createReqWithObo()).exports() as any;
+
+      // Must not throw (proves `this` is bound) AND must observe the user
+      // context (proves the OBO scope is still applied around the bound fn).
+      expect(() => exports.rawClassMethod()).not.toThrow();
+      expect(exports.rawClassMethod()).toBe("alice");
     });
 
     test("inline arrow function export sees user context", () => {


### PR DESCRIPTION
## Summary

Fixes an OBO (`asUser`) regression: `appkit.<plugin>.asUser(req).query(...)` threw

```
TypeError: Cannot read properties of undefined (reading 'queryProcessor')
```

because the exported method ran with `this === undefined`. The service-principal path (`appkit.<plugin>.query(...)`) was unaffected.

## Root cause

In `packages/appkit/src/plugin/plugin.ts`, `_createAsUserProxy`'s `exports` interception wrapped exported functions with `wrapExportFunctions(raw, wrapCall)` but never bound `this` to the target — unlike the sibling method-call branch, which does `wrapCall(value.bind(target))`.

`wrapExportFunctions` invokes `wrap(fn)` where `wrap` calls `fn(...args)` with no receiver, so any plugin whose `exports()` returns an unbound method reference runs with `this === undefined`. Analytics is exactly this case: `exports() { return { query: this.query }; }`.

Regressed in #385 (shipped in 0.37.0).

## Fix

One line, mirroring the method-call branch — bind the receiver before wrapping:

```diff
-              return wrapExportFunctions(raw, wrapCall);
+              return wrapExportFunctions(raw, (fn) =>
+                wrapCall(fn.bind(target)),
+              );
```

This fixes every plugin whose `exports()` returns a bare `this.method`, not just analytics, and covers the dev-fallback path since it shares the same proxy.

## Tests

Regression guards added at two layers, both verified **red before the fix** (reproducing the exact `Cannot read properties of undefined` TypeError) and **green after**:

- `plugin/tests/asUser-proxy.test.ts` — proxy-level unit test with an unbound export that dereferences `this`.
- `core/tests/appkit-as-user-exports.test.ts` — end-to-end guard through `createApp` → `appkit.plugin.asUser(req).method()`, shaped like analytics' `query: this.query`.

The pre-existing tests missed this because their exports were all either pre-bound (`this.method.bind(this)`) or arrows, and their probe methods never dereferenced `this`.

## Verification

- appkit unit suite: **3439 passed, 1 skipped** (pre-existing intentional skip)
- `@databricks/appkit typecheck`: clean
- `pnpm check` (oxlint + oxfmt): no new warnings in touched files
