### PR TITLE
fix(shared): don't downgrade already-installed deps in appkit add

### DIFF
--- a/packages/shared/src/cli/commands/registry/add.test.ts
+++ b/packages/shared/src/cli/commands/registry/add.test.ts
@@ -5,10 +5,12 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  parseDepSpec,
   partitionDeps,
   partitionVerified,
   pluginExportName,
   profileFromEnv,
+  reconcileDeps,
   resolveItems,
   resolveWithinBase,
   scopesForResources,
@@ -336,5 +338,87 @@ describe("partitionDeps (dependency-injection guard)", () => {
       "evil@https://attacker/e.tgz",
       "git+ssh://attacker/x",
     ]);
+  });
+});
+
+describe("parseDepSpec", () => {
+  it("splits a scoped name with a range", () => {
+    expect(parseDepSpec("@databricks/appkit-ui@^0.41.0")).toEqual({
+      name: "@databricks/appkit-ui",
+      range: "^0.41.0",
+    });
+  });
+
+  it("returns no range for a scoped name without one", () => {
+    expect(parseDepSpec("@databricks/appkit-ui")).toEqual({
+      name: "@databricks/appkit-ui",
+    });
+  });
+
+  it("splits a plain name with a range", () => {
+    expect(parseDepSpec("react@19.2.0")).toEqual({
+      name: "react",
+      range: "19.2.0",
+    });
+  });
+
+  it("returns no range for a bare name", () => {
+    expect(parseDepSpec("lodash")).toEqual({ name: "lodash" });
+  });
+});
+
+describe("reconcileDeps (never-downgrade guard)", () => {
+  it("installs a package that is not already present", () => {
+    const res = reconcileDeps(["lucide-react@^0.554.0"], {});
+    expect(res).toEqual({ install: ["lucide-react@^0.554.0"], skipped: [] });
+  });
+
+  // The reported bug: registry pins ^0.41.0 (which excludes 0.73.0, since ^0.x
+  // locks the minor), app already on 0.73.x → must NOT be reinstalled/downgraded.
+  it("skips a dep whose installed version is newer than the requested range", () => {
+    const res = reconcileDeps(["@databricks/appkit-ui@^0.41.0"], {
+      "@databricks/appkit-ui": "^0.73.0",
+    });
+    expect(res).toEqual({
+      install: [],
+      skipped: ["@databricks/appkit-ui@^0.41.0"],
+    });
+  });
+
+  it("upgrades when the installed version is older than the requested floor", () => {
+    const res = reconcileDeps(["@databricks/appkit-ui@^0.41.0"], {
+      "@databricks/appkit-ui": "~0.40.0",
+    });
+    expect(res).toEqual({
+      install: ["@databricks/appkit-ui@^0.41.0"],
+      skipped: [],
+    });
+  });
+
+  it("skips when the installed exact version equals the requested one", () => {
+    const res = reconcileDeps(["react@19.2.0"], { react: "19.2.0" });
+    expect(res).toEqual({ install: [], skipped: ["react@19.2.0"] });
+  });
+
+  it("skips a caret-range dep already satisfied by a newer install", () => {
+    const res = reconcileDeps(["typescript@^5.0.0"], {
+      typescript: "^5.9.0",
+    });
+    expect(res).toEqual({ install: [], skipped: ["typescript@^5.0.0"] });
+  });
+
+  it("leaves an unparseable installed range untouched (workspace:*)", () => {
+    const res = reconcileDeps(["@databricks/appkit-ui@^0.41.0"], {
+      "@databricks/appkit-ui": "workspace:*",
+    });
+    expect(res).toEqual({
+      install: [],
+      skipped: ["@databricks/appkit-ui@^0.41.0"],
+    });
+  });
+
+  it("keeps a present package when the registry asks for no specific version", () => {
+    const res = reconcileDeps(["lodash"], { lodash: "^4.17.0" });
+    expect(res).toEqual({ install: [], skipped: ["lodash"] });
   });
 });

