### PR TITLE
feat(agents): chat-history UI (hooks + components)

### DIFF
--- a/apps/dev-playground/client/src/lib/nav.ts
+++ b/apps/dev-playground/client/src/lib/nav.ts
@@ -116,6 +116,13 @@ export const NAV_GROUPS: ReadonlyArray<NavGroup> = [
         icon: BotIcon,
       },
       {
+        to: "/agent-history",
+        label: "Agent History",
+        description:
+          "Persistent chat history with <ThreadList> + <AgentThread> — resume, rename, delete across restarts.",
+        icon: LayersIcon,
+      },
+      {
         to: "/genie",
         label: "Genie",
         description:

--- a/apps/dev-playground/client/src/routeTree.gen.ts
+++ b/apps/dev-playground/client/src/routeTree.gen.ts
@@ -28,6 +28,7 @@ import { Route as ChartInferenceRouteRouteImport } from './routes/chart-inferenc
 import { Route as ArrowAnalyticsRouteRouteImport } from './routes/arrow-analytics.route'
 import { Route as AnalyticsRouteRouteImport } from './routes/analytics.route'
 import { Route as AiSearchRouteRouteImport } from './routes/ai-search.route'
+import { Route as AgentHistoryRouteRouteImport } from './routes/agent-history.route'
 import { Route as AgentRouteRouteImport } from './routes/agent.route'
 import { Route as IndexRouteImport } from './routes/index'
 
@@ -126,6 +127,11 @@ const AiSearchRouteRoute = AiSearchRouteRouteImport.update({
   path: '/ai-search',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AgentHistoryRouteRoute = AgentHistoryRouteRouteImport.update({
+  id: '/agent-history',
+  path: '/agent-history',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AgentRouteRoute = AgentRouteRouteImport.update({
   id: '/agent',
   path: '/agent',
@@ -140,6 +146,7 @@ const IndexRoute = IndexRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/agent': typeof AgentRouteRoute
+  '/agent-history': typeof AgentHistoryRouteRoute
   '/ai-search': typeof AiSearchRouteRoute
   '/analytics': typeof AnalyticsRouteRoute
   '/arrow-analytics': typeof ArrowAnalyticsRouteRoute
@@ -163,6 +170,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/agent': typeof AgentRouteRoute
+  '/agent-history': typeof AgentHistoryRouteRoute
   '/ai-search': typeof AiSearchRouteRoute
   '/analytics': typeof AnalyticsRouteRoute
   '/arrow-analytics': typeof ArrowAnalyticsRouteRoute
@@ -187,6 +195,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/agent': typeof AgentRouteRoute
+  '/agent-history': typeof AgentHistoryRouteRoute
   '/ai-search': typeof AiSearchRouteRoute
   '/analytics': typeof AnalyticsRouteRoute
   '/arrow-analytics': typeof ArrowAnalyticsRouteRoute
@@ -212,6 +221,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/agent'
+    | '/agent-history'
     | '/ai-search'
     | '/analytics'
     | '/arrow-analytics'
@@ -235,6 +245,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/agent'
+    | '/agent-history'
     | '/ai-search'
     | '/analytics'
     | '/arrow-analytics'
@@ -258,6 +269,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/agent'
+    | '/agent-history'
     | '/ai-search'
     | '/analytics'
     | '/arrow-analytics'
@@ -282,6 +294,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AgentRouteRoute: typeof AgentRouteRoute
+  AgentHistoryRouteRoute: typeof AgentHistoryRouteRoute
   AiSearchRouteRoute: typeof AiSearchRouteRoute
   AnalyticsRouteRoute: typeof AnalyticsRouteRoute
   ArrowAnalyticsRouteRoute: typeof ArrowAnalyticsRouteRoute
@@ -438,6 +451,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AiSearchRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/agent-history': {
+      id: '/agent-history'
+      path: '/agent-history'
+      fullPath: '/agent-history'
+      preLoaderRoute: typeof AgentHistoryRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/agent': {
       id: '/agent'
       path: '/agent'
@@ -458,6 +478,7 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AgentRouteRoute: AgentRouteRoute,
+  AgentHistoryRouteRoute: AgentHistoryRouteRoute,
   AiSearchRouteRoute: AiSearchRouteRoute,
   AnalyticsRouteRoute: AnalyticsRouteRoute,
   ArrowAnalyticsRouteRoute: ArrowAnalyticsRouteRoute,

--- a/apps/dev-playground/client/src/routes/agent-history.route.tsx
+++ b/apps/dev-playground/client/src/routes/agent-history.route.tsx
@@ -14,23 +14,14 @@ export const Route = createFileRoute("/agent-history")({
  * the agents plugin uses LakebaseThreadStore (see server/index.ts).
  */
 function AgentHistoryRoute() {
-  // `undefined` = a fresh conversation; a string = an opened thread.
+  // `undefined` = a fresh conversation; a string = an opened thread. Switching
+  // is driven purely by this prop — no remount — so <AgentThread>'s per-thread
+  // transcript cache survives and re-opening a thread doesn't refetch.
   const [activeThreadId, setActiveThreadId] = useState<string | undefined>();
-  // Bumping this key remounts <AgentThread> for a clean "New" conversation.
-  const [threadKey, setThreadKey] = useState(0);
   // Bumping this tells <ThreadList> to refetch (new/updated thread).
   const [listSignal, setListSignal] = useState(0);
 
-  const openThread = useCallback((id: string) => {
-    setActiveThreadId(id);
-    setThreadKey((k) => k + 1);
-  }, []);
-
-  const newConversation = useCallback(() => {
-    setActiveThreadId(undefined);
-    setThreadKey((k) => k + 1);
-  }, []);
-
+  const newConversation = useCallback(() => setActiveThreadId(undefined), []);
   const refreshList = useCallback(() => setListSignal((n) => n + 1), []);
 
   return (
@@ -50,14 +41,13 @@ function AgentHistoryRoute() {
           <div className="w-72 shrink-0 rounded-lg border bg-card">
             <ThreadList
               activeThreadId={activeThreadId}
-              onSelect={openThread}
+              onSelect={setActiveThreadId}
               onNewThread={newConversation}
               refetchSignal={listSignal}
             />
           </div>
           <div className="min-w-0 flex-1 rounded-lg border bg-card">
             <AgentThread
-              key={threadKey}
               threadId={activeThreadId}
               onThreadCreated={setActiveThreadId}
               onTurnComplete={refreshList}

--- a/apps/dev-playground/client/src/routes/agent-history.route.tsx
+++ b/apps/dev-playground/client/src/routes/agent-history.route.tsx
@@ -1,0 +1,70 @@
+import { AgentThread, ThreadList } from "@databricks/appkit-ui/react/beta";
+import { createFileRoute } from "@tanstack/react-router";
+import { useCallback, useState } from "react";
+
+export const Route = createFileRoute("/agent-history")({
+  component: AgentHistoryRoute,
+});
+
+/**
+ * Persistent chat history with the beta appkit-ui components. `<ThreadList>`
+ * (left) owns the list; `<AgentThread>` (right) owns the active conversation.
+ * The page holds the active thread id and wires the two together — clicking a
+ * thread opens it, a new/finished turn refreshes the list. Threads persist when
+ * the agents plugin uses LakebaseThreadStore (see server/index.ts).
+ */
+function AgentHistoryRoute() {
+  // `undefined` = a fresh conversation; a string = an opened thread.
+  const [activeThreadId, setActiveThreadId] = useState<string | undefined>();
+  // Bumping this key remounts <AgentThread> for a clean "New" conversation.
+  const [threadKey, setThreadKey] = useState(0);
+  // Bumping this tells <ThreadList> to refetch (new/updated thread).
+  const [listSignal, setListSignal] = useState(0);
+
+  const openThread = useCallback((id: string) => {
+    setActiveThreadId(id);
+    setThreadKey((k) => k + 1);
+  }, []);
+
+  const newConversation = useCallback(() => {
+    setActiveThreadId(undefined);
+    setThreadKey((k) => k + 1);
+  }, []);
+
+  const refreshList = useCallback(() => setListSignal((n) => n + 1), []);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="mx-auto max-w-7xl px-6 py-12">
+        <div className="mb-8">
+          <h1 className="mb-2 text-3xl font-bold">Agent History</h1>
+          <p className="text-base text-muted-foreground">
+            <code>&lt;ThreadList&gt;</code> + <code>&lt;AgentThread&gt;</code>{" "}
+            from <code>@databricks/appkit-ui/react/beta</code>. Threads persist
+            across restarts when the agent uses <code>LakebaseThreadStore</code>
+            .
+          </p>
+        </div>
+
+        <div className="flex h-[700px] gap-6">
+          <div className="w-72 shrink-0 rounded-lg border bg-card">
+            <ThreadList
+              activeThreadId={activeThreadId}
+              onSelect={openThread}
+              onNewThread={newConversation}
+              refetchSignal={listSignal}
+            />
+          </div>
+          <div className="min-w-0 flex-1 rounded-lg border bg-card">
+            <AgentThread
+              key={threadKey}
+              threadId={activeThreadId}
+              onThreadCreated={setActiveThreadId}
+              onTurnComplete={refreshList}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/docs/docs/plugins/agents.md
+++ b/docs/docs/plugins/agents.md
@@ -528,6 +528,46 @@ interface ThreadStore {
 For the exact exported symbols, run `npx @databricks/appkit docs` and open the
 `appkit` API reference.
 
+### Chat-history UI (`@databricks/appkit-ui`)
+
+The persistence above powers a history sidebar on the client. `@databricks/appkit-ui/react/beta` ships two hooks and two drop-in components (beta), built on the thread endpoints (`GET /threads` summaries, `GET /threads/:id`, `PATCH`/`DELETE /threads/:id`):
+
+| Export | Kind | What it does |
+| --- | --- | --- |
+| `useAgentThreads()` | hook | Lists thread summaries; `deleteThread` / `renameThread` (optimistic); `refetch`. Owns the list, not the active chat. |
+| `useAgentThread(threadId?)` | hook | One conversation's transcript — loads history, streams turns (on `useAgentChat`), resumes an existing thread or creates a new one. |
+| `<ThreadList>` | component | History sidebar over `useAgentThreads`: controlled selection (`activeThreadId` / `onSelect`), per-row rename + delete. |
+| `<AgentThread>` | component | Transcript + composer over `useAgentThread`; `onThreadCreated` / `onTurnComplete` let the page refresh the list. |
+
+They're **sibling** pieces (the list and the active conversation are separate lifecycles) — compose them at the page level; the page holds the active thread id:
+
+```tsx
+import { AgentThread, ThreadList } from "@databricks/appkit-ui/react/beta";
+
+function AgentHistory() {
+  const [active, setActive] = useState<string>();
+  const [refresh, setRefresh] = useState(0);
+  return (
+    <div className="flex gap-4 h-[700px]">
+      <ThreadList
+        activeThreadId={active}
+        onSelect={setActive}
+        onNewThread={() => setActive(undefined)}
+        refetchSignal={refresh}
+      />
+      <AgentThread
+        key={active ?? "new"}
+        threadId={active}
+        onThreadCreated={setActive}
+        onTurnComplete={() => setRefresh((n) => n + 1)}
+      />
+    </div>
+  );
+}
+```
+
+The same components work with any `ThreadStore` — the list just isn't durable across restarts unless the agent uses `LakebaseThreadStore`. See the dev-playground `Agent History` route for a working example. `<AgentThread>` renders plain-text messages in v1 (markdown and tool-call chips are a planned enhancement).
+
 ## Configuration reference
 
 ```ts

--- a/docs/static/appkit-ui/styles.gen.css
+++ b/docs/static/appkit-ui/styles.gen.css
@@ -657,6 +657,9 @@
   .h-\[200px\] {
     height: 200px;
   }
+  .h-\[700px\] {
+    height: 700px;
+  }
   .h-\[calc\(100\%-1px\)\] {
     height: calc(100% - 1px);
   }
@@ -836,6 +839,9 @@
   }
   .max-w-\[80\%\] {
     max-width: 80%;
+  }
+  .max-w-\[85\%\] {
+    max-width: 85%;
   }
   .max-w-\[calc\(100\%-2rem\)\] {
     max-width: calc(100% - 2rem);
@@ -1515,6 +1521,9 @@
   .py-12 {
     padding-block: calc(var(--spacing) * 12);
   }
+  .py-20 {
+    padding-block: calc(var(--spacing) * 20);
+  }
   .pt-0 {
     padding-top: calc(var(--spacing) * 0);
   }
@@ -1713,6 +1722,12 @@
   }
   .text-muted-foreground {
     color: var(--muted-foreground);
+  }
+  .text-muted-foreground\/60 {
+    color: var(--muted-foreground);
+    @supports (color: color-mix(in lab, red, red)) {
+      color: color-mix(in oklab, var(--muted-foreground) 60%, transparent);
+    }
   }
   .text-popover-foreground {
     color: var(--popover-foreground);
@@ -2727,6 +2742,11 @@
       color: var(--accent-foreground);
     }
   }
+  .focus\:text-destructive {
+    &:focus {
+      color: var(--destructive);
+    }
+  }
   .focus\:shadow-md {
     &:focus {
       --tw-shadow: 0 4px 6px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 2px 4px -2px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
@@ -2774,6 +2794,11 @@
   .focus-visible\:border-ring {
     &:focus-visible {
       border-color: var(--ring);
+    }
+  }
+  .focus-visible\:opacity-100 {
+    &:focus-visible {
+      opacity: 100%;
     }
   }
   .focus-visible\:shadow-none {

--- a/packages/appkit-ui/src/react/agent/__tests__/thread-list.test.tsx
+++ b/packages/appkit-ui/src/react/agent/__tests__/thread-list.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { ThreadList } from "../thread-list";
+
+const ISO = "2026-06-06T12:00:00.000Z";
+
+function okJson(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("<ThreadList>", () => {
+  test("renders titles (with derived-empty fallback) and selects on click", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      okJson({
+        threads: [
+          {
+            id: "t1",
+            title: "Weather in Paris",
+            messageCount: 2,
+            createdAt: ISO,
+            updatedAt: ISO,
+          },
+          {
+            id: "t2",
+            title: "",
+            messageCount: 0,
+            createdAt: ISO,
+            updatedAt: ISO,
+          },
+        ],
+      }),
+    );
+    const onSelect = vi.fn();
+    render(<ThreadList onSelect={onSelect} />);
+
+    await waitFor(() => expect(screen.getByText("Weather in Paris")));
+    // Empty title falls back to a placeholder label.
+    expect(screen.getByText("New conversation")).toBeTruthy();
+
+    fireEvent.click(screen.getByText("Weather in Paris"));
+    expect(onSelect).toHaveBeenCalledWith("t1");
+  });
+
+  test('renders a "New" button only when onNewThread is provided', async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(okJson({ threads: [] }));
+    const onNewThread = vi.fn();
+    const { rerender } = render(<ThreadList />);
+    await waitFor(() => expect(screen.getByText("No conversations yet")));
+    expect(screen.queryByText("+ New")).toBeNull();
+
+    rerender(<ThreadList onNewThread={onNewThread} />);
+    fireEvent.click(screen.getByText("+ New"));
+    expect(onNewThread).toHaveBeenCalled();
+  });
+});

--- a/packages/appkit-ui/src/react/agent/agent-thread.tsx
+++ b/packages/appkit-ui/src/react/agent/agent-thread.tsx
@@ -1,0 +1,184 @@
+import { type KeyboardEvent, useEffect, useRef, useState } from "react";
+
+import { useAgentThread } from "../hooks/use-agent-thread";
+import { usePluginClientConfig } from "../hooks/use-plugin-config";
+import { cn } from "../lib/utils";
+import { Button } from "../ui/button";
+import { ScrollArea } from "../ui/scroll-area";
+import { Spinner } from "../ui/spinner";
+
+interface AgentsClientConfig {
+  agents?: string[];
+  defaultAgent?: string | null;
+}
+
+export interface AgentThreadProps {
+  /** Thread to open. Omit for a new conversation (id assigned on first send). */
+  threadId?: string;
+  /** Agent to route turns to. Defaults to the plugin's default agent. */
+  agent?: string;
+  /** Base path the agents plugin is mounted under. Default `"/api/agents"`. */
+  basePath?: string;
+  /** Composer placeholder. */
+  placeholder?: string;
+  /** Mirror the active thread id in the URL (default off). */
+  persistInUrl?: boolean;
+  /** Fired when a brand-new thread gets its server-assigned id (uncontrolled use). */
+  onThreadCreated?: (threadId: string) => void;
+  /** Fired when an assistant turn finishes streaming (e.g. to refresh a list). */
+  onTurnComplete?: () => void;
+  /** Root container class. */
+  className?: string;
+}
+
+/**
+ * A single agent conversation: transcript + composer. Owns
+ * {@link useAgentThread} (history load + streaming). Pair with
+ * {@link ThreadList} — the page holds the active thread id and passes it here.
+ *
+ * @example
+ * ```tsx
+ * <AgentThread threadId={active} onThreadCreated={setActive} onTurnComplete={refetch} />
+ * ```
+ */
+export function AgentThread({
+  threadId,
+  agent,
+  basePath,
+  placeholder = "Ask a question...",
+  persistInUrl,
+  onThreadCreated,
+  onTurnComplete,
+  className,
+}: AgentThreadProps) {
+  const config = usePluginClientConfig<AgentsClientConfig>("agents");
+  const resolvedAgent =
+    agent ?? config.defaultAgent ?? config.agents?.[0] ?? "";
+
+  const {
+    messages,
+    threadId: activeThreadId,
+    loading,
+    isStreaming,
+    error,
+    send,
+  } = useAgentThread(threadId, {
+    agent: resolvedAgent,
+    basePath,
+    persistInUrl,
+  });
+
+  const [input, setInput] = useState("");
+  const endRef = useRef<HTMLDivElement>(null);
+
+  // Notify the parent when an uncontrolled conversation is first created.
+  const prevActive = useRef<string | null>(null);
+  useEffect(() => {
+    if (!threadId && !prevActive.current && activeThreadId) {
+      onThreadCreated?.(activeThreadId);
+    }
+    prevActive.current = activeThreadId;
+  }, [activeThreadId, threadId, onThreadCreated]);
+
+  // Notify the parent when a turn finishes (true -> false).
+  const wasStreaming = useRef(false);
+  useEffect(() => {
+    if (wasStreaming.current && !isStreaming) onTurnComplete?.();
+    wasStreaming.current = isStreaming;
+  }, [isStreaming, onTurnComplete]);
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  const submit = () => {
+    const trimmed = input.trim();
+    if (!trimmed || isStreaming) return;
+    setInput("");
+    void send(trimmed);
+  };
+  const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      submit();
+    }
+  };
+
+  // "Thinking" once a turn is in flight but before the first token lands.
+  const awaitingFirstToken =
+    isStreaming && messages[messages.length - 1]?.role !== "assistant";
+
+  return (
+    <div className={cn("flex h-full flex-col overflow-hidden", className)}>
+      <ScrollArea className="flex-1">
+        <div className="space-y-4 p-4">
+          {loading && (
+            <div className="flex justify-center py-6">
+              <Spinner />
+            </div>
+          )}
+          {!loading && messages.length === 0 && (
+            <p className="py-20 text-center text-muted-foreground">
+              Send a message to start a conversation
+            </p>
+          )}
+          {messages.map((m) => (
+            <div
+              key={m.id}
+              className={cn(
+                "flex",
+                m.role === "user" ? "justify-end" : "justify-start",
+              )}
+            >
+              <div
+                className={cn(
+                  "max-w-[85%] rounded-lg px-4 py-2 text-sm whitespace-pre-wrap",
+                  m.role === "user"
+                    ? "bg-primary text-primary-foreground"
+                    : "bg-muted",
+                )}
+              >
+                {m.content}
+              </div>
+            </div>
+          ))}
+          {awaitingFirstToken && (
+            <div className="flex justify-start">
+              <div className="rounded-lg bg-muted px-4 py-2">
+                <span className="animate-pulse text-sm text-muted-foreground">
+                  Thinking...
+                </span>
+              </div>
+            </div>
+          )}
+          <div ref={endRef} />
+        </div>
+      </ScrollArea>
+
+      {error && (
+        <div className="shrink-0 border-t bg-destructive/10 px-4 py-2 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      <div className="flex shrink-0 gap-2 border-t p-4">
+        <textarea
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={onKeyDown}
+          placeholder={placeholder}
+          rows={1}
+          disabled={isStreaming}
+          className="flex-1 resize-none rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+        />
+        <Button
+          onClick={submit}
+          disabled={isStreaming || !input.trim()}
+          className="self-end"
+        >
+          Send
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/appkit-ui/src/react/agent/index.ts
+++ b/packages/appkit-ui/src/react/agent/index.ts
@@ -1,0 +1,2 @@
+export { AgentThread, type AgentThreadProps } from "./agent-thread";
+export { ThreadList, type ThreadListProps } from "./thread-list";

--- a/packages/appkit-ui/src/react/agent/thread-list.tsx
+++ b/packages/appkit-ui/src/react/agent/thread-list.tsx
@@ -1,0 +1,229 @@
+import { type KeyboardEvent, useEffect, useRef, useState } from "react";
+
+import { useAgentThreads } from "../hooks/use-agent-threads";
+import { cn } from "../lib/utils";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "../ui/alert-dialog";
+import { Button } from "../ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "../ui/dropdown-menu";
+import { ScrollArea } from "../ui/scroll-area";
+import { Spinner } from "../ui/spinner";
+
+export interface ThreadListProps {
+  /** Currently open thread, highlighted in the list. */
+  activeThreadId?: string | null;
+  /** Fired when a thread row is clicked — wire it to your transcript view. */
+  onSelect?: (threadId: string) => void;
+  /** When provided, renders a "New" button that calls this. */
+  onNewThread?: () => void;
+  /**
+   * Bump this to any new value to trigger a refetch — e.g. from
+   * `<AgentThread onTurnComplete>` so the list reflects a new/updated thread.
+   * The initial value never triggers a fetch (the list loads on mount anyway).
+   */
+  refetchSignal?: number;
+  /** Base path the agents plugin is mounted under. Default `"/api/agents"`. */
+  basePath?: string;
+  /** Root container class. */
+  className?: string;
+}
+
+/**
+ * A conversation-history sidebar for agent apps. Owns {@link useAgentThreads}
+ * (list + delete + rename); selection is controlled via `activeThreadId` +
+ * `onSelect` so it pairs with {@link AgentThread}. Built on light primitives so
+ * it drops into any layout.
+ *
+ * @example
+ * ```tsx
+ * const [active, setActive] = useState<string>();
+ * <ThreadList activeThreadId={active} onSelect={setActive} onNewThread={() => setActive(undefined)} />
+ * ```
+ */
+export function ThreadList({
+  activeThreadId,
+  onSelect,
+  onNewThread,
+  refetchSignal,
+  basePath,
+  className,
+}: ThreadListProps) {
+  const { threads, loading, error, refetch, deleteThread, renameThread } =
+    useAgentThreads({ basePath });
+
+  // Refetch when the parent bumps the signal (skips the initial value — the
+  // hook already loads on mount).
+  const initialSignal = useRef(refetchSignal);
+  useEffect(() => {
+    if (
+      refetchSignal !== undefined &&
+      refetchSignal !== initialSignal.current
+    ) {
+      void refetch();
+    }
+  }, [refetchSignal, refetch]);
+
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [draft, setDraft] = useState("");
+  const [pendingDelete, setPendingDelete] = useState<string | null>(null);
+
+  const startRename = (id: string, current: string) => {
+    setRenamingId(id);
+    setDraft(current);
+  };
+  const commitRename = () => {
+    const title = draft.trim();
+    if (renamingId && title) void renameThread(renamingId, title);
+    setRenamingId(null);
+  };
+  const onRenameKey = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      commitRename();
+    } else if (e.key === "Escape") {
+      setRenamingId(null);
+    }
+  };
+
+  return (
+    <div className={cn("flex h-full flex-col", className)}>
+      <div className="flex shrink-0 items-center justify-between border-b px-3 py-2">
+        <span className="text-sm font-semibold text-muted-foreground">
+          Chats
+        </span>
+        {onNewThread && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7"
+            onClick={onNewThread}
+          >
+            + New
+          </Button>
+        )}
+      </div>
+
+      <ScrollArea className="flex-1">
+        <div className="space-y-1 p-2">
+          {loading && threads.length === 0 && (
+            <div className="flex justify-center py-6">
+              <Spinner />
+            </div>
+          )}
+          {!loading && threads.length === 0 && !error && (
+            <p className="py-8 text-center text-xs text-muted-foreground/60">
+              No conversations yet
+            </p>
+          )}
+          {error && (
+            <p className="px-2 py-1 text-xs text-destructive">{error}</p>
+          )}
+
+          {threads.map((t) => {
+            const isActive = t.id === activeThreadId;
+            if (t.id === renamingId) {
+              return (
+                <input
+                  key={t.id}
+                  // oxlint-disable-next-line jsx-a11y/no-autofocus -- rename field appears on user action and should take focus
+                  autoFocus
+                  value={draft}
+                  onChange={(e) => setDraft(e.target.value)}
+                  onBlur={commitRename}
+                  onKeyDown={onRenameKey}
+                  className="w-full rounded-md border border-input bg-background px-2 py-1 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                />
+              );
+            }
+            return (
+              <div
+                key={t.id}
+                className={cn(
+                  "group flex items-center gap-1 rounded-md",
+                  isActive ? "bg-muted" : "hover:bg-muted/50",
+                )}
+              >
+                <button
+                  type="button"
+                  className="min-w-0 flex-1 rounded-md px-2 py-1.5 text-left"
+                  onClick={() => onSelect?.(t.id)}
+                >
+                  <span className="block truncate text-sm">
+                    {t.title || "New conversation"}
+                  </span>
+                  <span className="block text-[10px] text-muted-foreground/60">
+                    {t.updatedAt.toLocaleString()} · {t.messageCount} msg
+                  </span>
+                </button>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <button
+                      type="button"
+                      aria-label="Conversation actions"
+                      className="px-1.5 text-muted-foreground opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
+                    >
+                      ⋯
+                    </button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem
+                      onSelect={() => startRename(t.id, t.title)}
+                    >
+                      Rename
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      className="text-destructive focus:text-destructive"
+                      onSelect={() => setPendingDelete(t.id)}
+                    >
+                      Delete
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            );
+          })}
+        </div>
+      </ScrollArea>
+
+      <AlertDialog
+        open={pendingDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingDelete(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete conversation?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This permanently deletes the conversation and all of its messages.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (pendingDelete) void deleteThread(pendingDelete);
+                setPendingDelete(null);
+              }}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/packages/appkit-ui/src/react/beta.ts
+++ b/packages/appkit-ui/src/react/beta.ts
@@ -5,6 +5,12 @@
 // Tracks the `agents` plugin (beta) and its thread endpoints.
 export type { ThreadSummary } from "shared";
 export {
+  AgentThread,
+  type AgentThreadProps,
+  ThreadList,
+  type ThreadListProps,
+} from "./agent";
+export {
   type UseAgentThreadsOptions,
   type UseAgentThreadsResult,
   useAgentThreads,

--- a/packages/appkit-ui/src/react/beta.ts
+++ b/packages/appkit-ui/src/react/beta.ts
@@ -1,6 +1,21 @@
 // Beta React components -- APIs may change between minor releases.
 // Import from '@databricks/appkit-ui/react' once graduated to stable.
 
+// Agent thread history — hooks + components for a persistent chat sidebar.
+// Tracks the `agents` plugin (beta) and its thread endpoints.
+export type { ThreadSummary } from "shared";
+export {
+  type UseAgentThreadsOptions,
+  type UseAgentThreadsResult,
+  useAgentThreads,
+} from "./hooks/use-agent-threads";
+export {
+  type AgentThreadMessage,
+  type UseAgentThreadOptions,
+  type UseAgentThreadResult,
+  useAgentThread,
+} from "./hooks/use-agent-thread";
+
 // AI Search hook + types. Tracks the `aiSearch` plugin, which ships at beta
 // from '@databricks/appkit/beta'.
 export type {

--- a/packages/appkit-ui/src/react/hooks/__tests__/use-agent-chat.test.ts
+++ b/packages/appkit-ui/src/react/hooks/__tests__/use-agent-chat.test.ts
@@ -250,6 +250,49 @@ describe("useAgentChat", () => {
     });
   });
 
+  test("initialThreadId seeds threadId and is forwarded on the first send()", async () => {
+    const { result } = renderHook(() =>
+      useAgentChat({ agent: "helper", initialThreadId: "t-resumed" }),
+    );
+
+    // Seeded synchronously — no send/metadata needed.
+    expect(result.current.threadId).toBe("t-resumed");
+
+    act(() => {
+      void result.current.send("continue please");
+    });
+    await waitFor(() => expect(mockConnectSSE).toHaveBeenCalled());
+
+    // The very first turn continues the resumed thread instead of creating one.
+    expect(capturedCallbacks.payload).toEqual({
+      message: "continue please",
+      agent: "helper",
+      threadId: "t-resumed",
+    });
+  });
+
+  test("changing initialThreadId re-seeds the thread (switch conversations)", async () => {
+    const { result, rerender } = renderHook(
+      ({ id }: { id?: string }) =>
+        useAgentChat({ agent: "helper", initialThreadId: id }),
+      { initialProps: { id: "t-1" } },
+    );
+    expect(result.current.threadId).toBe("t-1");
+
+    rerender({ id: "t-2" });
+    expect(result.current.threadId).toBe("t-2");
+
+    act(() => {
+      void result.current.send("hi");
+    });
+    await waitFor(() => expect(mockConnectSSE).toHaveBeenCalled());
+    expect(capturedCallbacks.payload).toEqual({
+      message: "hi",
+      agent: "helper",
+      threadId: "t-2",
+    });
+  });
+
   test("onEvent is invoked for every parsed event", async () => {
     const onEvent = vi.fn();
     const { result } = renderHook(() =>

--- a/packages/appkit-ui/src/react/hooks/__tests__/use-agent-thread.test.ts
+++ b/packages/appkit-ui/src/react/hooks/__tests__/use-agent-thread.test.ts
@@ -1,0 +1,166 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+// --- connectSSE harness (drives useAgentChat's streaming) ---
+let capturedOnMessage: ((msg: { data: string }) => Promise<void>) | undefined;
+let resolveStream: (() => void) | null = null;
+
+const mockConnectSSE = vi.fn();
+
+vi.mock("@/js", () => ({
+  connectSSE: (...args: unknown[]) => mockConnectSSE(...args),
+}));
+
+import { useAgentThread } from "../use-agent-thread";
+
+async function emit(data: string) {
+  await capturedOnMessage?.({ data });
+}
+
+function okJson(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  // Re-establish the impl each test — restoreAllMocks() in afterEach would
+  // otherwise strip it, making connectSSE resolve to undefined instantly.
+  mockConnectSSE.mockImplementation(
+    (opts: { onMessage?: typeof capturedOnMessage }) => {
+      capturedOnMessage = opts.onMessage;
+      return new Promise<void>((resolve) => {
+        resolveStream = resolve;
+      });
+    },
+  );
+});
+
+afterEach(() => {
+  capturedOnMessage = undefined;
+  resolveStream = null;
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+describe("useAgentThread", () => {
+  test("resumes a thread: loads history and keeps only user/assistant", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      okJson({
+        id: "t1",
+        messages: [
+          { id: "m1", role: "user", content: "hi" },
+          { id: "m2", role: "assistant", content: "hello" },
+          { id: "m3", role: "system", content: "system prompt" },
+          { id: "m4", role: "tool", content: "{}" },
+        ],
+      }),
+    );
+
+    const { result } = renderHook(() =>
+      useAgentThread("t1", { agent: "helper" }),
+    );
+
+    await waitFor(() => expect(result.current.messages).toHaveLength(2));
+    expect(result.current.messages.map((m) => m.role)).toEqual([
+      "user",
+      "assistant",
+    ]);
+    expect(result.current.messages[1].content).toBe("hello");
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "/api/agents/threads/t1",
+      expect.objectContaining({ signal: expect.anything() }),
+    );
+  });
+
+  test("new thread: send appends the user turn, streams, and commits the assistant turn", async () => {
+    const { result } = renderHook(() =>
+      useAgentThread(undefined, { agent: "helper" }),
+    );
+    expect(result.current.messages).toEqual([]);
+
+    // Send a turn — user message appears immediately.
+    await act(async () => {
+      void result.current.send("what is the weather?");
+    });
+    await waitFor(() => expect(mockConnectSSE).toHaveBeenCalled());
+    expect(result.current.messages).toEqual([
+      expect.objectContaining({
+        role: "user",
+        content: "what is the weather?",
+      }),
+    ]);
+
+    // Server assigns a thread id, then streams the answer.
+    await act(async () => {
+      await emit(
+        JSON.stringify({
+          type: "appkit.metadata",
+          data: { threadId: "srv-1" },
+        }),
+      );
+      await emit(
+        JSON.stringify({ type: "response.output_text.delta", delta: "Sunny" }),
+      );
+    });
+
+    expect(result.current.threadId).toBe("srv-1");
+    // Live streaming bubble is visible mid-turn.
+    expect(result.current.messages.at(-1)).toEqual(
+      expect.objectContaining({ role: "assistant", content: "Sunny" }),
+    );
+    expect(result.current.isStreaming).toBe(true);
+
+    // End the stream → the assistant turn is committed (survives isStreaming=false).
+    await act(async () => {
+      resolveStream?.();
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    await waitFor(() => expect(result.current.isStreaming).toBe(false));
+    expect(result.current.messages).toEqual([
+      expect.objectContaining({
+        role: "user",
+        content: "what is the weather?",
+      }),
+      expect.objectContaining({ role: "assistant", content: "Sunny" }),
+    ]);
+  });
+
+  test("forwards the resumed threadId so the first send continues the thread", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      okJson({ id: "t9", messages: [] }),
+    );
+    const { result } = renderHook(() =>
+      useAgentThread("t9", { agent: "helper" }),
+    );
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+
+    await act(async () => {
+      void result.current.send("continue");
+    });
+    await waitFor(() => expect(mockConnectSSE).toHaveBeenCalled());
+
+    const payload = mockConnectSSE.mock.calls[0][0].payload;
+    expect(payload).toEqual({
+      message: "continue",
+      agent: "helper",
+      threadId: "t9",
+    });
+  });
+
+  test("reset clears the transcript", async () => {
+    const { result } = renderHook(() =>
+      useAgentThread(undefined, { agent: "helper" }),
+    );
+    await act(async () => {
+      void result.current.send("hi");
+    });
+    await waitFor(() => expect(result.current.messages).toHaveLength(1));
+
+    act(() => result.current.reset());
+    expect(result.current.messages).toEqual([]);
+    expect(result.current.threadId).toBeNull();
+  });
+});

--- a/packages/appkit-ui/src/react/hooks/__tests__/use-agent-thread.test.ts
+++ b/packages/appkit-ui/src/react/hooks/__tests__/use-agent-thread.test.ts
@@ -150,6 +150,42 @@ describe("useAgentThread", () => {
     });
   });
 
+  test("caches a loaded thread — re-selecting it does not refetch", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation((input) => {
+        const id = decodeURIComponent(String(input).split("/threads/")[1]);
+        return Promise.resolve(
+          okJson({
+            id,
+            messages: [{ id: `${id}-m1`, role: "user", content: `hi ${id}` }],
+          }),
+        );
+      });
+
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string }) => useAgentThread(id, { agent: "helper" }),
+      { initialProps: { id: "t1" } },
+    );
+    await waitFor(() =>
+      expect(result.current.messages[0]?.content).toBe("hi t1"),
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    rerender({ id: "t2" });
+    await waitFor(() =>
+      expect(result.current.messages[0]?.content).toBe("hi t2"),
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+    // Back to t1 — served from cache, no third fetch.
+    rerender({ id: "t1" });
+    await waitFor(() =>
+      expect(result.current.messages[0]?.content).toBe("hi t1"),
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
   test("reset clears the transcript", async () => {
     const { result } = renderHook(() =>
       useAgentThread(undefined, { agent: "helper" }),

--- a/packages/appkit-ui/src/react/hooks/__tests__/use-agent-threads.test.ts
+++ b/packages/appkit-ui/src/react/hooks/__tests__/use-agent-threads.test.ts
@@ -1,0 +1,154 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { useAgentThreads } from "../use-agent-threads";
+
+const ISO = "2026-05-05T10:00:00.000Z";
+
+function okJson(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/** Route fetch by method + path so multi-call tests get fresh responses. */
+function routeFetch() {
+  return vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
+    const url = String(input);
+    const method = init?.method ?? "GET";
+    if (method === "GET" && url.endsWith("/threads")) {
+      return Promise.resolve(
+        okJson({
+          threads: [
+            {
+              id: "t1",
+              title: "Weather",
+              messageCount: 2,
+              createdAt: ISO,
+              updatedAt: ISO,
+            },
+            {
+              id: "t2",
+              title: "",
+              messageCount: 0,
+              createdAt: ISO,
+              updatedAt: ISO,
+            },
+          ],
+        }),
+      );
+    }
+    // DELETE / PATCH on /threads/:id
+    return Promise.resolve(okJson({ ok: true }));
+  });
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("useAgentThreads", () => {
+  test("loads summaries on mount and revives dates", async () => {
+    const fetchSpy = routeFetch();
+    const { result } = renderHook(() => useAgentThreads());
+
+    await waitFor(() => expect(result.current.threads).toHaveLength(2));
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/agents/threads",
+      expect.objectContaining({ signal: expect.anything() }),
+    );
+    expect(result.current.threads[0].updatedAt).toBeInstanceOf(Date);
+    expect(result.current.threads[0].updatedAt.toISOString()).toBe(ISO);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  test("basePath option is honored", async () => {
+    const fetchSpy = routeFetch();
+    const { result } = renderHook(() =>
+      useAgentThreads({ basePath: "/custom/agents" }),
+    );
+    await waitFor(() => expect(result.current.threads).toHaveLength(2));
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/custom/agents/threads",
+      expect.anything(),
+    );
+  });
+
+  test("deleteThread removes optimistically and calls DELETE", async () => {
+    const fetchSpy = routeFetch();
+    const { result } = renderHook(() => useAgentThreads());
+    await waitFor(() => expect(result.current.threads).toHaveLength(2));
+
+    await act(async () => {
+      await result.current.deleteThread("t1");
+    });
+
+    expect(result.current.threads.map((t) => t.id)).toEqual(["t2"]);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/agents/threads/t1",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  test("renameThread updates the title optimistically and PATCHes", async () => {
+    const fetchSpy = routeFetch();
+    const { result } = renderHook(() => useAgentThreads());
+    await waitFor(() => expect(result.current.threads).toHaveLength(2));
+
+    await act(async () => {
+      await result.current.renameThread("t1", "Renamed");
+    });
+
+    expect(result.current.threads.find((t) => t.id === "t1")?.title).toBe(
+      "Renamed",
+    );
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/agents/threads/t1",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ title: "Renamed" }),
+      }),
+    );
+  });
+
+  test("rolls back a failed delete and surfaces an error", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation((_input, init) => {
+      const method = init?.method ?? "GET";
+      if (method === "GET") {
+        return Promise.resolve(
+          okJson({
+            threads: [
+              {
+                id: "t1",
+                title: "x",
+                messageCount: 1,
+                createdAt: ISO,
+                updatedAt: ISO,
+              },
+            ],
+          }),
+        );
+      }
+      return Promise.resolve(okJson({ error: "boom" }, 500));
+    });
+    const { result } = renderHook(() => useAgentThreads());
+    await waitFor(() => expect(result.current.threads).toHaveLength(1));
+
+    await act(async () => {
+      await result.current.deleteThread("t1");
+    });
+
+    // Rolled back to the server state (refetch), and an error recorded.
+    await waitFor(() => expect(result.current.threads).toHaveLength(1));
+    expect(result.current.error).toBeTruthy();
+  });
+
+  test("surfaces a load error on a non-ok response", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      okJson({ error: "nope" }, 500),
+    );
+    const { result } = renderHook(() => useAgentThreads());
+    await waitFor(() => expect(result.current.error).toBeTruthy());
+    expect(result.current.threads).toEqual([]);
+  });
+});

--- a/packages/appkit-ui/src/react/hooks/use-agent-chat.ts
+++ b/packages/appkit-ui/src/react/hooks/use-agent-chat.ts
@@ -54,6 +54,14 @@ export interface UseAgentChatOptions {
    */
   endpoint?: string;
   /**
+   * Resume an existing thread: seeds `threadId` so the first `send()`
+   * continues that thread instead of creating a new one. Changing it
+   * re-seeds (switch conversations). Without it, a thread id is only
+   * assigned by the server on the first turn. Used by `useAgentThread`
+   * to resume persisted threads; also handy on its own.
+   */
+  initialThreadId?: string;
+  /**
    * Called for every parsed SSE event before any state update. Use this
    * to drive tool-call rows, approval cards, inspectors, or anything
    * beyond the streaming text content. Errors thrown here are swallowed
@@ -164,19 +172,22 @@ function resolveSkill(
 export function useAgentChat({
   agent,
   endpoint = "/api/agents/chat",
+  initialThreadId,
   onEvent,
   skills,
 }: UseAgentChatOptions): UseAgentChatResult {
   const [content, setContent] = useState("");
   const [events, setEvents] = useState<AgentChatEvent[]>([]);
-  const [threadId, setThreadId] = useState<string | null>(null);
+  const [threadId, setThreadId] = useState<string | null>(
+    initialThreadId ?? null,
+  );
   const [isStreaming, setIsStreaming] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   // Refs avoid the standard "stale closure" problem with `send` and
   // `onEvent`: `send` is a stable callback that reads the latest
   // threadId/onEvent without re-mounting connectSSE on every render.
-  const threadIdRef = useRef<string | null>(null);
+  const threadIdRef = useRef<string | null>(initialThreadId ?? null);
   const contentRef = useRef("");
   const onEventRef = useRef(onEvent);
   onEventRef.current = onEvent;
@@ -292,6 +303,16 @@ export function useAgentChat({
     },
     [agent, endpoint],
   );
+
+  // Re-seed the thread id when the caller switches to a different existing
+  // thread (e.g. useAgentThread resuming a persisted one), so the next send()
+  // continues it. A server-assigned id (from metadata) is never clobbered:
+  // that path leaves `initialThreadId` unchanged, so this effect doesn't fire.
+  useEffect(() => {
+    const next = initialThreadId ?? null;
+    threadIdRef.current = next;
+    setThreadId(next);
+  }, [initialThreadId]);
 
   // Abort any in-flight stream when the component unmounts.
   useEffect(() => {

--- a/packages/appkit-ui/src/react/hooks/use-agent-thread.ts
+++ b/packages/appkit-ui/src/react/hooks/use-agent-thread.ts
@@ -1,0 +1,224 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { useAgentChat } from "./use-agent-chat";
+
+const DEFAULT_BASE_PATH = "/api/agents";
+const STREAMING_ID = "__streaming__";
+
+/** A message rendered in a thread transcript. */
+export interface AgentThreadMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+}
+
+/** Wire shape of a persisted message from `GET {basePath}/threads/:id`. */
+interface WireMessage {
+  id: string;
+  role: string;
+  content: string;
+}
+
+export interface UseAgentThreadOptions {
+  /** Agent to route turns to (registered with the `agents()` plugin). */
+  agent: string;
+  /** Base path the agents plugin is mounted under. Default `"/api/agents"`. */
+  basePath?: string;
+  /**
+   * Mirror the active thread id in the URL query so a reload resumes it.
+   * Default `false` — AppKit apps usually own their router. When `true`, the
+   * hook reads the param on mount (if no `threadId` was passed) and writes it
+   * on change; an explicit `threadId` argument always wins.
+   */
+  persistInUrl?: boolean;
+  /** Query param used when `persistInUrl` is on. Default `"threadId"`. */
+  urlParamName?: string;
+}
+
+export interface UseAgentThreadResult {
+  /** The transcript: loaded history + completed turns + the live streaming turn. */
+  messages: AgentThreadMessage[];
+  /** Active thread id (the resumed id, or the server-assigned id after the first send). */
+  threadId: string | null;
+  /** True while loading a thread's history. */
+  loading: boolean;
+  /** True while an assistant turn is streaming. */
+  isStreaming: boolean;
+  /** History-load or streaming error message, or null. */
+  error: string | null;
+  /** Send a user turn; continues this thread (or creates one on the first send). */
+  send: (text: string) => Promise<void>;
+  /** Clear the transcript and start a fresh thread. */
+  reset: () => void;
+}
+
+function readUrlThreadId(param: string): string | undefined {
+  if (typeof window === "undefined") return undefined;
+  return new URLSearchParams(window.location.search).get(param) ?? undefined;
+}
+
+/**
+ * Owns one agent conversation's transcript: loads history for an existing
+ * thread, streams new turns (built on {@link useAgentChat}), and appends each
+ * completed turn. The "active thread" counterpart to {@link useAgentThreads}
+ * (the list) — compose them at the page level.
+ *
+ * Pass a `threadId` to resume a persisted thread, or omit it for a fresh one
+ * whose id the server assigns on the first `send()` (surfaced via
+ * {@link UseAgentThreadResult.threadId}).
+ *
+ * @example
+ * ```tsx
+ * const { messages, send, isStreaming } = useAgentThread(activeId, { agent: "helper" });
+ * ```
+ */
+export function useAgentThread(
+  threadId?: string,
+  options: UseAgentThreadOptions = { agent: "" },
+): UseAgentThreadResult {
+  const { agent, persistInUrl = false } = options;
+  const basePath = options.basePath ?? DEFAULT_BASE_PATH;
+  const urlParam = options.urlParamName ?? "threadId";
+
+  // The id to resume: explicit arg wins, else the URL (when persisting), else none.
+  const [resumeId, setResumeId] = useState<string | undefined>(() =>
+    threadId !== undefined
+      ? threadId
+      : persistInUrl
+        ? readUrlThreadId(urlParam)
+        : undefined,
+  );
+  // An explicit threadId argument always wins and re-seeds on change.
+  useEffect(() => {
+    if (threadId !== undefined) setResumeId(threadId);
+  }, [threadId]);
+
+  const [committed, setCommitted] = useState<AgentThreadMessage[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [historyError, setHistoryError] = useState<string | null>(null);
+
+  const {
+    content,
+    threadId: activeThreadId,
+    isStreaming,
+    error: streamError,
+    send: chatSend,
+    reset: chatReset,
+  } = useAgentChat({
+    agent,
+    endpoint: `${basePath}/chat`,
+    initialThreadId: resumeId,
+  });
+
+  // Load history whenever the resume target changes (a fresh id, or a switch).
+  useEffect(() => {
+    if (!resumeId) {
+      setCommitted([]);
+      return;
+    }
+    const ac = new AbortController();
+    setLoading(true);
+    setHistoryError(null);
+    fetch(`${basePath}/threads/${encodeURIComponent(resumeId)}`, {
+      signal: ac.signal,
+    })
+      .then(async (res) => {
+        if (!res.ok) {
+          const body = await res.json().catch(() => null);
+          throw new Error(body?.error || `HTTP ${res.status}`);
+        }
+        return res.json() as Promise<{ messages?: WireMessage[] }>;
+      })
+      .then((thread) => {
+        if (ac.signal.aborted) return;
+        setCommitted(
+          (thread.messages ?? [])
+            .filter((m) => m.role === "user" || m.role === "assistant")
+            .map((m) => ({
+              id: m.id,
+              role: m.role as AgentThreadMessage["role"],
+              content: m.content,
+            })),
+        );
+        setLoading(false);
+      })
+      .catch((err: Error) => {
+        if (ac.signal.aborted) return;
+        setHistoryError(err.message || "Failed to load thread");
+        setLoading(false);
+      });
+    return () => ac.abort();
+  }, [resumeId, basePath]);
+
+  // Commit the assistant turn once streaming ends (true -> false transition).
+  const wasStreaming = useRef(false);
+  useEffect(() => {
+    if (wasStreaming.current && !isStreaming && content) {
+      setCommitted((prev) => [
+        ...prev,
+        { id: `a-${prev.length}-${Date.now()}`, role: "assistant", content },
+      ]);
+    }
+    wasStreaming.current = isStreaming;
+  }, [isStreaming, content]);
+
+  // Reflect the active thread id in the URL when persisting.
+  useEffect(() => {
+    if (!persistInUrl || typeof window === "undefined") return;
+    const params = new URLSearchParams(window.location.search);
+    if (activeThreadId) params.set(urlParam, activeThreadId);
+    else params.delete(urlParam);
+    const qs = params.toString();
+    window.history.replaceState(
+      null,
+      "",
+      `${window.location.pathname}${qs ? `?${qs}` : ""}${window.location.hash}`,
+    );
+  }, [persistInUrl, urlParam, activeThreadId]);
+
+  const send = useCallback(
+    async (text: string) => {
+      const trimmed = text.trim();
+      if (!trimmed) return;
+      setCommitted((prev) => [
+        ...prev,
+        {
+          id: `u-${prev.length}-${Date.now()}`,
+          role: "user",
+          content: trimmed,
+        },
+      ]);
+      await chatSend(trimmed);
+    },
+    [chatSend],
+  );
+
+  const reset = useCallback(() => {
+    setCommitted([]);
+    setHistoryError(null);
+    setResumeId(undefined);
+    chatReset();
+  }, [chatReset]);
+
+  // Show the in-progress assistant turn as a live bubble once it has text.
+  // Before the first token, `isStreaming` alone signals "thinking" — no empty
+  // bubble. On completion the turn is committed above, so this reconciles
+  // seamlessly.
+  const messages = useMemo<AgentThreadMessage[]>(
+    () =>
+      isStreaming && content
+        ? [...committed, { id: STREAMING_ID, role: "assistant", content }]
+        : committed,
+    [committed, isStreaming, content],
+  );
+
+  return {
+    messages,
+    threadId: activeThreadId,
+    loading,
+    isStreaming,
+    error: historyError ?? streamError,
+    send,
+    reset,
+  };
+}

--- a/packages/appkit-ui/src/react/hooks/use-agent-thread.ts
+++ b/packages/appkit-ui/src/react/hooks/use-agent-thread.ts
@@ -97,6 +97,11 @@ export function useAgentThread(
   const [loading, setLoading] = useState(false);
   const [historyError, setHistoryError] = useState<string | null>(null);
 
+  // Per-hook transcript cache, so re-selecting a thread doesn't refetch. Kept
+  // write-through as turns are sent/streamed (see the sync effect below), so a
+  // cached entry stays current — no explicit invalidation needed.
+  const cacheRef = useRef<Map<string, AgentThreadMessage[]>>(new Map());
+
   const {
     content,
     threadId: activeThreadId,
@@ -111,10 +116,18 @@ export function useAgentThread(
   });
 
   // Load history whenever the resume target changes (a fresh id, or a switch).
+  // A cached transcript is served without a network round-trip.
   useEffect(() => {
     if (!resumeId) {
       setCommitted([]);
       return;
+    }
+    const cached = cacheRef.current.get(resumeId);
+    if (cached) {
+      setCommitted(cached);
+      setLoading(false);
+      setHistoryError(null);
+      return; // cache hit — no fetch
     }
     const ac = new AbortController();
     setLoading(true);
@@ -131,15 +144,15 @@ export function useAgentThread(
       })
       .then((thread) => {
         if (ac.signal.aborted) return;
-        setCommitted(
-          (thread.messages ?? [])
-            .filter((m) => m.role === "user" || m.role === "assistant")
-            .map((m) => ({
-              id: m.id,
-              role: m.role as AgentThreadMessage["role"],
-              content: m.content,
-            })),
-        );
+        const loaded = (thread.messages ?? [])
+          .filter((m) => m.role === "user" || m.role === "assistant")
+          .map((m) => ({
+            id: m.id,
+            role: m.role as AgentThreadMessage["role"],
+            content: m.content,
+          }));
+        cacheRef.current.set(resumeId, loaded);
+        setCommitted(loaded);
         setLoading(false);
       })
       .catch((err: Error) => {
@@ -161,6 +174,13 @@ export function useAgentThread(
     }
     wasStreaming.current = isStreaming;
   }, [isStreaming, content]);
+
+  // Write-through: keep the active thread's cache entry in sync with the
+  // committed transcript, so switching away and back reflects the latest turns
+  // without a refetch.
+  useEffect(() => {
+    if (activeThreadId) cacheRef.current.set(activeThreadId, committed);
+  }, [activeThreadId, committed]);
 
   // Reflect the active thread id in the URL when persisting.
   useEffect(() => {

--- a/packages/appkit-ui/src/react/hooks/use-agent-threads.ts
+++ b/packages/appkit-ui/src/react/hooks/use-agent-threads.ts
@@ -1,0 +1,152 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { ThreadSummary } from "shared";
+
+const DEFAULT_BASE_PATH = "/api/agents";
+
+/** Wire shape of a summary — dates arrive as ISO strings over JSON. */
+interface WireThreadSummary {
+  id: string;
+  title: string;
+  messageCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+function reviveSummary(s: WireThreadSummary): ThreadSummary {
+  return {
+    id: s.id,
+    title: s.title,
+    messageCount: s.messageCount,
+    createdAt: new Date(s.createdAt),
+    updatedAt: new Date(s.updatedAt),
+  };
+}
+
+export interface UseAgentThreadsOptions {
+  /**
+   * Base path the agents plugin is mounted under. Default `"/api/agents"`.
+   * The hook calls `GET/DELETE/PATCH {basePath}/threads[/:id]`.
+   */
+  basePath?: string;
+}
+
+export interface UseAgentThreadsResult {
+  /** Summaries for the current user, most-recently-updated first. */
+  threads: ThreadSummary[];
+  /** True while the initial load or a `refetch()` is in flight. */
+  loading: boolean;
+  /** Last error message, or null. */
+  error: string | null;
+  /** Re-fetch the list (call after a turn completes to reflect new/updated threads). */
+  refetch: () => Promise<void>;
+  /** Delete a thread. Removes it optimistically; reconciles from the server on failure. */
+  deleteThread: (threadId: string) => Promise<void>;
+  /** Rename a thread. Updates the title optimistically; reconciles on failure. */
+  renameThread: (threadId: string, title: string) => Promise<void>;
+}
+
+/**
+ * Lists the current user's agent threads for a history sidebar. Reads the cheap
+ * summary projection from `GET {basePath}/threads` (no message bodies) and
+ * offers delete/rename. Sibling to {@link useAgentChat}: it owns the list, not
+ * the active conversation — compose the two at the page level.
+ *
+ * Threads are scoped to the request's user server-side (via `x-forwarded-user`
+ * / the dev fallback), so the hook sends no user identity itself.
+ *
+ * @example
+ * ```tsx
+ * const { threads, deleteThread, refetch } = useAgentThreads();
+ * // <ThreadList> wraps this; or render `threads` yourself.
+ * ```
+ */
+export function useAgentThreads(
+  options: UseAgentThreadsOptions = {},
+): UseAgentThreadsResult {
+  const basePath = options.basePath ?? DEFAULT_BASE_PATH;
+
+  const [threads, setThreads] = useState<ThreadSummary[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const refetch = useCallback(async () => {
+    abortRef.current?.abort();
+    const ac = new AbortController();
+    abortRef.current = ac;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`${basePath}/threads`, { signal: ac.signal });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.error || `HTTP ${res.status}`);
+      }
+      const data = (await res.json()) as { threads?: WireThreadSummary[] };
+      if (ac.signal.aborted) return;
+      setThreads((data.threads ?? []).map(reviveSummary));
+    } catch (err) {
+      if (ac.signal.aborted) return;
+      setError(err instanceof Error ? err.message : "Failed to load threads");
+    } finally {
+      if (!ac.signal.aborted) setLoading(false);
+    }
+  }, [basePath]);
+
+  const deleteThread = useCallback(
+    async (threadId: string) => {
+      // Optimistic: drop it now, reconcile from the server if the call fails.
+      const prev = threads;
+      setThreads((list) => list.filter((t) => t.id !== threadId));
+      try {
+        const res = await fetch(
+          `${basePath}/threads/${encodeURIComponent(threadId)}`,
+          { method: "DELETE" },
+        );
+        if (!res.ok && res.status !== 404) {
+          throw new Error(`HTTP ${res.status}`);
+        }
+      } catch (err) {
+        setThreads(prev); // rollback already reconciles to the known-good list
+        setError(
+          err instanceof Error ? err.message : "Failed to delete thread",
+        );
+      }
+    },
+    [basePath, threads],
+  );
+
+  const renameThread = useCallback(
+    async (threadId: string, title: string) => {
+      const prev = threads;
+      setThreads((list) =>
+        list.map((t) => (t.id === threadId ? { ...t, title } : t)),
+      );
+      try {
+        const res = await fetch(
+          `${basePath}/threads/${encodeURIComponent(threadId)}`,
+          {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ title }),
+          },
+        );
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      } catch (err) {
+        setThreads(prev); // rollback already reconciles to the known-good list
+        setError(
+          err instanceof Error ? err.message : "Failed to rename thread",
+        );
+      }
+    },
+    [basePath, threads],
+  );
+
+  // Initial load + reload when the base path changes.
+  useEffect(() => {
+    void refetch();
+    return () => abortRef.current?.abort();
+  }, [refetch]);
+
+  return { threads, loading, error, refetch, deleteThread, renameThread };
+}


### PR DESCRIPTION
## What

The client layer for persistent agent chat history: hooks and drop-in components for a conversation sidebar, in `@databricks/appkit-ui/react/beta`.

**Stacked on #576** (backend). Base branch is `feat/agent-persistent-threads`; this PR is UI-only (`packages/appkit-ui` + `apps/dev-playground`). Review/merge #576 first.

## How it works

Sibling design (the list and the active conversation are separate lifecycles — CopilotKit-style, not one god hook):

- **`useAgentThreads`** — lists thread summaries; optimistic `deleteThread` / `renameThread`; `refetch`.
- **`useAgentThread(threadId?)`** — one conversation's transcript: loads history, streams turns (built on `useAgentChat` via a new additive `initialThreadId` seam to resume), commits each turn, surfaces the server-assigned id for a new thread. **Caches transcripts per thread** (write-through) so re-selecting doesn't refetch.
- **`<ThreadList>`** — history sidebar over `useAgentThreads`: controlled selection (`activeThreadId` / `onSelect`), per-row rename + delete, `refetchSignal` to refresh from a parent.
- **`<AgentThread>`** — transcript + composer over `useAgentThread`; resolves the default agent from the plugin client config; `onThreadCreated` / `onTurnComplete` callbacks let the page refresh the list (no shared provider).

Compose them at the page level (the page holds the active thread id). See the dev-playground `Agent History` route (`/agent-history`) for a working example.

## Verification

- 33 unit tests (both hooks, the `useAgentChat` seam, `<ThreadList>`, and the transcript cache), typecheck clean, `check:fix` / `build` / `docs:build` pass.
- Backend endpoints this consumes were live-tested against a real Lakebase (see #576).

## NOT verified

- **UI visual render** — the route serves and every endpoint it uses is verified, but the rendered `<ThreadList>` / `<AgentThread>` were not eyeballed in a browser in-loop.

## Notes

- `<AgentThread>` renders plain-text messages in v1 (markdown + tool-call chips are a planned enhancement).
- **Squash-merge repo**: after #576 merges, this branch needs a rebase onto `main` (dropping the merged backend commits) + force-push. Commits are unsigned — re-sign before merge.

Draft.