--- a/packages/shared/src/cli/commands/registry/add.test.ts
+++ b/packages/shared/src/cli/commands/registry/add.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import * as semver from "semver";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -369,16 +370,17 @@ describe("parseDepSpec", () => {
 
 describe("reconcileDeps (never-downgrade guard)", () => {
   it("installs a package that is not already present", () => {
-    const res = reconcileDeps(["lucide-react@^0.554.0"], {});
+    const res = reconcileDeps(["lucide-react@^0.554.0"], {}, semver);
     expect(res).toEqual({ install: ["lucide-react@^0.554.0"], skipped: [] });
   });
 
-  // The reported bug: registry pins ^0.41.0 (which excludes 0.73.0, since ^0.x
-  // locks the minor), app already on 0.73.x → must NOT be reinstalled/downgraded.
+  // ^0.x locks the minor, so 0.73.0 is outside ^0.41.0 — must not be downgraded.
   it("skips a dep whose installed version is newer than the requested range", () => {
-    const res = reconcileDeps(["@databricks/appkit-ui@^0.41.0"], {
-      "@databricks/appkit-ui": "^0.73.0",
-    });
+    const res = reconcileDeps(
+      ["@databricks/appkit-ui@^0.41.0"],
+      { "@databricks/appkit-ui": "^0.73.0" },
+      semver,
+    );
     expect(res).toEqual({
       install: [],
       skipped: ["@databricks/appkit-ui@^0.41.0"],
@@ -386,9 +388,11 @@ describe("reconcileDeps (never-downgrade guard)", () => {
   });
 
   it("upgrades when the installed version is older than the requested floor", () => {
-    const res = reconcileDeps(["@databricks/appkit-ui@^0.41.0"], {
-      "@databricks/appkit-ui": "~0.40.0",
-    });
+    const res = reconcileDeps(
+      ["@databricks/appkit-ui@^0.41.0"],
+      { "@databricks/appkit-ui": "~0.40.0" },
+      semver,
+    );
     expect(res).toEqual({
       install: ["@databricks/appkit-ui@^0.41.0"],
       skipped: [],
@@ -396,21 +400,25 @@ describe("reconcileDeps (never-downgrade guard)", () => {
   });
 
   it("skips when the installed exact version equals the requested one", () => {
-    const res = reconcileDeps(["react@19.2.0"], { react: "19.2.0" });
+    const res = reconcileDeps(["react@19.2.0"], { react: "19.2.0" }, semver);
     expect(res).toEqual({ install: [], skipped: ["react@19.2.0"] });
   });
 
   it("skips a caret-range dep already satisfied by a newer install", () => {
-    const res = reconcileDeps(["typescript@^5.0.0"], {
-      typescript: "^5.9.0",
-    });
+    const res = reconcileDeps(
+      ["typescript@^5.0.0"],
+      { typescript: "^5.9.0" },
+      semver,
+    );
     expect(res).toEqual({ install: [], skipped: ["typescript@^5.0.0"] });
   });
 
   it("leaves an unparseable installed range untouched (workspace:*)", () => {
-    const res = reconcileDeps(["@databricks/appkit-ui@^0.41.0"], {
-      "@databricks/appkit-ui": "workspace:*",
-    });
+    const res = reconcileDeps(
+      ["@databricks/appkit-ui@^0.41.0"],
+      { "@databricks/appkit-ui": "workspace:*" },
+      semver,
+    );
     expect(res).toEqual({
       install: [],
       skipped: ["@databricks/appkit-ui@^0.41.0"],
@@ -418,7 +426,7 @@ describe("reconcileDeps (never-downgrade guard)", () => {
   });
 
   it("keeps a present package when the registry asks for no specific version", () => {
-    const res = reconcileDeps(["lodash"], { lodash: "^4.17.0" });
+    const res = reconcileDeps(["lodash"], { lodash: "^4.17.0" }, semver);
     expect(res).toEqual({ install: [], skipped: ["lodash"] });
   });
 });

--- a/packages/shared/src/cli/commands/registry/add.ts
+++ b/packages/shared/src/cli/commands/registry/add.ts
@@ -5,7 +5,6 @@ import process from "node:process";
 
 import { Command } from "commander";
 import pc from "picocolors";
-import { gte, minVersion } from "semver";
 
 import {
   fetchRegistryItem,
@@ -198,31 +197,30 @@ export function parseDepSpec(spec: string): { name: string; range?: string } {
   return { name: spec.slice(0, at), range: spec.slice(at + 1) };
 }
 
-/** minVersion() but null-safe: returns null for unparseable ranges
- * (`workspace:*`, `catalog:`, git/tarball URLs) instead of throwing. */
-function rangeFloor(range: string): string | null {
-  try {
-    return minVersion(range)?.version ?? null;
-  } catch {
-    return null;
-  }
-}
-
 /**
  * Registry `dependencies` are floors ("needs at least this version"), not pins.
- * Given the versions already declared in the target `package.json`, decide which
- * specs to actually install: packages that are missing (installed as declared)
- * and genuine upgrades (installed floor below the requested floor). A package
- * already at the same-or-newer version is skipped, so `pnpm add` never rewrites
- * it downward — the reported bug, where e.g. `@databricks/appkit-ui@^0.41.0`
- * from the registry downgraded an app on 0.73.x (0.73.0 is outside `^0.41.0`).
- * Ranges we can't compare on either side (workspace:*, catalog:, git) are left
- * untouched — skipped — since downgrading a linked/pinned dep is never right.
+ * Against the versions already in the target `package.json`, returns which specs
+ * to install: missing packages (as declared) and genuine upgrades (installed
+ * floor below the requested floor). A package already at a same-or-newer version
+ * is skipped so the package manager never downgrades it; ranges that can't be
+ * compared (workspace:*, catalog:, git) are skipped for the same reason.
+ *
+ * `semver` is injected so the caller can lazy-load it (see `installDependencies`).
  */
 export function reconcileDeps(
   specs: string[],
   installed: Record<string, string>,
+  { gte, minVersion }: Pick<typeof import("semver"), "gte" | "minVersion">,
 ): { install: string[]; skipped: string[] } {
+  // minVersion() throws on ranges it can't parse (workspace:*, catalog:, git);
+  // treat those as uncomparable and skip rather than risk a downgrade.
+  const floor = (range: string): string | null => {
+    try {
+      return minVersion(range)?.version ?? null;
+    } catch {
+      return null;
+    }
+  };
   const install: string[] = [];
   const skipped: string[] = [];
   for (const spec of specs) {
@@ -236,8 +234,8 @@ export function reconcileDeps(
       skipped.push(spec); // present, no version asked → keep what's there
       continue;
     }
-    const reqFloor = rangeFloor(range);
-    const haveFloor = rangeFloor(have);
+    const reqFloor = floor(range);
+    const haveFloor = floor(have);
     if (!reqFloor || !haveFloor) {
       skipped.push(spec); // can't compare safely → don't touch
     } else if (gte(haveFloor, reqFloor)) {
@@ -263,7 +261,7 @@ function readInstalledRanges(pkgPath: string): Record<string, string> {
   }
 }
 
-function installDependencies(deps: string[], cwd: string): void {
+async function installDependencies(deps: string[], cwd: string): Promise<void> {
   if (deps.length === 0) return;
 
   const { safe, rejected } = partitionDeps(deps);
@@ -286,11 +284,13 @@ function installDependencies(deps: string[], cwd: string): void {
     return;
   }
 
-  // Registry deps are floors, not pins: skip anything already installed at a
-  // same-or-newer version so we never downgrade the app's own packages.
+  // Lazy import: this file is loaded eagerly by the CLI entry, so keep semver
+  // (only needed here) off the startup path — as with server-register/env-writer.
+  const semver = await import("semver");
   const { install, skipped } = reconcileDeps(
     safe,
     readInstalledRanges(pkgPath),
+    semver,
   );
   if (skipped.length > 0) {
     console.log(
@@ -565,7 +565,7 @@ async function runAdd(refs: string[], opts: AddOptions): Promise<void> {
     }
   }
 
-  installDependencies([...deps], findNearestPackageJson(cwd));
+  await installDependencies([...deps], findNearestPackageJson(cwd));
 
   if (hasPlugin) {
     console.log(pc.dim("\nRegistering plugins (appkit plugin sync)..."));

--- a/packages/shared/src/cli/commands/registry/add.ts
+++ b/packages/shared/src/cli/commands/registry/add.ts
@@ -5,6 +5,7 @@ import process from "node:process";
 
 import { Command } from "commander";
 import pc from "picocolors";
+import { gte, minVersion } from "semver";
 
 import {
   fetchRegistryItem,
@@ -187,6 +188,81 @@ export function partitionDeps(deps: string[]): {
   return { safe, rejected };
 }
 
+/** Splits an npm spec into `name` and optional version `range`, handling the
+ * leading `@` of scoped names (`@databricks/appkit-ui@^0.41.0` → name
+ * `@databricks/appkit-ui`, range `^0.41.0`; `lodash` → no range). */
+export function parseDepSpec(spec: string): { name: string; range?: string } {
+  const at = spec.lastIndexOf("@");
+  // at <= 0 means either no `@` (bare name) or the scope's `@` at index 0.
+  if (at <= 0) return { name: spec };
+  return { name: spec.slice(0, at), range: spec.slice(at + 1) };
+}
+
+/** minVersion() but null-safe: returns null for unparseable ranges
+ * (`workspace:*`, `catalog:`, git/tarball URLs) instead of throwing. */
+function rangeFloor(range: string): string | null {
+  try {
+    return minVersion(range)?.version ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Registry `dependencies` are floors ("needs at least this version"), not pins.
+ * Given the versions already declared in the target `package.json`, decide which
+ * specs to actually install: packages that are missing (installed as declared)
+ * and genuine upgrades (installed floor below the requested floor). A package
+ * already at the same-or-newer version is skipped, so `pnpm add` never rewrites
+ * it downward — the reported bug, where e.g. `@databricks/appkit-ui@^0.41.0`
+ * from the registry downgraded an app on 0.73.x (0.73.0 is outside `^0.41.0`).
+ * Ranges we can't compare on either side (workspace:*, catalog:, git) are left
+ * untouched — skipped — since downgrading a linked/pinned dep is never right.
+ */
+export function reconcileDeps(
+  specs: string[],
+  installed: Record<string, string>,
+): { install: string[]; skipped: string[] } {
+  const install: string[] = [];
+  const skipped: string[] = [];
+  for (const spec of specs) {
+    const { name, range } = parseDepSpec(spec);
+    const have = installed[name];
+    if (!have) {
+      install.push(spec); // missing → install as declared
+      continue;
+    }
+    if (!range) {
+      skipped.push(spec); // present, no version asked → keep what's there
+      continue;
+    }
+    const reqFloor = rangeFloor(range);
+    const haveFloor = rangeFloor(have);
+    if (!reqFloor || !haveFloor) {
+      skipped.push(spec); // can't compare safely → don't touch
+    } else if (gte(haveFloor, reqFloor)) {
+      skipped.push(spec); // installed is same-or-newer → keep (no downgrade)
+    } else {
+      install.push(spec); // installed is older than required → upgrade
+    }
+  }
+  return { install, skipped };
+}
+
+/** Merged dependencies + devDependencies (name → declared range) of a
+ * package.json, tolerating a missing/unreadable file (returns {}). */
+function readInstalledRanges(pkgPath: string): Record<string, string> {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8")) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    return { ...pkg.dependencies, ...pkg.devDependencies };
+  } catch {
+    return {};
+  }
+}
+
 function installDependencies(deps: string[], cwd: string): void {
   if (deps.length === 0) return;
 
@@ -200,7 +276,8 @@ function installDependencies(deps: string[], cwd: string): void {
   }
   if (safe.length === 0) return;
 
-  if (!fs.existsSync(path.join(cwd, "package.json"))) {
+  const pkgPath = path.join(cwd, "package.json");
+  if (!fs.existsSync(pkgPath)) {
     console.warn(
       pc.yellow(
         `No package.json found — install these manually: ${safe.join(" ")}`,
@@ -208,18 +285,34 @@ function installDependencies(deps: string[], cwd: string): void {
     );
     return;
   }
+
+  // Registry deps are floors, not pins: skip anything already installed at a
+  // same-or-newer version so we never downgrade the app's own packages.
+  const { install, skipped } = reconcileDeps(
+    safe,
+    readInstalledRanges(pkgPath),
+  );
+  if (skipped.length > 0) {
+    console.log(
+      pc.dim(
+        `Keeping already-installed (registry asked for an older/equal range): ${skipped.join(", ")}`,
+      ),
+    );
+  }
+  if (install.length === 0) return;
+
   const pm = detectPackageManager(cwd);
   const subcommand = pm === "npm" ? "install" : "add";
-  console.log(`\nInstalling dependencies with ${pm}: ${safe.join(" ")}`);
+  console.log(`\nInstalling dependencies with ${pm}: ${install.join(" ")}`);
   // `--` stops the PM from parsing any dep as a flag (defense in depth).
-  const result = spawnSync(pm, [subcommand, "--", ...safe], {
+  const result = spawnSync(pm, [subcommand, "--", ...install], {
     stdio: "inherit",
     cwd,
   });
   if (result.status !== 0) {
     console.warn(
       pc.yellow(
-        `Dependency install exited with code ${result.status ?? "unknown"} — install manually if needed: ${safe.join(" ")}`,
+        `Dependency install exited with code ${result.status ?? "unknown"} — install manually if needed: ${install.join(" ")}`,
       ),
     );
   }


### PR DESCRIPTION
## Problem

`appkit add <item>` could **downgrade** a package the app already had installed.

Registry items declare npm `dependencies` as version specs and `installDependencies` ran `pnpm add <spec>` for each one verbatim. When the spec is a caret range on a `0.x` package, that range is narrower than it looks:

- `metric-card` declares `@databricks/appkit-ui@^0.41.0`
- `^0.41.0` resolves to `>=0.41.0 <0.42.0` (caret locks the **minor** on `0.x`)
- An app already on `@databricks/appkit-ui@0.73.0` is therefore **outside** the range, so `pnpm add @databricks/appkit-ui@^0.41.0` rewrote it back down into the `0.41.x` window — a silent downgrade.

Registry `dependencies` are meant as *floors* ("needs at least this version"), not *pins*.

## Fix

Reconcile the registry's requested specs against the target `package.json` before installing (`packages/shared/src/cli/commands/registry/add.ts`):

- **Missing** package → install as declared.
- Installed version **older** than the requested floor → install (genuine upgrade).
- Installed version **same-or-newer** → skip, so the app's version is never rewritten downward.
- Ranges that can't be compared (`workspace:*`, `catalog:`, git/tarball URLs) are left untouched.

The guard lives in the single shared `installDependencies` function every `add` routes through, so it covers all current and future registry items. `semver` (already an `appkit` dependency, hoisted repo-wide) does the range comparison — `minVersion()` returns `null` for non-semver ranges, which is what makes the "leave untouched" branch safe.

## Tests

Added unit tests for the two new pure helpers `parseDepSpec` and `reconcileDeps`, including the exact reported case (newer install + older caret range → skipped), the upgrade case, exact-match, `workspace:*`, and the no-version-requested case.

- `add.test.ts`: 42 tests pass
- `pnpm --filter=shared typecheck`, `oxlint`, `oxfmt --check`, `pnpm knip`: clean

## Related

The `databricks/appkit-registry` item `metric-card` pins `@databricks/appkit-ui@^0.41.0`, which is the stale floor that triggered this. A companion PR there loosens that to an open lower bound (`>=`) as defense-in-depth for users on older CLI versions. This CLI change is the durable guard: it skips reinstalling entirely rather than relying on the registry's range being wide enough.

This pull request and its description were written by Isaac.
